### PR TITLE
Update code example on ImplementingAHandler.md

### DIFF
--- a/contents/ImplementingAHandler.md
+++ b/contents/ImplementingAHandler.md
@@ -13,8 +13,7 @@ public class GreetingCommand : Command
     {
         Name = name;
     }
-
-    public Guid Id { get; set; }
+    
     public string Name { get; private set; }
 }
 ```


### PR DESCRIPTION
The Command class has an Id property which is set through the base constructor, so should not be redeclared in the GreetingCommand subclass in the example.