### PR TITLE
docs: update BoxProvisioning for value-type APIs

### DIFF
--- a/contents/BoxProvisioning.md
+++ b/contents/BoxProvisioning.md
@@ -132,12 +132,51 @@ BoxProvisioning is scoped narrowly. It does **not**:
 
 ## Source-breaking changes on upgrade
 
-The first release of BoxProvisioning ships two source-breaking interface changes. These are only relevant if you *implement* the affected interfaces yourself (most applications consume Brighter's built-in implementations and are unaffected).
+The first release of BoxProvisioning ships source-breaking interface changes. These are only relevant if you *implement* the affected interfaces yourself (most applications consume Brighter's built-in implementations and are unaffected).
 
-- **`IAmARelationalDatabaseConfiguration.SchemaName`** is now an abstract member of the interface (previously a property on the concrete class only). If you implement `IAmARelationalDatabaseConfiguration` directly — for example to surface a custom configuration source — add a `public string? SchemaName => null;` member to preserve the pre-change behaviour. The provisioner treats `null` as "use the backend default schema" (`dbo` for MSSQL, `public` for PostgreSQL, and so on). The default-interface-member form is not available because `Paramore.Brighter` targets `netstandard2.0`.
-- **`IAmABoxMigration`** gains one required member (`ISet<string> LogicalColumns`) and two optional members (`string? SourceReference`, `string? IdempotencyCheckSql`). If you author your own migration classes — for example, to ship a private extension column — implement the new members on recompile. The vast majority of users consume Brighter's built-in migrations and never touch this interface.
+- **`IAmARelationalDatabaseConfiguration.SchemaName`** is now an abstract member of the interface (previously a property on the concrete class only). If you implement `IAmARelationalDatabaseConfiguration` directly — for example to surface a custom configuration source — add a `public string? SchemaName => null;` member to preserve the pre-change behaviour. The provisioner treats `null` as "use the backend default schema" (`dbo` for MSSQL, `public` for PostgreSQL, and so on). The default-interface-member form is not available because `Paramore.Brighter` targets `netstandard2.0`. `SchemaName` on this core interface stays a plain `string?` — it is *not* one of the BoxProvisioning value types described below.
+- **`IAmABoxMigration` exposes its members as value types.** The interface declares `Version` as `MigrationVersion`, `Description` as `MigrationDescription`, and `UpScript` as `SqlScript`, plus one required `IReadOnlyCollection<string> LogicalColumns` member (the cross-backend column-name set used for version detection) and two optional members, `SourceReference?` and `IdempotencyCheckSql` (typed `SqlScript?`). If you author your own migration classes — for example, to ship a private extension column — declare these members with the value types on recompile. `LogicalColumns` stays a plain string collection. The vast majority of users consume Brighter's built-in migrations and never touch this interface.
+- **`IAmABoxMigrationRunner.MigrateAsync` and `IAmABoxProvisioner.BoxTableName` use value types.** `MigrateAsync(BoxTableName tableName, SchemaName? schemaName, …)` types its table and schema parameters, and `IAmABoxProvisioner.BoxTableName` is typed `BoxTableName`. Only implementers of these infrastructure interfaces — typically authors adding a new backend — are affected; the built-in per-backend runners and provisioners already carry the new signatures.
 
-If you only call `AddBrighter().UseBoxProvisioning(...)` and the built-in `Add{Backend}Outbox` / `Add{Backend}Inbox` extensions, neither change affects you.
+If you only call `AddBrighter().UseBoxProvisioning(...)` and the built-in `Add{Backend}Outbox` / `Add{Backend}Inbox` extensions, none of these changes affect you.
+
+### Value types on the provisioning interfaces
+
+The provisioning interfaces wrap their user-facing `string` and `int` parameters in dedicated value types rather than passing bare primitives. The motivation is to defeat *primitive obsession*: in a signature such as `MigrateAsync(string tableName, string? schemaName, …)` the two adjacent strings can be transposed with no compiler error, and the bug surfaces only at runtime as a wrong-table or wrong-schema DDL operation. Typing each parameter makes that transposition a compile error and lets the type itself document what the value means.
+
+Six value types live in the `Paramore.Brighter.BoxProvisioning` namespace, each modelled on the existing `Id` type — a `record` wrapping a single primitive, with a `Value` property, a public constructor, implicit conversions to and from the underlying primitive, an overridden `ToString()`, and value equality:
+
+| Value type | Wraps | Used for | Nullable in use |
+|------------|-------|----------|-----------------|
+| `BoxTableName` | `string` | the box table name | no |
+| `SchemaName` | `string` | the database schema name | yes (`SchemaName?` — SQLite has no schema) |
+| `MigrationVersion` | `int` | the migration version number | no |
+| `MigrationDescription` | `string` | the human-readable migration description | no |
+| `SqlScript` | `string` | the migration up-script and idempotency-check SQL | up-script no; idempotency check `SqlScript?` |
+| `SourceReference` | `string` | the commit / PR that introduced a migration | yes (`SourceReference?` — V1 has none) |
+
+The five string-backed types also expose a static `IsNullOrEmpty` helper (mirroring `Id.IsNullOrEmpty`), so `BoxTableName.IsNullOrEmpty(t)` replaces `string.IsNullOrEmpty(t.Value)`. `MigrationVersion` additionally implements `IComparable<MigrationVersion>` so versions order correctly.
+
+Because the conversions are **implicit in both directions**, existing code that passes primitives keeps compiling unchanged. Constructing a `BoxMigration` with string and `int` literals still works — the literals convert to the value types at the call site:
+
+```csharp
+using Paramore.Brighter.BoxProvisioning;
+
+// Primitives convert implicitly — no argument changes needed.
+var migration = new BoxMigration(
+    5,                                              // int → MigrationVersion
+    "V5: add CloudEvents columns",                  // string → MigrationDescription
+    "ALTER TABLE Outbox ADD Source NVARCHAR(255) NULL", // string → SqlScript
+    new[] { "Source" });                            // IReadOnlyCollection<string>, unchanged
+
+MigrationVersion version = migration.Version;       // value type round-trips
+int versionNumber = version;                        // MigrationVersion → int, implicit
+string description = migration.Description;          // MigrationDescription → string, implicit
+```
+
+The same implicit conversions apply at every infrastructure call site, so `MigrateAsync("Outbox", "dbo", …)` and a `RelationalDatabaseConfiguration` whose `SchemaName` is a core `string?` continue to compile. The one place the implicit conversion does **not** help is implementing `IAmABoxMigration` (or the runner / provisioner interfaces) with your own class: a property's declared type must match the interface exactly, so declare the members with the value types — `public MigrationVersion Version => …` — rather than the underlying primitive. Constructing the built-in `BoxMigration` record, which is what almost everyone does, needs no change.
+
+Identifier validation is unchanged: `Identifiers.AssertSafe` still runs at the provisioner and runner entry points (on the wrapped string), so a malformed table name such as `"1Outbox"` is rejected exactly as before. The value types are pure information holders — they carry and compare the value, but they do not decide whether it is a safe SQL identifier. For the full design rationale, see ADR `Brighter/docs/adr/0061-box-provisioning-value-types.md`.
 
 ## Further Reading
 
@@ -148,5 +187,5 @@ If you only call `AddBrighter().UseBoxProvisioning(...)` and the built-in `Add{B
 - Per-backend Inbox pages: [MSSQL](/contents/MSSQLInbox.md) · [MySQL](/contents/MySQLInbox.md) · [PostgreSQL](/contents/PostgresInbox.md) · [SQLite](/contents/SqliteInbox.md).
 - [Outbox Pattern](/contents/OutboxPattern.md) — the underlying messaging pattern and the boundary between application data and the Outbox.
 - [Glossary](/contents/Glossary.md) — definitions of [BoxProvisioning](/contents/Glossary.md#boxprovisioning), [Migration Chain](/contents/Glossary.md#migration-chain), [Migration History Table](/contents/Glossary.md#migration-history-table), [Bootstrap Path](/contents/Glossary.md#bootstrap-path), and [Advisory Lock](/contents/Glossary.md#advisory-lock).
-- ADRs: `Brighter/docs/adr/0053-box-database-migration.md` (architecture, hosted service, package layout) and `Brighter/docs/adr/0057-box-schema-versioning-and-migrations.md` (versioning model, three-path runner, advisory-lock design).
+- ADRs: `Brighter/docs/adr/0053-box-database-migration.md` (architecture, hosted service, package layout), `Brighter/docs/adr/0057-box-schema-versioning-and-migrations.md` (versioning model, three-path runner, advisory-lock design), and `Brighter/docs/adr/0061-box-provisioning-value-types.md` (the value types that replace primitives on the provisioning interfaces).
 - If you are adding a new backend or a new column to an existing migration chain, see the implementor guides in the Brighter repository under `docs/guides/box-provisioning-*.md` — those guides are scoped to Brighter contributors, not consumers.

--- a/contents/BoxProvisioning.md
+++ b/contents/BoxProvisioning.md
@@ -130,19 +130,11 @@ BoxProvisioning is scoped narrowly. It does **not**:
 - **Run on read replicas.** The provisioner needs `CREATE TABLE` / `ALTER TABLE` rights on the connection it's given. Point it at the writable primary, not at a read-only follower. If your application normally reads from a follower and writes to a primary, configure BoxProvisioning with the primary's connection string explicitly.
 - **Replace your back-up strategy.** Provisioning rolls forward; it does not roll back. If a deployment ships a broken migration, you recover from your database back-up, not from BoxProvisioning. Plan accordingly.
 
-## Source-breaking changes on upgrade
+## Value types on the provisioning interfaces
 
-The first release of BoxProvisioning ships source-breaking interface changes. These are only relevant if you *implement* the affected interfaces yourself (most applications consume Brighter's built-in implementations and are unaffected).
+The provisioning interfaces express their table name, schema name, and migration parameters as dedicated value types rather than bare `string`/`int` primitives. The motivation is to defeat *primitive obsession*: in a signature such as `MigrateAsync(string tableName, string? schemaName, …)` the two adjacent strings can be transposed with no compiler error, and the bug surfaces only at runtime as a wrong-table or wrong-schema DDL operation. Typing each parameter makes that transposition a compile error and lets the type itself document what the value means.
 
-- **`IAmARelationalDatabaseConfiguration.SchemaName`** is now an abstract member of the interface (previously a property on the concrete class only). If you implement `IAmARelationalDatabaseConfiguration` directly — for example to surface a custom configuration source — add a `public string? SchemaName => null;` member to preserve the pre-change behaviour. The provisioner treats `null` as "use the backend default schema" (`dbo` for MSSQL, `public` for PostgreSQL, and so on). The default-interface-member form is not available because `Paramore.Brighter` targets `netstandard2.0`. `SchemaName` on this core interface stays a plain `string?` — it is *not* one of the BoxProvisioning value types described below.
-- **`IAmABoxMigration` exposes its members as value types.** The interface declares `Version` as `MigrationVersion`, `Description` as `MigrationDescription`, and `UpScript` as `SqlScript`, plus one required `IReadOnlyCollection<string> LogicalColumns` member (the cross-backend column-name set used for version detection) and two optional members, `SourceReference?` and `IdempotencyCheckSql` (typed `SqlScript?`). If you author your own migration classes — for example, to ship a private extension column — declare these members with the value types on recompile. `LogicalColumns` stays a plain string collection. The vast majority of users consume Brighter's built-in migrations and never touch this interface.
-- **`IAmABoxMigrationRunner.MigrateAsync` and `IAmABoxProvisioner.BoxTableName` use value types.** `MigrateAsync(BoxTableName tableName, SchemaName? schemaName, …)` types its table and schema parameters, and `IAmABoxProvisioner.BoxTableName` is typed `BoxTableName`. Only implementers of these infrastructure interfaces — typically authors adding a new backend — are affected; the built-in per-backend runners and provisioners already carry the new signatures.
-
-If you only call `AddBrighter().UseBoxProvisioning(...)` and the built-in `Add{Backend}Outbox` / `Add{Backend}Inbox` extensions, none of these changes affect you.
-
-### Value types on the provisioning interfaces
-
-The provisioning interfaces wrap their user-facing `string` and `int` parameters in dedicated value types rather than passing bare primitives. The motivation is to defeat *primitive obsession*: in a signature such as `MigrateAsync(string tableName, string? schemaName, …)` the two adjacent strings can be transposed with no compiler error, and the bug surfaces only at runtime as a wrong-table or wrong-schema DDL operation. Typing each parameter makes that transposition a compile error and lets the type itself document what the value means.
+This only matters if you *implement* the provisioning interfaces yourself — for example, to author a custom migration or add a new backend. Applications that call `AddBrighter().UseBoxProvisioning(...)` with the built-in `Add{Backend}Outbox` / `Add{Backend}Inbox` extensions never see these types.
 
 Six value types live in the `Paramore.Brighter.BoxProvisioning` namespace, each modelled on the existing `Id` type — a `record` wrapping a single primitive, with a `Value` property, a public constructor, implicit conversions to and from the underlying primitive, an overridden `ToString()`, and value equality:
 
@@ -155,28 +147,30 @@ Six value types live in the `Paramore.Brighter.BoxProvisioning` namespace, each 
 | `SqlScript` | `string` | the migration up-script and idempotency-check SQL | up-script no; idempotency check `SqlScript?` |
 | `SourceReference` | `string` | the commit / PR that introduced a migration | yes (`SourceReference?` — V1 has none) |
 
+The interfaces use them like this: `IAmABoxMigration` and the `BoxMigration` record declare `Version` as `MigrationVersion`, `Description` as `MigrationDescription`, `UpScript` as `SqlScript`, `SourceReference` as `SourceReference?`, and `IdempotencyCheckSql` as `SqlScript?`; `LogicalColumns` (the cross-backend column-name set used for version detection) stays a plain `IReadOnlyCollection<string>`. `IAmABoxMigrationRunner.MigrateAsync(BoxTableName tableName, SchemaName? schemaName, …)` types its table and schema parameters, and `IAmABoxProvisioner.BoxTableName` is typed `BoxTableName`.
+
 The five string-backed types also expose a static `IsNullOrEmpty` helper (mirroring `Id.IsNullOrEmpty`), so `BoxTableName.IsNullOrEmpty(t)` replaces `string.IsNullOrEmpty(t.Value)`. `MigrationVersion` additionally implements `IComparable<MigrationVersion>` so versions order correctly.
 
-Because the conversions are **implicit in both directions**, existing code that passes primitives keeps compiling unchanged. Constructing a `BoxMigration` with string and `int` literals still works — the literals convert to the value types at the call site:
+Because the conversions are **implicit in both directions**, you can pass primitives directly. Constructing a `BoxMigration` with string and `int` literals works — the literals convert to the value types at the call site:
 
 ```csharp
 using Paramore.Brighter.BoxProvisioning;
 
-// Primitives convert implicitly — no argument changes needed.
+// Primitives convert implicitly — pass strings and ints directly.
 var migration = new BoxMigration(
     5,                                              // int → MigrationVersion
     "V5: add CloudEvents columns",                  // string → MigrationDescription
     "ALTER TABLE Outbox ADD Source NVARCHAR(255) NULL", // string → SqlScript
-    new[] { "Source" });                            // IReadOnlyCollection<string>, unchanged
+    new[] { "Source" });                            // IReadOnlyCollection<string>
 
 MigrationVersion version = migration.Version;       // value type round-trips
 int versionNumber = version;                        // MigrationVersion → int, implicit
 string description = migration.Description;          // MigrationDescription → string, implicit
 ```
 
-The same implicit conversions apply at every infrastructure call site, so `MigrateAsync("Outbox", "dbo", …)` and a `RelationalDatabaseConfiguration` whose `SchemaName` is a core `string?` continue to compile. The one place the implicit conversion does **not** help is implementing `IAmABoxMigration` (or the runner / provisioner interfaces) with your own class: a property's declared type must match the interface exactly, so declare the members with the value types — `public MigrationVersion Version => …` — rather than the underlying primitive. Constructing the built-in `BoxMigration` record, which is what almost everyone does, needs no change.
+The same implicit conversions apply wherever the infrastructure consumes a value type, so `MigrateAsync("Outbox", "dbo", …)` and a `RelationalDatabaseConfiguration` whose `SchemaName` is a plain `string?` work without casts. The one place the implicit conversion does **not** help is implementing `IAmABoxMigration` (or the runner / provisioner interfaces) with your own class: a property's declared type must match the interface exactly, so declare the members with the value types — `public MigrationVersion Version => …` — rather than the underlying primitive. Constructing the built-in `BoxMigration` record, which is what almost everyone does, needs no such declaration.
 
-Identifier validation is unchanged: `Identifiers.AssertSafe` still runs at the provisioner and runner entry points (on the wrapped string), so a malformed table name such as `"1Outbox"` is rejected exactly as before. The value types are pure information holders — they carry and compare the value, but they do not decide whether it is a safe SQL identifier. For the full design rationale, see ADR `Brighter/docs/adr/0061-box-provisioning-value-types.md`.
+Identifier validation lives outside the value types: `Identifiers.AssertSafe` runs at the provisioner and runner entry points (on the wrapped string), so a malformed table name such as `"1Outbox"` is rejected with a `ConfigurationException`. The value types are pure information holders — they carry and compare the value, but they do not decide whether it is a safe SQL identifier. For the full design rationale, see ADR `Brighter/docs/adr/0061-box-provisioning-value-types.md`.
 
 ## Further Reading
 

--- a/contents/BoxProvisioningConfiguration.md
+++ b/contents/BoxProvisioningConfiguration.md
@@ -66,7 +66,7 @@ services.AddBrighter()
 
 The `RelationalDatabaseConfiguration` you pass to `AddMsSqlOutbox` is the same configuration object you already supply to the MSSQL Outbox itself. Reuse the singleton you registered for `IAmARelationalDatabaseConfiguration` rather than constructing a second one.
 
-> **Note**: BoxProvisioning's internal interfaces now wrap their table name, schema name, and migration parameters in [value types](/contents/BoxProvisioning.md#value-types-on-the-provisioning-interfaces) (`BoxTableName`, `SchemaName`, and so on) to defeat primitive obsession. This does not change how you *configure* provisioning: `outBoxTableName`, `schemaName`, and the other configuration parameters shown on this page remain plain strings, and they convert implicitly where the provisioning interfaces consume them. The value types only matter if you implement those interfaces yourself.
+> **Note**: BoxProvisioning's internal interfaces express their table name, schema name, and migration parameters as [value types](/contents/BoxProvisioning.md#value-types-on-the-provisioning-interfaces) (`BoxTableName`, `SchemaName`, and so on) to defeat primitive obsession. This does not affect how you *configure* provisioning: `outBoxTableName`, `schemaName`, and the other configuration parameters shown on this page are plain strings, and they convert implicitly where the provisioning interfaces consume them. The value types only matter if you implement those interfaces yourself.
 
 ### Outbox and Inbox together
 

--- a/contents/BoxProvisioningConfiguration.md
+++ b/contents/BoxProvisioningConfiguration.md
@@ -66,6 +66,8 @@ services.AddBrighter()
 
 The `RelationalDatabaseConfiguration` you pass to `AddMsSqlOutbox` is the same configuration object you already supply to the MSSQL Outbox itself. Reuse the singleton you registered for `IAmARelationalDatabaseConfiguration` rather than constructing a second one.
 
+> **Note**: BoxProvisioning's internal interfaces now wrap their table name, schema name, and migration parameters in [value types](/contents/BoxProvisioning.md#value-types-on-the-provisioning-interfaces) (`BoxTableName`, `SchemaName`, and so on) to defeat primitive obsession. This does not change how you *configure* provisioning: `outBoxTableName`, `schemaName`, and the other configuration parameters shown on this page remain plain strings, and they convert implicitly where the provisioning interfaces consume them. The value types only matter if you implement those interfaces yourself.
+
 ### Outbox and Inbox together
 
 If your service uses both an Outbox and an Inbox, configure both inside the same `UseBoxProvisioning` delegate:
@@ -243,4 +245,4 @@ Spanner uses the *degenerate runner* — see [Box Provisioning](/contents/BoxPro
 - Per-backend Outbox pages: [MSSQL](/contents/MSSQLOutbox.md) · [MySQL](/contents/MySQLOutbox.md) · [PostgreSQL](/contents/PostgresOutbox.md) · [SQLite](/contents/SqliteOutbox.md).
 - Per-backend Inbox pages: [MSSQL](/contents/MSSQLInbox.md) · [MySQL](/contents/MySQLInbox.md) · [PostgreSQL](/contents/PostgresInbox.md) · [SQLite](/contents/SqliteInbox.md).
 - Sample: `Brighter/samples/WebAPI/WebAPI_Dapper/GreetingsWeb/Startup.cs:116` — the canonical `UseBoxProvisioning` call-site in the WebAPI Dapper sample. (The sample wraps the per-backend call in a small `BoxProvisioningFactory` because it supports multiple backends at runtime; in your application you call the per-backend extension directly, as the examples above show.)
-- ADRs: `Brighter/docs/adr/0053-box-database-migration.md` (architecture, hosted service, package layout) and `Brighter/docs/adr/0057-box-schema-versioning-and-migrations.md` (advisory-lock design, migration runner).
+- ADRs: `Brighter/docs/adr/0053-box-database-migration.md` (architecture, hosted service, package layout), `Brighter/docs/adr/0057-box-schema-versioning-and-migrations.md` (advisory-lock design, migration runner), and `Brighter/docs/adr/0061-box-provisioning-value-types.md` (the value types on the provisioning interfaces).

--- a/contents/BoxProvisioningUpgrade.md
+++ b/contents/BoxProvisioningUpgrade.md
@@ -213,3 +213,4 @@ This is intentional. Backwards-compatible additive migrations and a redeploy-and
 - Per-backend Inbox pages: [MSSQL](/contents/MSSQLInbox.md), [MySQL](/contents/MySQLInbox.md), [PostgreSQL](/contents/PostgresInbox.md), [SQLite](/contents/SqliteInbox.md).
 - `Brighter/docs/adr/0057-box-schema-versioning-and-migrations.md` — versioning model, three-path runner, discriminator gate, mid-chain failure semantics.
 - `Brighter/docs/adr/0053-box-database-migration.md` — hosted-service logging, MSSQL all-or-nothing transaction model, payload-mode validation.
+- `Brighter/docs/adr/0061-box-provisioning-value-types.md` — the value types that replace primitives on the provisioning interfaces (a source-level change only; no effect on the operator-visible behaviour described on this page).


### PR DESCRIPTION
## Summary

Updates the Box Provisioning documentation to reflect the value-type change in the Brighter source (ADR 0061 / spec 0030), which replaces bare `string`/`int` primitives on the provisioning interfaces with dedicated value types: `BoxTableName`, `SchemaName`, `MigrationVersion`, `MigrationDescription`, `SqlScript`, and `SourceReference`.

Verified against the actual source (`IAmABoxMigration.cs`, `BoxMigration.cs`, `IAmABoxMigrationRunner.cs`, `IAmABoxProvisioner.cs`), not just the spec.

## Changes

- **`BoxProvisioning.md`**: Rewrote the "Source-breaking changes on upgrade" section. The old text described `IAmABoxMigration` as gaining `ISet<string> LogicalColumns` plus bare `string?` members — both inaccurate. `LogicalColumns` is actually `IReadOnlyCollection<string>` (corrected a pre-existing error), and the other members are now value types. Added a new "Value types on the provisioning interfaces" subsection: motivation (primitive obsession), a table of the six types, the implicit-conversion source-compatibility story, a `BoxMigration` code example, the property-declaration gotcha for direct implementers, and the note that `Identifiers.AssertSafe` validation is unchanged. Added ADR 0061 to Further Reading.
- **`BoxProvisioningConfiguration.md`**: Code examples are correct as-is — consumer config params stay plain strings (constraint C-1). Added a clarifying note and the ADR reference.
- **`BoxProvisioningUpgrade.md`**: Operator-facing; the change is source-level only with byte-for-byte identical runtime behaviour/logs (NFR-3), so the body is unchanged. Added ADR 0061 to Further Reading.

No new files, so `SUMMARY.md` is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)