### PR TITLE
Fix Hexagonal Architecture blog links

### DIFF
--- a/contents/10/CommandsCommandDispatcherandProcessor.md
+++ b/contents/10/CommandsCommandDispatcherandProcessor.md
@@ -84,7 +84,7 @@ appropriate method(s) on the handler to process the Command.
 
 ![CommandExtendedWorkflow](_static/images/CommandExtendedWorkflow.png)
 
-A Command Dispatcher can also act as the port layer in a [Ports & Adapters architecture](http://alistair.cockburn.us/Hexagonal+architecture).
+A Command Dispatcher can also act as the port layer in a [Ports & Adapters architecture](https://alistair.cockburn.us/hexagonal-architecture/).
 
 ## Command Processor
 

--- a/contents/9/CommandsCommandDispatcherandProcessor.md
+++ b/contents/9/CommandsCommandDispatcherandProcessor.md
@@ -84,7 +84,7 @@ appropriate method(s) on the handler to process the Command.
 
 ![CommandExtendedWorkflow](_static/images/CommandExtendedWorkflow.png)
 
-A Command Dispatcher can also act as the port layer in a [Ports & Adapters architecture](http://alistair.cockburn.us/Hexagonal+architecture).
+A Command Dispatcher can also act as the port layer in a [Ports & Adapters architecture](https://alistair.cockburn.us/hexagonal-architecture/).
 
 ## Command Processor
 

--- a/source/shared/CommandsCommandDispatcherandProcessor.md
+++ b/source/shared/CommandsCommandDispatcherandProcessor.md
@@ -84,7 +84,7 @@ appropriate method(s) on the handler to process the Command.
 
 ![CommandExtendedWorkflow](_static/images/CommandExtendedWorkflow.png)
 
-A Command Dispatcher can also act as the port layer in a [Ports & Adapters architecture](http://alistair.cockburn.us/Hexagonal+architecture).
+A Command Dispatcher can also act as the port layer in a [Ports & Adapters architecture](https://alistair.cockburn.us/hexagonal-architecture/).
 
 ## Command Processor
 


### PR DESCRIPTION
Fixes links to Alistair Cockburn's post on Hexagonal Architecture, which has moved

This also affects the link on https://www.goparamore.io/ in the text
> It can be used for implementing [Ports and Adapters](http://alistair.cockburn.us/Hexagonal+architecture) and [CQRS (PDF)](https://cqrs.files.wordpress.com/2010/11/cqrs_documents.pdf) architectural styles in .NET.

However I have not been able to find the source for that.