### PR TITLE
docs: Reference Outbox.Hosting package for UseOutboxSweeper

### DIFF
--- a/contents/BrighterBasicConfiguration.md
+++ b/contents/BrighterBasicConfiguration.md
@@ -173,7 +173,7 @@ When raising a message on the *Internal Bus*, you use one of the following metho
 When raising a message on an *External Bus*, you use the following methods on the *CommandProcessor*:
 
 * **Post()** and **PostAsync()** - Immediately posts a *Command* or *Event* to another process via the external Bus
-* **DepositPost()** and **DepositPostAsync()** - Puts on or many *Command*(s) or *Event*(s) in the *Outbox* for later delivery
+* **DepositPost()** and **DepositPostAsync()** - Puts one or many *Command*(s) or *Event*(s) in the *Outbox* for later delivery
 * **ClearOutbox()** and **ClearOutboxAsync()** - Clears the *Outbox*, posting un-dispatched messages to another process via the *External Bus*.
 * **ClearAsyncOutbox()** - Implicitly clears the **Outbox**, similar to above however allows bulk dispatching of messages onto a **Transport**.
 
@@ -350,7 +350,7 @@ Typically you run one sweeper. Brighter does not have a distributed lock. As suc
 
 To add the *Outbox Sweeper* you will need to take a dependency on another NuGet package:
 
-* **Paramore.Brighter.Extensions.Hosting**
+* **Paramore.Brighter.Outbox.Hosting**
 
 You can then add a sweeper using "UseOutboxSweeper"
 


### PR DESCRIPTION
Using 10.0.2 the package I had to add to get `UseOutboxSweeper` was `Paramore.Brighter.Outbox.Hosting` instead of `Paramore.Brighter.Extensions.Hosting`