### PR TITLE
Adjust for new multi-policy support

### DIFF
--- a/contents/HowConfiguringTheCommandProcessorWorks.md
+++ b/contents/HowConfiguringTheCommandProcessorWorks.md
@@ -116,7 +116,24 @@ When you attribute your code, you then use the key to attach a specific policy:
 ``` csharp
 [RequestLogging(step: 1, timing: HandlerTiming.Before)]
 [UsePolicy(Globals.MYRETRYPOLICY, step: 2)]
-[UsePolicy(Globals.MYCIRCUITBREAKER, step: 3)]
+public override TaskReminderCommand Handle(TaskReminderCommand command)
+{
+    _mailGateway.Send(new TaskReminder(
+        taskName: new TaskName(command.TaskName),
+        dueDate: command.DueDate,
+        reminderTo: new EmailAddress(command.Recipient),
+        copyReminderTo: new EmailAddress(command.CopyTo)
+    ));
+
+    return base.Handle(command);
+}
+```
+
+If you need multiple policies then you can pass them as an array. We evaluate them left to right.
+
+``` csharp
+[RequestLogging(step: 1, timing: HandlerTiming.Before)]
+[UsePolicy(new [] {Globals.MYRETRYPOLICY, Globals.MYCIRCUITBREAKER}, step: 2)]
 public override TaskReminderCommand Handle(TaskReminderCommand command)
 {
     _mailGateway.Send(new TaskReminder(

--- a/contents/ImplementingExternalBus.md
+++ b/contents/ImplementingExternalBus.md
@@ -90,8 +90,7 @@ public class MailTaskReminderHandler : RequestHandler<TaskReminderCommand>
     }
 
     [RequestLogging(step: 1, timing: HandlerTiming.Before)]
-    [UsePolicy(CommandProcessor.CIRCUITBREAKER, step: 2)]
-    [UsePolicy(CommandProcessor.RETRYPOLICY, step: 3)]
+    [UsePolicy(new [] {CommandProcessor.CIRCUITBREAKER, CommandProcessor.RETRYPOLICY}, step: 2)]
     public override TaskReminderCommand Handle(TaskReminderCommand command)
     {
         _mailGateway.Send(new TaskReminder(

--- a/contents/PolicyFallback.md
+++ b/contents/PolicyFallback.md
@@ -24,8 +24,7 @@ The following example shows a Handler with **Request Handler Attributes** for [R
 public class MyFallbackProtectedHandler: RequestHandler<MyCommand>
 {
     [FallbackPolicy(backstop: false, circuitBreaker: true, step: 1)]
-    [UsePolicy("MyCircuitBreakerStrategy", step: 2)]
-    [UsePolicy("MyRetryStrategy", step: 3)]
+    [UsePolicy(new [] {}"MyCircuitBreakerStrategy", "MyRetryStrategy"}, step: 2)]
     public override MyCommand Handle(MyCommand command)
     {
         /*Do some work that can fail*/


### PR DESCRIPTION
We are changing our support for multiple policies to pass in an array of policy names. This is because we no longer support allow multiple on the policy handler as a Scoped default for handlers will result in the same handler being recreated