### PR TITLE
docs: Replay On Seen (spec 008), plus a link checker and the links it found

### DIFF
--- a/.claude/commands/spec/review.md
+++ b/.claude/commands/spec/review.md
@@ -1,5 +1,5 @@
 ---
-allowed-tools: Bash(cat:*), Bash(test:spec/*), Bash(ls:spec/*), Bash(touch:spec/*), Bash(grep:*), Read
+allowed-tools: Bash(cat:*), Bash(test:spec/*), Bash(ls:spec/*), Bash(touch:spec/*), Bash(grep:*), Bash(python3 tools/linkcheck.py:*), Read
 description: Review current specification phase
 ---
 
@@ -7,12 +7,37 @@ description: Review current specification phase
 
 Current spec: !`cat spec/.current-spec 2>/dev/null || echo "No active spec"`
 
+## Internal Link Check
+
+!`python3 tools/linkcheck.py`
+
 ## Your Task
 
 1. Identify which phase is currently active (the earliest phase not yet approved)
 2. Display the content of that phase's document
 3. Provide a review against the checklist for that phase (see below)
-4. Ask the user if they want to approve. If approved, create the approval marker file.
+4. Report the Internal Link Check result (see below)
+5. Ask the user if they want to approve. If approved, create the approval marker file.
+
+### Internal Link Check
+
+The `## Internal Link Check` section above is the output of `tools/linkcheck.py`,
+which walks every published markdown file and verifies that each internal link
+resolves — both that the target file exists and that the anchor matches a real
+heading.
+
+How to treat the result depends on the phase:
+
+- **Requirements and Design phases** — no documentation has been written yet, so
+  any breakage is pre-existing. Mention it in one line so it is on the record,
+  but do not block approval on it. Offer to fix it as a separate change.
+- **Tasks phase, and any review after writing has begun** — breakage may be
+  *yours*. Compare against what was already broken; anything introduced by this
+  spec's work is **blocking** and must be fixed before approval.
+
+If the check reports "No broken internal links", say so in one line and move on.
+Do not re-run the tool — the output above is current. To check a single file
+while fixing, run `python3 tools/linkcheck.py contents/SomePage.md`.
 
 ### Phase Detection
 
@@ -49,7 +74,7 @@ The active phase is the first one where the document exists but the approval mar
 - Are tasks small and specific (one section or file each)?
 - Do tasks have clear inputs and outputs?
 - Are dependencies between tasks noted?
-- Is there a final task for SUMMARY.md and link verification?
+- Is there a final task for SUMMARY.md and link verification (running `python3 tools/linkcheck.py`)?
 - Are tasks ordered so foundational content comes first?
 
 ### Approval

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -121,10 +121,19 @@ When unclear about a feature:
 ### Cross-Linking Documentation
 
 **Verifying links:** `python3 tools/linkcheck.py` checks every internal link in
-the published docs — that the target file exists, and that the anchor matches a
-real heading. Pass file paths to check just those files. It exits non-zero when
-anything is broken, so it can gate CI. Run it after any change that adds or
-retargets links.
+the published docs. It reports four faults:
+
+- **MISSING FILE** — the target does not exist
+- **MISSING ANCHOR** — the file exists, but no heading slugifies to the anchor
+- **WRONG CASE** — the target exists only under different capitalisation. macOS
+  and Windows resolve these; GitBook does not, so they 404 once published
+- **ORPHAN** — a page under `contents/` that `SUMMARY.md` never links to
+
+Pass file paths to check just those files; orphans are only reported on a
+whole-repo run, since that check needs every page in view. It exits non-zero
+when anything is broken, so it can gate CI. Run it after any change that adds or
+retargets links, **and after adding a page** — the orphan check is what enforces
+the "never create orphaned files" rule below.
 
 **Internal Links (to other docs):**
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -120,6 +120,12 @@ When unclear about a feature:
 
 ### Cross-Linking Documentation
 
+**Verifying links:** `python3 tools/linkcheck.py` checks every internal link in
+the published docs — that the target file exists, and that the anchor matches a
+real heading. Pass file paths to check just those files. It exits non-zero when
+anything is broken, so it can gate CI. Run it after any change that adds or
+retargets links.
+
 **Internal Links (to other docs):**
 
 ```markdown
@@ -416,7 +422,7 @@ Before finalizing documentation, verify:
 **Structure:**
 
 - [ ] SUMMARY.md updated with any new files
-- [ ] All cross-links work (no broken links)
+- [ ] All cross-links work (no broken links) — verify with `python3 tools/linkcheck.py`
 - [ ] File follows standard organization pattern
 - [ ] Headings are logical and scannable
 - [ ] Further Reading section includes relevant links

--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -79,6 +79,8 @@
    * [MongoDB Distributed Lock](/contents/MongoDbDistributedLock.md)
    * [Firestore Distributed Lock](/contents/FirestoreDistributedLock.md)
  * [Inbox Support](/contents/BrighterInboxSupport.md)
+ * [Replay On Seen](/contents/ReplayOnSeen.md)
+ * [Causation Tracking in a Custom Store](/contents/CausationTrackingStores.md)
  * [MSSQL Outbox](/contents/MSSQLOutbox.md)
  * [MySQL Outbox](/contents/MySQLOutbox.md)
  * [Postgres Outbox](/contents/PostgresOutbox.md)

--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -19,13 +19,14 @@
 
 ## Brighter Request Handlers and Middleware Pipelines
 
- * [Requests, Commands and an Events](/contents/Requests%2C%20Commands%20and%20Events.md)
+ * [Requests, Commands and Events](/contents/Requests%2C%20Commands%20and%20Events.md)
  * [Dispatching Requests](/contents/DispatchingARequest.md)
  * [Dispatching An Async Request](/contents/AsyncDispatchARequest.md)
  * [Returning results from a Handler](/contents/ReturningResultsFromAHandler.md) 
  * [Building a Pipeline of Request Handlers](/contents/BuildingAPipeline.md)
  * [Building an Async Pipeline of Request Handlers](/contents/BuildingAnAsyncPipeline.md)
  * [Passing information between Handlers in the Pipeline](/contents/UsingTheContextBag.md) 
+ * [How to Implement a Request Handler](/contents/ImplementingAHandler.md)
  * [How to Implement an Async Request Handler](/contents/ImplementingAsyncHandler.md)
  * [Agreement Dispatcher](/contents/AgreementDispatcher.md)
  * [Supporting Retry and Circuit Breaker](/contents/PolicyRetryAndCircuitBreaker.md)
@@ -51,6 +52,9 @@
  * [Routing](/contents/Routing.md) 
  * [Default Message Mappers](/contents/DefaultMessageMappers.md)
  * [Cloud Events Support](/contents/CloudEventsSupport.md)
+ * [Claim Check](/contents/ClaimCheck.md)
+   * [S3 Luggage Store](/contents/S3LuggageStore.md)
+ * [Compression](/contents/Compression.md)
  * [Dynamic Message Deserialization](/contents/DynamicMessageDeserialization.md) 
  * [AsyncAPI Document Generation](/contents/AsyncAPISupport.md)
  * [Error Handling](/contents/HandlerFailure.md)
@@ -63,7 +67,8 @@
  * [AWS SNS Configuration](/contents/AWSSQSConfiguration.md)
  * [Kafka Configuration](/contents/KafkaConfiguration.md)
  * [Azure Service Bus Configuration](/contents/AzureServiceBusConfiguration.md)
- * [Azure Archive Provider Configuration](/contents/AzureBlobArchiveProvider.md)
+ * [Azure Blob Archive Provider](/contents/AzureBlobArchiveProvider.md)
+   * [Azure Archive Provider Configuration](/contents/AzureBlobConfiguration.md)
  * [Brighter Control API](/contents/BrighterControlAPI.md)
 
 ## Outbox and Inbox
@@ -86,6 +91,7 @@
  * [Postgres Outbox](/contents/PostgresOutbox.md)
  * [Sqlite Outbox](/contents/SqliteOutbox.md)
  * [Dapper Outbox](/contents/DapperOutbox.md)
+ * [EF Core Outbox](/contents/EFCoreOutbox.md)
  * [Dynamo Outbox](/contents/DynamoOutbox.md)
  * [MongoDb Outbox](/contents/MongoDBOutbox.md)
  * [MSSQL Inbox](/contents/MSSQLInbox.md)
@@ -93,7 +99,7 @@
  * [Postgres Inbox](/contents/PostgresInbox.md)
  * [Sqlite Inbox](/contents/SqliteInbox.md)
  * [Dynamo Inbox](/contents/DynamoInbox.md)
- * [MongoDb Inbox](/contents/MongoDbInbox.md)
+ * [MongoDb Inbox](/contents/MongoDBInbox.md)
 
 ## Database Provisioning
 

--- a/contents/AWSSQSConfiguration.md
+++ b/contents/AWSSQSConfiguration.md
@@ -424,7 +424,7 @@ V10 maintains backwards compatibility with existing configurations while providi
 3. **Side-by-side**: Run v3 and v4 packages in the same application (different transport types)
 4. **New projects**: Start with v4 packages for the latest features and performance
 
-See [Migration Guidance](#migration-guidance) below for step-by-step instructions.
+See [Migration Guidance](#migrating-from-aws-sdk-v3-to-v4) below for step-by-step instructions.
 
 ### Migrating from AWS SDK v3 to v4
 

--- a/contents/AzureServiceBusConfiguration.md
+++ b/contents/AzureServiceBusConfiguration.md
@@ -47,7 +47,7 @@ For more on a *Publication* see the material on an *Add Producers* in [Basic Con
 
 ## Subscription
 
-For more on a *Subscription* see the material on configuring *Service Activator* in [Basic Configuration](/contents/BrighterBasicConfiguration.md#configuring-the-service-activator).
+For more on a *Subscription* see the material on configuring *Service Activator* in [Basic Configuration](/contents/BrighterBasicConfiguration.md#configuring-the-dispatcher).
 
 When 
 

--- a/contents/BoxProvisioning.md
+++ b/contents/BoxProvisioning.md
@@ -69,7 +69,7 @@ Each column has an operator-visible purpose:
 - `MigrationVersion` — the integer version the row records. `1` for V1 (bootstrap or fresh install on a born-past-V1 backend), counting up from there.
 - `SchemaName` — the database schema the box lives in (`dbo` on MSSQL, `public` on PostgreSQL, the database name on SQLite, and so on). Set to the backend's default schema when not otherwise specified.
 - `BoxTableName` — the table name (`Outbox`, `Inbox`, `tenant_1_Outbox`, whatever you configured).
-- `Description` — a human-readable note recording how the row was inserted: `"fresh install at V7"`, `"bootstrap: detected at V4"`, or the migration's own description string (e.g. `"V5: add CloudEvents columns"`). Useful when triaging an upgrade — it tells you whether a row came from the fresh path, the bootstrap path, or a real chain replay.
+- `Description` — a human-readable note recording how the row was inserted: `"fresh install at V8"`, `"bootstrap: detected at V4"`, or the migration's own description string (e.g. `"Add CloudEvents columns (Source, Type, DataSchema, Subject, TraceParent, TraceState, Baggage)"`). Useful when triaging an upgrade — it tells you whether a row came from the fresh path, the bootstrap path, or a real chain replay.
 - `AppliedAt` — UTC timestamp set by the database default (`GETUTCDATE()` on MSSQL, `NOW()` on PostgreSQL, and so on). Useful for correlating against deploy times.
 
 For day-to-day operations, treat the history table as read-only audit data. You can `SELECT` from it to confirm which migrations have run on a given environment (the [Upgrading Existing Deployments](/contents/BoxProvisioningUpgrade.md) page shows the query); you should not delete or rewrite rows. Deleting a row would cause the runner to re-apply that migration on the next startup, which is safe but pointless.
@@ -90,22 +90,26 @@ On Kubernetes, size your readiness probe's `initialDelaySeconds` and `failureThr
 
 | Backend | NuGet package | Outbox versions | Inbox versions | Advisory-lock primitive |
 |---------|---------------|-----------------|----------------|-------------------------|
-| MSSQL | `Paramore.Brighter.BoxProvisioning.MsSql` | V1..V7 | V1..V2 | `sp_getapplock` |
-| PostgreSQL | `Paramore.Brighter.BoxProvisioning.PostgreSql` | V1..V7 | V1 only | `pg_try_advisory_lock` |
-| MySQL | `Paramore.Brighter.BoxProvisioning.MySql` | V1..V7 | V1..V2 | `GET_LOCK` |
-| SQLite | `Paramore.Brighter.BoxProvisioning.Sqlite` | V1..V7 | V1..V2 | `BEGIN IMMEDIATE` |
-| Spanner | `Paramore.Brighter.BoxProvisioning.Spanner` | fresh-install-only | fresh-install-only | n/a (DDL serialised by Spanner) |
+| MSSQL | `Paramore.Brighter.BoxProvisioning.MsSql` | V1..V8 | V1..V3 | `sp_getapplock` |
+| PostgreSQL | `Paramore.Brighter.BoxProvisioning.PostgreSql` | V1..V8 | V1..V2 | `pg_try_advisory_lock` |
+| MySQL | `Paramore.Brighter.BoxProvisioning.MySql` | V1..V8 | V1..V3 | `GET_LOCK` |
+| SQLite | `Paramore.Brighter.BoxProvisioning.Sqlite` | V1..V8 | V1..V3 | `BEGIN IMMEDIATE` |
+| Spanner | `Paramore.Brighter.BoxProvisioning.Spanner` | fresh-install-only (creates the V8 shape) | fresh-install-only (creates the V3 shape) | n/a (DDL serialised by Spanner) |
 
 Per-backend Outbox pages: [MSSQL](/contents/MSSQLOutbox.md), [MySQL](/contents/MySQLOutbox.md), [PostgreSQL](/contents/PostgresOutbox.md), [SQLite](/contents/SqliteOutbox.md). Per-backend Inbox pages: [MSSQL](/contents/MSSQLInbox.md), [MySQL](/contents/MySQLInbox.md), [PostgreSQL](/contents/PostgresInbox.md), [SQLite](/contents/SqliteInbox.md). Each of these pages shows the Option A and Option B shapes for that backend.
 
-The "Outbox versions" and "Inbox versions" columns refer to the ordered [migration chain](/contents/Glossary.md#migration-chain). V1 is the historical first-shipped DDL for that backend; later versions add columns over time as Brighter's message model has grown (for example, V4 added `PartitionKey`; V5 added the CloudEvents columns; V7 added `DataRef` and `SpecVersion`). Each version's full column list is recorded in the backend's `*MigrationCatalog` source, alongside the PR and commit that introduced it.
+The "Outbox versions" and "Inbox versions" columns refer to the ordered [migration chain](/contents/Glossary.md#migration-chain). V1 is the historical first-shipped DDL for that backend; later versions add columns over time as Brighter's message model has grown (for example, V4 added `PartitionKey`; V5 added the CloudEvents columns; V7 added `DataRef` and `SpecVersion`; V8 added `CausationId`). Each version's full column list is recorded in the backend's `*MigrationCatalog` source, alongside the PR and commit that introduced it.
+
+The Inbox chains are much shorter, and their latest migration adds the matching causation column: V3 on MSSQL, MySQL, and SQLite, V2 on PostgreSQL. Both boxes need it before [replay on seen](/contents/ReplayOnSeen.md) will work — an Outbox migrated without its Inbox, or the reverse, leaves replay silently doing nothing.
+
+**The Outbox V8 migration also creates an index**, which makes it the first migration in any catalog to create anything other than columns. The index name varies by backend — `idx_{table}_CausationId` on MSSQL and SQLite, the bare `idx_CausationId` on MySQL (which scopes index names to the table), and lowercase `idx_{table}_causationid` on PostgreSQL, whose column is `causationid` rather than `CausationId`. Because the index is built over rows that already exist, expect this migration to take longer than earlier ones on a large Outbox table, and to hold the migration lock for that time.
 
 ## Per-backend differences to be aware of
 
 | Backend | Asymmetry | What it means for operators |
 |---------|-----------|------------------------------|
 | MSSQL | All-or-nothing multi-version upgrade | A mid-chain failure rolls back *all* migrations in that run. See [Upgrading Existing Deployments](/contents/BoxProvisioningUpgrade.md#mssql-multi-version-upgrades). |
-| PostgreSQL | Inbox is V1-only | The Postgres Inbox shipped with its final column set in 2021; no V2 exists. The chain is intentionally shorter. |
+| PostgreSQL | Inbox chain is one version shorter | The Postgres Inbox shipped with `ContextKey` in 2021, so it never needed the V2 migration the other backends have. It runs V1..V2 where they run V1..V3, and ends at the same column set. |
 | MySQL | Minimum 8.0 | Earlier MySQL versions are not supported. |
 | SQLite | File-level locking only | Long migration chains block readers. Acceptable for the dev/test use case SQLite targets. |
 | Spanner | Fresh-install-only (degenerate runner) | The runner can create the table but cannot evolve an existing table. Track-record: no known production deployments. |
@@ -113,7 +117,7 @@ The "Outbox versions" and "Inbox versions" columns refer to the ordered [migrati
 These differences are not bugs — they reflect each backend's native semantics or the historical shape of the code that already shipped:
 
 - **MSSQL's all-or-nothing rule** follows from MSSQL's single-transaction-spans-the-whole-run model, which is how MSSQL gives you transactional DDL at all. The runner wraps the lock-acquire, every migration's DDL, and every history-row insert in one transaction. A failure at migration *N* rolls back migrations *1..N-1* applied in the same run, which is consistent with MSSQL's general transactional-DDL behaviour. PostgreSQL, MySQL, and SQLite commit per-migration, so a mid-chain failure there leaves the earlier migrations intact. The MSSQL semantics matter mostly when you skip several Brighter versions at once; see [Upgrading Existing Deployments](/contents/BoxProvisioningUpgrade.md#mssql-multi-version-upgrades) for the operator-facing detail.
-- **The PostgreSQL Inbox is V1-only** because the PostgreSQL Inbox was introduced in 2021 and shipped with `ContextKey` and the composite primary key from its very first commit. The MSSQL / MySQL / SQLite Inbox V2 migration added `ContextKey` to tables that pre-existed without it; PostgreSQL never had that earlier shape, so there is nothing to migrate. Not a missing feature — just a shorter chain.
+- **The PostgreSQL Inbox chain is one version shorter** because the PostgreSQL Inbox was introduced in 2021 and shipped with `ContextKey` and the composite primary key from its very first commit. The MSSQL / MySQL / SQLite Inbox V2 migration added `ContextKey` to tables that pre-existed without it; PostgreSQL never had that earlier shape, so it had nothing to migrate and its chain starts one step ahead. Later migrations still apply — what the other three do at V3, PostgreSQL does at V2 (adding the causation column). So a fully migrated PostgreSQL Inbox reports V2 and a fully migrated MSSQL Inbox reports V3, and both have the same columns. Not a missing feature — just a shorter chain.
 - **MySQL's 8.0 minimum** reflects the underlying need for `JSON` and modern `INFORMATION_SCHEMA.COLUMNS` behaviour. MySQL 5.7 is end-of-life from Oracle and unsupported.
 - **SQLite's file-level locking** is the SQLite design; long migrations on a high-throughput SQLite database would briefly block readers. In practice SQLite serves dev, test, and small-deployment workloads, where this is acceptable.
 - **Spanner's degenerate runner** reflects the fact that no production Brighter installation has ever run on Spanner. The runner creates the table on a fresh database but does not attempt to evolve an existing one; if that ever changes, a full Spanner migration chain can be added without breaking the abstraction.

--- a/contents/BoxProvisioningUpgrade.md
+++ b/contents/BoxProvisioningUpgrade.md
@@ -12,7 +12,7 @@ The first start of your application after you enable `UseBoxProvisioning` follow
 2. It finds the table and queries `__BrighterMigrationHistory` (or `BrighterMigrationHistory` on Spanner) for rows scoped to that table. There are none — this is a pre-existing deployment.
 3. It introspects the table's columns through the database's `information_schema` (or `pragma_table_info` on SQLite) and walks the migration chain top-down until it finds the highest version whose columns are all present. That is the version Brighter originally shipped the table at.
 4. It writes a single synthetic row into `__BrighterMigrationHistory` recording that version as already applied. No DDL runs at this point.
-5. It then runs any subsequent migrations in order — for example, if your table was originally created at V4 and the current Brighter ships V7, the runner applies V5, V6, and V7, inserting a history row after each successful migration.
+5. It then runs any subsequent migrations in order — for example, if your table was originally created at V4 and the current Brighter ships V8, the runner applies V5, V6, V7, and V8, inserting a history row after each successful migration.
 6. Every future start uses the normal path: the runner reads `MAX(MigrationVersion)` from the history table and applies any new migrations that have shipped since the last run.
 
 The entire bootstrap path runs inside the [advisory lock](/contents/Glossary.md#advisory-lock) — so concurrent application instances starting at the same time cannot race on the synthetic history insertion.
@@ -60,23 +60,25 @@ WHERE BoxTableName = 'Outbox'
 ORDER BY MigrationVersion;
 ```
 
-A bootstrap of a table that was originally at V4 against a Brighter release that ships V7 produces something like:
+A bootstrap of a table that was originally at V4 against a Brighter release that ships V8 produces something like:
 
 ```text
 MigrationVersion | BoxTableName | AppliedAt           | Description
------------------+--------------+---------------------+----------------------------------------
-1                | Outbox       | 2026-05-26 09:14:01 | bootstrap: detected at V4
-2                | Outbox       | 2026-05-26 09:14:01 | bootstrap: detected at V4
-3                | Outbox       | 2026-05-26 09:14:01 | bootstrap: detected at V4
+-----------------+--------------+---------------------+---------------------------------------------------
 4                | Outbox       | 2026-05-26 09:14:01 | bootstrap: detected at V4
-5                | Outbox       | 2026-05-26 09:14:02 | + DataRef + SpecVersion
-6                | Outbox       | 2026-05-26 09:14:02 | + Source + Type + Subject
-7                | Outbox       | 2026-05-26 09:14:03 | + DataSchema
+5                | Outbox       | 2026-05-26 09:14:02 | Add CloudEvents columns (Source, Type, DataSchema, Subject, TraceParent, TraceState, Baggage)
+6                | Outbox       | 2026-05-26 09:14:02 | Add WorkflowId, JobId columns
+7                | Outbox       | 2026-05-26 09:14:03 | Add DataRef, SpecVersion columns
+8                | Outbox       | 2026-05-26 09:14:04 | Add CausationId column and replay index
 ```
+
+There is **one** bootstrap row, not one per skipped version: the runner stamps the version it detected and moves straight on to the migrations above it. The rows that follow carry each migration's own description string, verbatim from the backend's `*MigrationCatalog`.
 
 Cross-check `MAX(MigrationVersion)` against the per-backend support matrix on [Database Provisioning](/contents/BoxProvisioning.md#per-backend-support). If the highest applied version matches `V_latest` for your backend, your table is current.
 
-New columns added by V5–V7 on a bootstrapped table will be `NULL` for every row that already existed. That is expected and safe — every Brighter migration is additive, and Brighter accepts `NULL` for these columns on old rows. No backfill is required.
+New columns added by V5–V8 on a bootstrapped table will be `NULL` for every row that already existed. That is expected and safe — every Brighter migration is additive, and Brighter accepts `NULL` for these columns on old rows. No backfill is required.
+
+- **If you intend to use [replay on seen](/contents/ReplayOnSeen.md)**, confirm the causation column landed on *both* boxes: the Outbox at V8, and the Inbox at V3 — or V2 on PostgreSQL, whose chain is one step shorter. The column is `CausationId`, or lowercase `causationid` on PostgreSQL. Replay needs both boxes migrated, and a box that missed the migration produces a startup *warning* rather than an error, so your application starts and quietly replays nothing. Note also that rows written before the migration keep a `NULL` causation id and can never be replayed — only messages deposited afterwards can.
 
 ## Documented edge cases
 
@@ -127,7 +129,7 @@ This is acceptable only when the existing table already matches `V_latest`. If y
 
 The MSSQL runner wraps the entire migration chain — `sp_getapplock`, every `ALTER TABLE`, every history insert — in a single `SqlTransaction`. This produces **all-or-nothing** semantics for a single provisioning run:
 
-- A mid-chain failure rolls back **every** migration the run touched. If V5, V6, and V7 are pending and V7 fails, V5 and V6 are also rolled back.
+- A mid-chain failure rolls back **every** migration the run touched. If V6, V7, and V8 are pending and V8 fails, V6 and V7 are also rolled back.
 - The `__BrighterMigrationHistory` table will not contain partial progress. After a failure, `MAX(MigrationVersion)` reflects the last fully successful run, not the highest individual migration that succeeded in the failed run.
 - PostgreSQL behaves the same way (transactional DDL). MySQL and SQLite differ: MySQL commits implicitly on each DDL statement and SQLite commits per-migration, so a mid-chain failure on those backends leaves the migrations that did succeed in the history table and the next run resumes from the next version.
 

--- a/contents/BrighterBasicConfiguration.md
+++ b/contents/BrighterBasicConfiguration.md
@@ -4,7 +4,7 @@ Configuration is the most labor-intensive part of using Brighter. Once you have 
 
 ## **Using .NET Core Dependency Injection**
 
-This section covers using .NET Core Dependency Injection to configure Brighter. If you want to use an alternative DI container then see the section [How Configuration Works](/contents/HowConfigurationWorks.md)
+This section covers using .NET Core Dependency Injection to configure Brighter. If you want to use an alternative DI container then see the section [How Configuration Works](/contents/HowConfiguringTheCommandProcessorWorks.md)
 
 We divide configuration into two sections, depending on your requirements:
 
@@ -106,7 +106,7 @@ public void ConfigureServices(IServiceCollection services)
 
 #### **Configuring Lifetimes**
 
-Brighter can register your *Request Handlers* and *Message Mappers* for you (see [IBrighter Builder Fluent Interface](#ibrighterbuilder-fluent-interface)). 
+Brighter can register your *Request Handlers* and *Message Mappers* for you (see [IBrighter Builder Fluent Interface](#brighter-builder-fluent-interface)). 
 
 When we register *Request Handlers* and *Message Mappers* for you with ServiceCollection, we need to register them with a given lifetime (see [Dependency Injection Service Lifetimes](https://docs.microsoft.com/en-us/dotnet/core/extensions/dependency-injection#service-lifetimes)).
 
@@ -590,7 +590,7 @@ public void ConfigureServices(IServiceCollection services)
 
 #### Request-Reply
 
-(**AddProducers()** has optional parameters for use with Request-Reply support for some transports. We don't cover that here, instead see [Direct Messaging](/contents/Routing.md#direct-messaging) for more).
+(**AddProducers()** has optional parameters for use with Request-Reply support for some transports. We don't cover that here, instead see [Direct Messaging](/contents/Routing.md#commands) for more).
 
 #### **Configuring JSON Serialization**
 
@@ -734,7 +734,7 @@ if you are using .NET 6 you can make the call direction on your **HostBuilder**'
 
 The **AddConsumers()** method takes an **`Action<ServiceActivatorOptions>`** delegate. The extension method supplies the delegate with a **ServiceActivatorOptions** object that allows you to configure how Brighter runs.
 
-The **AddConsumers()** method returns an **IBrighterBuilder** interface. **IBrighterBuilder** is a [fluent interface](https://en.wikipedia.org/wiki/Fluent_interface) that you can use to configure Brighter *Command Processor* properties. It is discussed above at [Brighter Builder Fluent Interface](#brighter-builder-fluent-interface)) and the same options apply. We discuss one additional option that becomes important when receiving requests the *Inbox* in [Additional Brighter Builder Options](/contents/BasicConfiguration.md#the-inbox).
+The **AddConsumers()** method returns an **IBrighterBuilder** interface. **IBrighterBuilder** is a [fluent interface](https://en.wikipedia.org/wiki/Fluent_interface) that you can use to configure Brighter *Command Processor* properties. It is discussed above at [Brighter Builder Fluent Interface](#brighter-builder-fluent-interface)) and the same options apply. We discuss one additional option that becomes important when receiving requests the *Inbox* in [Additional Brighter Builder Options](/contents/BrighterBasicConfiguration.md#inbox).
 
 #### **Subscriptions**
 
@@ -883,7 +883,7 @@ To configure our *Inbox* we then need to use the UseExternalInbox method call an
 
 For *Inbox Configuration* you set the following properties:
 
-* **ActionOnExists**: What do we do if the request has been handled? The default,**OnceOnlyAction.Throw** is to throw a **OnceOnlyException**. If you take no other action this will cause the message to be rejected and sent to a DLQ if one is configured (See [Handler Failure](/contents/HandlerFailure.md)). The alternative is **OnceOnlyAction.Warn** simply logs that the request is a duplicate, but takes no other action.
+* **ActionOnExists**: What do we do if the request has been handled? The default,**OnceOnlyAction.Throw** is to throw a **OnceOnlyException**. If you take no other action this will cause the message to be rejected and sent to a DLQ if one is configured (See [Handler Failure](/contents/HandlerFailure.md)). The alternative is **OnceOnlyAction.Warn** simply logs that the request is a duplicate, but takes no other action. A third option, **OnceOnlyAction.Replay**, also skips the handler but resends the messages that handler produced the first time it ran — it has prerequisites, so see [Replay On Seen](/contents/ReplayOnSeen.md) before you choose it.
 * **OnceOnly**: This defaults to *true* and will check for a duplicate and take the action indicated by **ActionOnExists**. If *false* the *Inbox* will record the request, but will take no further action. (This tends to be set to *false* if you are using the *Inbox* to record what requests caused current state only and not de-duplicate).
 * **Scope**: This indicates the type of request (*Command* or *Event*) to store in the *Inbox*. By default this is set to **InboxScope.All** and captures everything but you can be explicit and just capture **InboxScope.Commands** or **InboxScope.Events**. (This tends to be set to **InboxScope.Commands** when only commands cause changes to state that are not idempotent).
 * **Context**: Used to uniquely identify receipt of this request via this handler. If you are recording *Events* and have multiple handlers, then the first event handler to receive the message will block the others from doing so, unless you disambiguate the handler identity by supplying a context method.

--- a/contents/BrighterInboxSupport.md
+++ b/contents/BrighterInboxSupport.md
@@ -35,6 +35,7 @@ You also need to configure what action the inbox takes when it has seen a reques
 - OnceOnlyAction: What does the inbox do, when a duplicate is encountered. Defaults to Throw.
   - Warn: Just log that a duplicate was received
   - Throw: Throws a OnceOnlyException
+  - Replay: Resends the messages this handler produced the first time it ran, without running it again. See [Replay On Seen](/contents/ReplayOnSeen.md)
 
 The combination of these flags results in the following behaviors:
 
@@ -43,8 +44,11 @@ The combination of these flags results in the following behaviors:
 | `false`    | `Warn` or `Throw`| Always processes the message. Records the message in the inbox. This is the default behavior.        |
 | `true`     | `Warn`           | If a duplicate is found, logs a warning and **stops** processing the message. Otherwise, processes it. |
 | `true`     | `Throw`          | If a duplicate is found, throws a `OnceOnlyException` and **stops** processing. Otherwise, processes it. |
+| `true`     | `Replay`         | If a duplicate is found, replays the Outbox messages produced during the original handling and **stops** processing. Otherwise, processes it. |
 
 **If you wish to terminate processing on a duplicate, you must set `onceOnly` to `true`.**
+
+`Replay` asks for more than the other two actions: it needs an inbox and an outbox that both track causation, a schema migrated to hold the causation column, and an [Outbox Sweeper](/contents/BrighterOutboxSupport.md#you-always-need-a-sweeper) to resend what it marks undispatched. Read [Replay On Seen](/contents/ReplayOnSeen.md) before you enable it — miss a prerequisite and replay does nothing, usually without an error.
 
 In the context of the Service Activator (listening to messages over middleware) throwing a `OnceOnlyException` will result in the message being acked (because it has already been processed).
 

--- a/contents/BrighterInboxSupport.md
+++ b/contents/BrighterInboxSupport.md
@@ -50,7 +50,7 @@ The combination of these flags results in the following behaviors:
 
 `Replay` asks for more than the other two actions: it needs an inbox and an outbox that both track causation, a schema migrated to hold the causation column, and an [Outbox Sweeper](/contents/BrighterOutboxSupport.md#you-always-need-a-sweeper) to resend what it marks undispatched. Read [Replay On Seen](/contents/ReplayOnSeen.md) before you enable it — miss a prerequisite and replay does nothing, usually without an error.
 
-In the context of the Service Activator (listening to messages over middleware) throwing a `OnceOnlyException` will result in the message being acked (because it has already been processed).
+In the context of the Dispatcher (listening to messages over middleware) throwing a `OnceOnlyException` results in the message being acked (because it has already been processed).
 
 The inbox is global to your application and uses the request id; you will want to distinguish requests in the inbox if you need to store the same request id for different pipelines. For example, if you deliver an event to multiple handlers, each handler has a request with the same request id.
 

--- a/contents/BrighterOutboxSupport.md
+++ b/contents/BrighterOutboxSupport.md
@@ -190,6 +190,8 @@ Without the Sweeper, you have two risks:
 - An explicit attempt to clear the Outbox by calling `ClearOutbox` on the `CommandProcessor` can fail. Although it is protected by a Polly resilience policy, if that policy still does not succeed in clearing the Outbox, the messages will linger there. Running a Sweeper means they are eventually sent.
 - Some transports, notably RabbitMQ and Kafka, support callbacks to inform the caller that a message has been sent. This happens asynchronously, so at the point of calling `Post` or `ClearOutbox` you do not yet know whether the message was sent; instead you must await the callback. Because the calling code has moved on, the response always returns on a new thread, which has no context for the original call and cannot interactively notify you that the operation failed. However, if you have a Sweeper, the message — still in your Outbox — will be sent.
 
+There is a third case, and it makes the Sweeper unavoidable rather than merely advisable. If you configure an Inbox with `OnceOnlyAction.Replay`, a duplicate request makes Brighter clear the dispatched marker on the messages the original handling produced — the `Dispatched` column on a relational Outbox — putting them back in the Sweeper's path. That is the *only* way a replayed message ever leaves your application: replay resets rows, it never dispatches anything itself, so without a Sweeper the messages are marked outstanding and stay there. See [Replay On Seen](/contents/ReplayOnSeen.md).
+
 
 ## Outbox Archiver
 
@@ -509,3 +511,5 @@ public class GreetingMadeHandler : RequestHandlerAsync<GreetingMade>
 - Both entity writes and message writes succeed or fail together
 
 For a simpler, non-transactional approach suitable for getting started, see [Show me the code!](/contents/ShowMeTheCode.md#using-an-external-bus).
+
+This handler drops a duplicate: the Inbox stops it, and `SalutationReceived` is not sent again. If a duplicate should instead push a stalled flow forward — resending the messages the first run produced, without running the handler again — see [Replay On Seen](/contents/ReplayOnSeen.md).

--- a/contents/CausationTrackingStores.md
+++ b/contents/CausationTrackingStores.md
@@ -1,0 +1,151 @@
+# Implementing Causation Tracking in Your Own Store
+
+[Replay On Seen](/contents/ReplayOnSeen.md) needs two things from your storage: an Inbox
+that can hand back the [Causation Id](/contents/ReplayOnSeen.md#causation-id) it recorded
+when a request was first handled, and an Outbox that can find every message stored under
+that Causation Id and make it outstanding again. A **Causation Id** is the value shared by
+an Inbox entry and every Outbox message the handler produced during that invocation; it
+defaults to the handled request's own `Id`. Brighter asks for both capabilities through a
+pair of optional role interfaces, and this page covers what your implementation has to do.
+
+> This page is for people **writing** an Inbox or Outbox — a backend Brighter does not
+> ship, or a wrapper of your own. If you are using a Brighter-maintained store, it already
+> implements everything below; see
+> [Store Support](/contents/ReplayOnSeen.md#store-support) instead.
+
+Causation tracking is an **optional role interface** on each box, separate from the core
+Inbox and Outbox interfaces. A store that does not implement it keeps working exactly as
+before — it simply never participates in replay.
+
+## The two interfaces
+
+Both live in the `Paramore.Brighter` namespace.
+
+`IAmACausationTrackingInbox` has three jobs:
+
+| Member | What your implementation must do |
+|---|---|
+| `SupportsCausationTracking()` / `…Async()` | Report whether the **live** store can hold a Causation Id right now |
+| `GetCausationId(id, contextKey, …)` / `…Async()` | Return the Causation Id stored against an entry, or `null` if there is none |
+| *(your `Add`)* | Read the Causation Id out of the request context and store it with the entry |
+
+`IAmACausationTrackingOutbox` mirrors it:
+
+| Member | What your implementation must do |
+|---|---|
+| `SupportsCausationTracking()` / `…Async()` | As above |
+| `ReplayCausation(causationId, …)` / `…Async()` | Clear the dispatched state of every message stored under that Causation Id, so the Sweeper resends them. Return `true` if you did it, `false` if it was a no-op |
+| *(your `Add`)* | Read the Causation Id out of the request context and store it with the message |
+
+Note that storing the Causation Id is **not** on either interface. It happens inside your
+`Add`, which already receives the `RequestContext` it needs:
+
+```csharp
+using Paramore.Brighter;
+
+private static string? ReadCausationId(RequestContext? requestContext)
+    => requestContext?.Bag.TryGetValue(RequestContextBagNames.CausationId, out var value) == true
+        ? value as string
+        : null;
+```
+
+## Three rules that are easy to get wrong
+
+**`SupportsCausationTracking()` must report the live state, not your intent.** It is not
+"does this class implement the interface" — the class obviously does, or the method would not
+be there. It is "can the store *this instance is talking to* hold a Causation Id today". For a
+schemaless store that is genuinely always `true`. For anything with a schema, go and look:
+Brighter's relational stores query for the column, and its DynamoDB Outbox calls
+`DescribeTable` for the index. Returning an optimistic `true` makes
+[pipeline validation](/contents/PipelineValidation.md) pass and then fails at runtime, which
+is precisely the outcome the method exists to prevent.
+
+**Never throw for an unsupported store — degrade.** `GetCausationId` returns `null` and
+`ReplayCausation` returns `false`. A duplicate arriving at an un-migrated store must not
+unwind the consumer pipeline with a schema error, and the `false` return is what lets
+Brighter record a
+[`Replay Skipped` event](/contents/ReplayOnSeen.md#replay-versus-replay-skipped) rather than
+claiming a replay that never happened.
+
+**Gate your own write path on the same answer.** If your `Add` unconditionally writes a
+Causation Id, an un-migrated store starts failing deposits the moment someone upgrades. Ask
+the same probe, and fall back to your original write when it says no. If the probe is
+expensive, memoize it — and read
+[Upgrading Without Migrating](/contents/ReplayOnSeen.md#upgrading-without-migrating) for the
+restart consequence that memoizing carries.
+
+## A skeleton
+
+```csharp
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Paramore.Brighter;
+
+public class MyOutbox : IAmAnOutboxSync<Message, MyTransaction>, IAmACausationTrackingOutbox
+{
+    private bool? _causationSupported;
+
+    // ... the core Outbox members: Get, MarkDispatched, OutstandingMessages, Delete ...
+
+    public void Add(Message message, RequestContext requestContext, int outBoxTimeout = -1,
+        IAmABoxTransactionProvider<MyTransaction>? transactionProvider = null)
+    {
+        var causationId = ReadCausationId(requestContext);
+
+        // Gate the write on the same probe: an un-migrated store keeps its original shape
+        if (SupportsCausationTracking())
+            StoreWithCausation(message, causationId);
+        else
+            Store(message);
+    }
+
+    public bool SupportsCausationTracking()
+        => _causationSupported ??= CausationColumnExists();   // a live check, memoized
+
+    public Task<bool> SupportsCausationTrackingAsync(CancellationToken cancellationToken = default)
+        => Task.FromResult(SupportsCausationTracking());
+
+    public bool ReplayCausation(string causationId, RequestContext? requestContext,
+        Dictionary<string, object>? args = null)
+    {
+        // A no-op, not an exception, when the store cannot support it
+        if (!SupportsCausationTracking())
+            return false;
+
+        foreach (var message in FindByCausation(causationId))
+            ClearDispatchedState(message);   // the Sweeper takes it from here
+
+        return true;
+    }
+
+    public Task<bool> ReplayCausationAsync(string causationId, RequestContext? requestContext,
+        Dictionary<string, object>? args = null, CancellationToken cancellationToken = default)
+        => Task.FromResult(ReplayCausation(causationId, requestContext, args));
+}
+```
+
+The Inbox side is the same shape: probe, store the Causation Id in `Add` when the probe says
+you can, and return it from `GetCausationId` — or `null`.
+
+## Registration
+
+Nothing extra to do. `AddProducers` checks whether your Outbox implements
+`IAmACausationTrackingOutbox` and registers the same instance under that interface as well.
+The Inbox handler takes it as an optional constructor dependency, so an Outbox that does not
+implement the role resolves to `null` and the handler degrades to a plain skip.
+
+## Further Reading
+
+- [Replay On Seen](/contents/ReplayOnSeen.md) — what replay does, and how the Causation Id
+  links an Inbox entry to the messages it produced
+- [Store Support](/contents/ReplayOnSeen.md#store-support) — what the Brighter-maintained
+  stores already do, and what each needs before replay works
+- [Pipeline Validation](/contents/PipelineValidation.md) — the startup checks your
+  `SupportsCausationTracking()` answer feeds
+- [Outbox Support](/contents/BrighterOutboxSupport.md) — the Outbox, the Sweeper, and
+  delivery guarantees
+- [Inbox Support](/contents/BrighterInboxSupport.md) — configuring an Inbox, and the other
+  `OnceOnlyAction` values
+- [ADR 0057 — Replay Outbox Messages on Inbox Duplicate Detection](https://github.com/BrighterCommand/Brighter/blob/master/docs/adr/0057-replay-outbox-on-inbox-duplicate.md)
+  — the design rationale

--- a/contents/CloudEventsSupport.md
+++ b/contents/CloudEventsSupport.md
@@ -393,7 +393,7 @@ When migrating to V10, be aware of these CloudEvents-related breaking changes:
    public Message MapToMessage(OrderCreated request, Publication publication)
    ```
 
-See the [V10 Migration Guide](MigrationV10.md) for complete migration instructions.
+See the [V10 Migration Guide](V10MigrationGuide.md) for complete migration instructions.
 
 ## Best Practices
 

--- a/contents/DefaultMessageMappers.md
+++ b/contents/DefaultMessageMappers.md
@@ -465,7 +465,7 @@ services.AddBrighter(options => { })
 - [Claim Check Pattern](ClaimCheck.md) - Handling large messages
 - [Message Mappers](MessageMappers.md) - Legacy V9 mapper documentation
 - [Compression](Compression.md) - Compressing messages
-- [V10 Migration Guide](MigrationV10.md) - Complete migration instructions
+- [V10 Migration Guide](V10MigrationGuide.md) - Complete migration instructions
 
 ## Sample Code
 

--- a/contents/DynamoInbox.md
+++ b/contents/DynamoInbox.md
@@ -11,7 +11,7 @@ For this we will need the *Inbox* packages for the DynamoDb *Inbox*.
 **AWS SDK v4** (recommended for new projects):
 * **Paramore.Brighter.Inbox.DynamoDb.V4**
 
-See [AWS Configuration](/contents/AWSSQSConfiguration.md#migration-guidance) for migration guidance between v3 and v4.
+See [AWS Configuration](/contents/AWSSQSConfiguration.md#migrating-from-aws-sdk-v3-to-v4) for migration guidance between v3 and v4.
 
 ``` csharp
 private static IHostBuilder CreateHostBuilder(string[] args) =>

--- a/contents/DynamoOutbox.md
+++ b/contents/DynamoOutbox.md
@@ -175,9 +175,11 @@ Two operational notes:
 
 ### The index name
 
-`DynamoDbConfiguration.CausationIndexName` defaults to `"Causation"` and is settable, so the Outbox can query an index under another name.
+`DynamoDbConfiguration.CausationIndexName` defaults to `"Causation"`. **Leave it there.**
 
-Be aware of one wrinkle if you change it: the index name on `MessageItem` is a compile-time literal, so `DynamoDbTableFactory` always generates an index called `Causation`. Point `CausationIndexName` somewhere else and you must create that index yourself — otherwise the Outbox probes for a name nothing has created and concludes replay is unsupported.
+It has a public setter, unlike the name suggests it should be treated — but it does not behave like the `Outstanding` and `Delivered` index names, which you can rename freely. The Causation index name is also declared on `MessageItem` as an attribute argument, and attribute arguments must be compile-time constants, so the annotation cannot read your configured value. `DynamoDbTableFactory` therefore always generates an index called `Causation`, whatever you set here.
+
+Point `CausationIndexName` at another name and the probe and the replay query both target a GSI the table model never declares. Nothing errors: `SupportsCausationTracking()` simply reports `false`, and replay silently finds no messages. If you have a genuine reason to rename it, you must create the index under that name yourself.
 
 ### If you skip the index
 

--- a/contents/DynamoOutbox.md
+++ b/contents/DynamoOutbox.md
@@ -87,3 +87,104 @@ public override async Task<AddGreeting> HandleAsync(AddGreeting addGreeting, Can
 	return await base.HandleAsync(addGreeting, cancellationToken);
 }
 ```
+
+## Replay Support: The Causation Index
+
+[Replay On Seen](/contents/ReplayOnSeen.md) resends every Outbox message produced under a given Causation Id. On DynamoDB that means querying on a non-key attribute, which needs a Global Secondary Index — by default one named **Causation**, with `CausationId` as its hash key.
+
+This applies to both `Paramore.Brighter.Outbox.DynamoDB` and `.V4`. The DynamoDB **Inbox** needs nothing: it looks a Causation Id up by the table's own primary key.
+
+### A new table gets the index for free
+
+`MessageItem.CausationId` is decorated with `[DynamoDBGlobalSecondaryIndexHashKey(indexName: "Causation")]`, and `DynamoDbTableFactory` reflects over those attributes when it builds the request. So a table you create through the factory already has the index — you only add a throughput entry for it:
+
+```csharp
+var createTableRequest = new DynamoDbTableFactory().GenerateCreateTableRequest<MessageItem>(
+    new DynamoDbCreateProvisionedThroughput(
+        new ProvisionedThroughput { ReadCapacityUnits = 10, WriteCapacityUnits = 10 },
+        new Dictionary<string, ProvisionedThroughput?>
+        {
+            ["Outstanding"] = new() { ReadCapacityUnits = 10, WriteCapacityUnits = 10 },
+            ["OutstandingAllTopics"] = new() { ReadCapacityUnits = 10, WriteCapacityUnits = 10 },
+            ["Delivered"] = new() { ReadCapacityUnits = 10, WriteCapacityUnits = 10 },
+            ["DeliveredAllTopics"] = new() { ReadCapacityUnits = 10, WriteCapacityUnits = 10 },
+            ["Causation"] = new() { ReadCapacityUnits = 10, WriteCapacityUnits = 10 },  // replay
+        }));
+
+var builder = new DynamoDbTableBuilder(client);
+await builder.Build(createTableRequest);
+await builder.EnsureTablesReady([createTableRequest.TableName], TableStatus.ACTIVE);
+```
+
+### Adding the index to an existing table
+
+A table provisioned before replay shipped does not have the index, and there is no migration runner for DynamoDB. Add it yourself with `UpdateTable`:
+
+```csharp
+using Amazon.DynamoDBv2;
+using Amazon.DynamoDBv2.Model;
+
+var request = new UpdateTableRequest
+{
+    TableName = "brighter_outbox",
+
+    // The index's key attribute has to be declared, even though the table already stores it
+    AttributeDefinitions =
+    [
+        new AttributeDefinition
+        {
+            AttributeName = "CausationId",
+            AttributeType = ScalarAttributeType.S
+        }
+    ],
+
+    GlobalSecondaryIndexUpdates =
+    [
+        new GlobalSecondaryIndexUpdate
+        {
+            Create = new CreateGlobalSecondaryIndexAction
+            {
+                IndexName = "Causation",
+                KeySchema =
+                [
+                    new KeySchemaElement { AttributeName = "CausationId", KeyType = KeyType.HASH }
+                ],
+
+                // Replay only reads MessageId, which is the base table's hash key and is
+                // therefore always present in a KEYS_ONLY index
+                Projection = new Projection { ProjectionType = ProjectionType.KEYS_ONLY },
+
+                // Omit this on a PAY_PER_REQUEST table — it applies to PROVISIONED billing only
+                ProvisionedThroughput = new ProvisionedThroughput
+                {
+                    ReadCapacityUnits = 10,
+                    WriteCapacityUnits = 10
+                }
+            }
+        }
+    ]
+};
+
+await client.UpdateTableAsync(request);
+```
+
+Two operational notes:
+
+- **The index backfills asynchronously.** DynamoDB populates a new GSI in the background, and the index reports `CREATING` until it finishes. Until then a replay may find only part of a causation's messages, so wait for the index to become `ACTIVE` before you rely on it.
+- **Restart your hosts afterwards.** The Outbox probes for the index once, with `DescribeTable`, and caches the answer for the life of the store instance. An Outbox built before the index existed keeps reporting that replay is unsupported until the process restarts.
+
+### The index name
+
+`DynamoDbConfiguration.CausationIndexName` defaults to `"Causation"` and is settable, so the Outbox can query an index under another name.
+
+Be aware of one wrinkle if you change it: the index name on `MessageItem` is a compile-time literal, so `DynamoDbTableFactory` always generates an index called `Causation`. Point `CausationIndexName` somewhere else and you must create that index yourself — otherwise the Outbox probes for a name nothing has created and concludes replay is unsupported.
+
+### If you skip the index
+
+Nothing breaks, and replay never happens:
+
+- **Deposits are unaffected.** The `CausationId` attribute is still written; with no index to populate it is simply an ordinary attribute.
+- **Startup warns.** `SupportsCausationTracking()` reports `false`, and [pipeline validation](/contents/PipelineValidation.md) raises a *warning* — not an error — for any handler configured with `OnceOnlyAction.Replay`.
+- **Duplicates are skipped quietly.** `ReplayCausation` returns `false` rather than throwing, so a duplicate does not fail the consumer pipeline with a DynamoDB `ValidationException`. Nothing is resent.
+
+See [When Replay Does Not Fire](/contents/ReplayOnSeen.md#when-replay-does-not-fire) for how to tell this apart from the other reasons a replay produces nothing.

--- a/contents/DynamoOutbox.md
+++ b/contents/DynamoOutbox.md
@@ -17,7 +17,7 @@ For this we will need the *Outbox* package for DynamoDb:
 
 * **Paramore.Brighter.DynamoDb** (or **Paramore.Brighter.DynamoDb.V4**)
 
-See [AWS Configuration](/contents/AWSSQSConfiguration.md#migration-guidance) for migration guidance between v3 and v4.
+See [AWS Configuration](/contents/AWSSQSConfiguration.md#migrating-from-aws-sdk-v3-to-v4) for migration guidance between v3 and v4.
 
 As described in [Basic Configuration](/contents/BrighterBasicConfiguration.md#outbox-support), we configure Brighter to use an outbox with the Use{DB}Outbox method call.
 

--- a/contents/Glossary.md
+++ b/contents/Glossary.md
@@ -8,7 +8,7 @@ This glossary provides definitions for key terms used in Brighter and Darker. Te
 
 A message sent over a bus. The base type for Commands, Events, and Queries. A Request represents an instruction or notification that needs to be processed by a handler.
 
-See: [Implementing Command, Events and Queries](/contents/ImplementingCommand.md)
+See: [Implementing Command, Events and Queries](/contents/Requests%2C%20Commands%20and%20Events.md)
 
 ### Command
 
@@ -24,7 +24,7 @@ A notification that something has happened. Events are facts about the past. Mul
 
 Example: `GreetingMade`, `PersonDeleted`, `OrderPlaced`
 
-See: [Publishing Events](/contents/DistributedTaskQueue.md)
+See: [Publishing Events](/contents/TaskQueuePattern.md)
 
 ### Query
 
@@ -175,7 +175,7 @@ See: [Outbox Pattern](/contents/OutboxPattern.md), [Outbox Support](/contents/Br
 
 A pattern for deduplication - ensuring that a message is only processed once. The Inbox tracks which messages have been processed and prevents duplicate processing of the same message.
 
-See: [Inbox Configuration](/contents/InboxConfiguration.md)
+See: [Inbox Configuration](/contents/BrighterInboxSupport.md#inbox-configuration)
 
 ### Sweeper
 

--- a/contents/Glossary.md
+++ b/contents/Glossary.md
@@ -177,6 +177,18 @@ A pattern for deduplication - ensuring that a message is only processed once. Th
 
 See: [Inbox Configuration](/contents/BrighterInboxSupport.md#inbox-configuration)
 
+### Causation Id
+
+The identifier that links an Inbox entry to the Outbox messages produced while handling that request. Every message a handler deposits during one invocation is stamped with the same Causation Id, and so is the Inbox entry recording that the request was handled — which is what lets a later duplicate find its own downstream messages. It defaults to the handled request's own `Id`. Distinct from the **Correlation Id**, which ties a reply back to its request; neither is derived from the other.
+
+See: [Causation Id](/contents/ReplayOnSeen.md#causation-id)
+
+### Replay (Inbox)
+
+The `OnceOnlyAction` that makes duplicate detection re-dispatch the Outbox messages produced during the original handling, instead of throwing or logging a warning. The handler does not run again: Brighter looks up the Inbox entry's [Causation Id](#causation-id), clears the dispatched state of the Outbox messages stored under it, and the Sweeper sends them on its next pass. Used to walk a stalled workflow forward when an upstream step succeeded but its downstream message was lost.
+
+See: [Replay On Seen](/contents/ReplayOnSeen.md)
+
 ### Sweeper
 
 A background process that monitors an Outbox and dispatches messages that have not yet been sent. The Sweeper provides guaranteed, at-least-once delivery by continuously attempting to send messages until they succeed.

--- a/contents/HowServiceActivatorWorks.md
+++ b/contents/HowServiceActivatorWorks.md
@@ -463,7 +463,7 @@ The **Dispatcher** is the primary class in the `Brighter.ServiceActivator` assem
 - **[Reactor and Proactor](ReactorAndProactor.md)** - Concurrency model details
 - **[Brighter Basic Configuration](BrighterBasicConfiguration.md)** - Initial setup
 - **[Configuring the Dispatcher](HowConfiguringTheDispatcherWorks.md)** - Advanced configuration
-- **[Subscriptions and Topology](BrighterSubscriptionsAndTopology.md)** - Subscription patterns
+- **[Configuring Subscriptions](/contents/BrighterBasicConfiguration.md#configuring-the-dispatcher)** - Subscription patterns
 - **[Dynamic Message Deserialization](DynamicMessageDeserialization.md)** - Content-based routing
 - **[Agreement Dispatcher](AgreementDispatcher.md)** - Dynamic handler selection
 - **[Health Checks](HealthChecks.md)** - Monitoring

--- a/contents/InMemoryOptions.md
+++ b/contents/InMemoryOptions.md
@@ -25,7 +25,7 @@ Brighter V10 provides InMemory implementations for the following components:
 | [InMemory Inbox](#inmemory-inbox) | Message deduplication | Limited use cases |
 | [InMemory Scheduler](#inmemory-scheduler) | Delayed message scheduling | Limited use cases |
 | [InMemory Archive](#inmemory-archive) | Message archiving | No |
-| [InMemory Storage Provider](#inmemory-storage-provider) | Claim Check pattern | No |
+| [InMemory Storage Provider](/contents/ClaimCheck.md) | Claim Check pattern | No |
 
 ## InMemory Transport
 

--- a/contents/KafkaConfiguration.md
+++ b/contents/KafkaConfiguration.md
@@ -161,7 +161,7 @@ If you want to specify the topic through Brighter, or through your own IaaS code
 
 ## Subscription
 
-For more on a *Subscription* see the material on configuring *Service Activator* in [Basic Configuration](/contents/BrighterBasicConfiguration.md#configuring-the-service-activator).
+For more on a *Subscription* see the material on configuring *Service Activator* in [Basic Configuration](/contents/BrighterBasicConfiguration.md#configuring-the-dispatcher).
 
 We support a number of Kafka specific *Subscription* options:
 

--- a/contents/MessageMappers.md
+++ b/contents/MessageMappers.md
@@ -8,7 +8,7 @@ Typically, you serialize your request as the **MessageBody** for in **MapToMessa
 
 The body is a byte[] and as such we can support any format that can be converted into a byte[] as the message body.
 
-Because [message oriented middleware](#message-oriented-middleware-mom) typically looks in a header for routing information, you add your routing information in the **MessageHeader**.
+Because [message oriented middleware](/contents/BasicConcepts.md#message-oriented-middleware-mom) typically looks in a header for routing information, you add your routing information in the **MessageHeader**.
 
 Each individual transport has code to turn a Brighter format message into a message oriented middleware compatible message, and vice versa, so your code only needs to translate to and from the Brighter format.
 

--- a/contents/NullableReferenceTypes.md
+++ b/contents/NullableReferenceTypes.md
@@ -704,6 +704,6 @@ Then address warnings incrementally and eventually enable `TreatWarningsAsErrors
 - [Microsoft: Nullable Reference Types](https://learn.microsoft.com/en-us/dotnet/csharp/nullable-references)
 - [Microsoft: Nullable Reference Types Tutorial](https://learn.microsoft.com/en-us/dotnet/csharp/tutorials/nullable-reference-types)
 - [Microsoft: Nullable Attributes](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/attributes/nullable-analysis)
-- [Brighter Commands and Events](CommandsEventsAndMessages.md)
+- [Brighter Commands and Events](/contents/Requests%2C%20Commands%20and%20Events.md)
 - [Brighter Handlers](ImplementingAHandler.md)
 - [Brighter Message Mappers](MessageMappers.md)

--- a/contents/PipelineValidation.md
+++ b/contents/PipelineValidation.md
@@ -332,7 +332,7 @@ new RmqSubscription<OrderCreated>(...)
 
 ### Replay Without Causation Tracking
 
-A handler configured with `OnceOnlyAction.Replay` needs an Inbox and an Outbox that both track causation ids, *and* live schemas that can store them. Validation checks each store in turn. Only a store that does not implement the role interface is an Error — an un-migrated schema is a Warning, so the host starts cleanly and replay silently does nothing.
+A handler configured with `OnceOnlyAction.Replay` needs an Inbox and an Outbox that both track Causation Ids, *and* live schemas that can store them. Validation checks each store in turn. Only a store that does not implement the role interface is an Error — an un-migrated schema is a Warning, so the host starts cleanly and replay silently does nothing.
 
 The usual cause is provisioning one box and forgetting the other.
 
@@ -364,7 +364,7 @@ services.AddBrighter()
     });
 ```
 
-Replay reads the causation id from the Inbox and hands it to the Outbox, so either box being behind is enough to stop it. [Replay On Seen](/contents/ReplayOnSeen.md#when-replay-does-not-fire) lists every finding this rule produces, along with the runtime failures that produce no startup finding at all.
+Replay reads the Causation Id from the Inbox and hands it to the Outbox, so either box being behind is enough to stop it. [Replay On Seen](/contents/ReplayOnSeen.md#when-replay-does-not-fire) lists every finding this rule produces, along with the runtime failures that produce no startup finding at all.
 
 ## Further Reading
 

--- a/contents/PipelineValidation.md
+++ b/contents/PipelineValidation.md
@@ -38,6 +38,7 @@ These checks apply to all Brighter applications, including those that only use t
 | Handler type visibility | Error | Handler class must be `public`. Brighter only discovers public handler types — a non-public handler will silently not be found by the pipeline builder. |
 | Sync/async attribute consistency | Error | Async handlers (`IHandleRequestsAsync<T>`) must use async attributes (e.g. `RejectMessageOnErrorAsyncAttribute`). Sync handlers must use sync attributes. A mismatch will throw a `ConfigurationException` at pipeline build time. |
 | Backstop attribute ordering | Warning | Backstop error-handling attributes (`RejectMessageOnError`, `DeferMessageOnError`, `DontAckOnError`) should be at the outermost position (lowest step number). If a backstop has a higher step number than a resilience pipeline attribute, it will never execute on failure. |
+| Replay requires causation tracking | Error and Warning | A pipeline using `OnceOnlyAction.Replay` needs an Inbox and an Outbox that both implement the causation-tracking role interfaces *and* whose live schemas support it. A store that does not implement the interface is an Error; an un-migrated schema, a missing Outbox, or a probe that could not reach the store is a Warning. Only pipelines configured for `Replay` are checked. See [Replay On Seen](/contents/ReplayOnSeen.md). |
 
 **Example error messages:**
 
@@ -51,6 +52,15 @@ this will throw a ConfigurationException at pipeline build time
 'RejectMessageOnError' at step 5 is after 'UseResiliencePipeline' at step 3 —
 in Brighter, lower step values are outer wrappers, so the backstop will never
 execute on failure
+
+Handler 'ProcessPaymentHandler': OnceOnlyAction.Replay requires a
+causation-tracking outbox, but the configured outbox 'MyCustomOutbox' does not
+implement IAmACausationTrackingOutbox — Replay cannot reset the dispatched
+state of the original messages
+
+Handler 'ProcessPaymentHandler': OnceOnlyAction.Replay requires causation
+tracking, but the inbox store schema does not support it — migrate the inbox
+schema to add the CausationId column for Replay to work
 ```
 
 ### Producer Checks (AddProducers)
@@ -319,6 +329,42 @@ new RmqSubscription<OrderCreated>(...)
 // Explicitly include the handler's assembly
 .AutoFromAssemblies([typeof(OrderHandler).Assembly])
 ```
+
+### Replay Without Causation Tracking
+
+A handler configured with `OnceOnlyAction.Replay` needs an Inbox and an Outbox that both track causation ids, *and* live schemas that can store them. Validation checks each store in turn. Only a store that does not implement the role interface is an Error — an un-migrated schema is a Warning, so the host starts cleanly and replay silently does nothing.
+
+The usual cause is provisioning one box and forgetting the other.
+
+**Before** (warning):
+
+```csharp
+[UseInbox(step: 1, contextKey: typeof(ProcessPaymentHandler), onceOnly: true,
+    onceOnlyAction: OnceOnlyAction.Replay)]
+public override ProcessPayment Handle(ProcessPayment command) { ... }
+
+// ... but only the Outbox is provisioned, so the Inbox has no CausationId column
+services.AddBrighter()
+    .AddProducers(producers => { /* ... */ })
+    .UseBoxProvisioning(opts =>
+    {
+        opts.AddMsSqlOutbox(outboxConfig);
+    });
+```
+
+**After** (fixed):
+
+```csharp
+services.AddBrighter()
+    .AddProducers(producers => { /* ... */ })
+    .UseBoxProvisioning(opts =>
+    {
+        opts.AddMsSqlOutbox(outboxConfig);
+        opts.AddMsSqlInbox(inboxConfig);   // both boxes need the causation column
+    });
+```
+
+Replay reads the causation id from the Inbox and hands it to the Outbox, so either box being behind is enough to stop it. [Replay On Seen](/contents/ReplayOnSeen.md#when-replay-does-not-fire) lists every finding this rule produces, along with the runtime failures that produce no startup finding at all.
 
 ## Further Reading
 

--- a/contents/PostgreSQLMessageBroker.md
+++ b/contents/PostgreSQLMessageBroker.md
@@ -655,6 +655,6 @@ var normalSubscription = new PostgresSubscription<NormalEvent>(
 - [Outbox Pattern](OutboxPattern.md)
 - [Claim Check Pattern](ClaimCheck.md)
 - [OpenTelemetry Integration](Telemetry.md)
-- [Transactional Messaging](TransactionalMessaging.md)
+- [Transactional Messaging](/contents/BrighterOutboxSupport.md#complete-example-transactional-messaging)
 - [PostgreSQL Documentation](https://www.postgresql.org/docs/)
 - [Npgsql - .NET PostgreSQL Driver](https://www.npgsql.org/)

--- a/contents/RabbitMQConfiguration.md
+++ b/contents/RabbitMQConfiguration.md
@@ -138,7 +138,7 @@ public void ConfigureServices(IServiceCollection services)
 
 ## Subscription
 
-For more on a *Subscription* see the material on configuring *Service Activator* in [Basic Configuration](/contents/BrighterBasicConfiguration.md#configuring-the-service-activator).
+For more on a *Subscription* see the material on configuring *Service Activator* in [Basic Configuration](/contents/BrighterBasicConfiguration.md#configuring-the-dispatcher).
 
 We support a number of RabbitMQ specific *Subscription* options:
 

--- a/contents/ReactorAndProactor.md
+++ b/contents/ReactorAndProactor.md
@@ -427,9 +427,7 @@ var subscription = new Subscription<OrderCommand>(
 
 - [How the Dispatcher Works](HowServiceActivatorWorks.md) - Dispatcher internals
 - [Configuring the Dispatcher](HowConfiguringTheDispatcherWorks.md) - Dispatcher configuration
-- [Subscriptions](BrighterSubscriptionsAndTopology.md) - Subscription configuration
-- [Message Pumps](MessagePumps.md) - Message pump implementation details
-- [Performance Tuning](PerformanceTuning.md) - Optimization strategies
+- [Configuring Subscriptions](/contents/BrighterBasicConfiguration.md#configuring-the-dispatcher) - Subscription configuration
 
 ## Summary
 

--- a/contents/ReplayOnSeen.md
+++ b/contents/ReplayOnSeen.md
@@ -1,0 +1,1154 @@
+# Replay On Seen
+
+When your [Inbox](/contents/BrighterInboxSupport.md) recognises a message it has already
+handled, it normally throws or logs a warning and stops — the work is done, so there is
+nothing to do. `OnceOnlyAction.Replay` changes what a duplicate means: instead of stopping,
+Brighter re-sends the messages that handler already produced, by clearing their dispatched
+state in the [Outbox](/contents/BrighterOutboxSupport.md) so the Sweeper picks them up
+again. The handler itself never runs a second time.
+
+## The Problem: A Workflow That Stalls Halfway
+
+Consider an order flow spread across three services, each step driven by a command:
+
+1. **Order** handles `PlaceOrder` and, once the order is written, deposits `ProcessPayment`.
+2. **Payment** handles `ProcessPayment`, takes the money, and deposits `ShipOrder`.
+3. **Shipping** handles `ShipOrder` and books the courier.
+
+Now suppose Shipping is down for an hour. Payment ran to completion — the money is taken,
+and `ShipOrder` was dispatched onto the broker — but nothing ever consumed it. Perhaps the
+queue was misconfigured, perhaps the message hit the dead letter queue, perhaps Shipping
+crashed mid-restart and lost it. However it happened, the customer has paid and no parcel
+is going anywhere. The flow has stalled halfway.
+
+The obvious recovery is to re-send `PlaceOrder` and let the flow run again. Today that
+achieves nothing:
+
+- Order's Inbox recognises `PlaceOrder` as already seen. With `OnceOnlyAction.Throw` it
+  raises a `OnceOnlyException`; with `Warn` it logs and returns. Either way the handler
+  does not run.
+- Because the handler does not run, it does not deposit `ProcessPayment`.
+- Payment never hears anything, so it never deposits `ShipOrder`.
+
+Nothing moves. The Inbox has done exactly what you asked of it, and the flow is still
+stuck at the same step.
+
+### Why de-duplication alone is not enough
+
+The Inbox exists to stop a handler running twice. That is a real guarantee, and you want
+it: re-running `ProcessPaymentHandler` would take the money a second time.
+
+But de-duplication protects the *handler*; it does not protect the *flow*. Skipping the
+handler also skips everything the handler emitted, and the downstream steps are waiting on
+exactly those messages. So the Inbox turns "this step already ran" into "this step and
+every step after it are unreachable" — which is a strictly stronger claim than the one it
+is entitled to make.
+
+The information needed to do better is already on disk. The Outbox still holds the
+`ProcessPayment` message from the original run, together with the fact that it was
+produced while handling `PlaceOrder`. Nothing has to be recomputed or guessed. It only has
+to be sent again.
+
+## How Replay Walks the Flow Forward
+
+`OnceOnlyAction.Replay` uses that stored link. When the Inbox recognises a duplicate,
+Brighter looks up the messages the original handling produced and marks them undispatched,
+which puts them back in the Sweeper's path. The handler is skipped, exactly as it would be
+under `Throw` or `Warn` — but its downstream effects are re-sent.
+
+Applied to the stalled order, and with `Replay` configured on each step:
+
+1. You re-send `PlaceOrder`.
+2. Order's Inbox sees a duplicate. `PlaceOrderHandler` does **not** run. The original
+   `ProcessPayment` message is marked undispatched, and the Sweeper resends it.
+3. Payment's Inbox sees `ProcessPayment` as a duplicate. `ProcessPaymentHandler` does
+   **not** run — the money is not taken again. The original `ShipOrder` message is marked
+   undispatched, and the Sweeper resends it.
+4. Shipping's Inbox has never seen `ShipOrder`. There is no duplicate, so
+   `ShipOrderHandler` runs normally and books the courier.
+
+The flow advances one step per hop, skipping the work that was already done, until it
+reaches the step that never ran — which executes for the first time. That step-by-step
+advance is the point of the feature.
+
+### The same messages, not new ones
+
+Replay re-dispatches the *stored* messages from the original handling. It does not
+re-generate them, because it does not re-run the handler that would have produced them.
+
+That distinction matters more than it first appears. Re-running `PlaceOrderHandler` an hour
+later could produce a *different* `ProcessPayment` — a repriced order, a changed address, a
+customer who has since been flagged. The downstream steps would then be reacting to a
+message that never existed in the original flow. Replaying the stored message means the
+system converges on the state the first run was heading for, rather than on a new state
+assembled from whatever is true now.
+
+It also means replay is safe with respect to the side effects the Inbox was protecting: no
+handler body executes, so nothing is charged, written, or called twice.
+
+### Every already-seen step needs Replay
+
+> **⚠ Important**: The cascade only propagates through handlers that are themselves
+> configured with `OnceOnlyAction.Replay`. One step left on `Throw` or `Warn` stops it
+> dead.
+
+This is the single most common way to configure the feature and see nothing happen. Suppose
+Payment is left on the default `Throw` while Order is set to `Replay`:
+
+1. You re-send `PlaceOrder`. Order replays `ProcessPayment`. So far so good.
+2. Payment's Inbox sees the duplicate `ProcessPayment` and throws. Nothing is replayed.
+3. `ShipOrder` is never re-sent. Shipping is never reached.
+
+The flow advanced exactly one step and stalled again — one step further along than before,
+and still short of the handler that actually failed. Set `Replay` on **every** handler the
+flow passes back through, not just the one at the front.
+
+A step that has never been seen needs nothing: its Inbox finds no duplicate, so its
+handler runs normally whatever `OnceOnlyAction` it is configured with. It is only the
+already-seen steps between the message you re-send and the failure point that need
+`Replay`.
+
+## Causation Id
+
+For replay to resend the right messages, Brighter has to know which Outbox messages came
+out of which handler invocation. That link is the **Causation Id**.
+
+A Causation Id answers one question: *when I handled request X, which messages did I
+produce?* Every message a handler deposits during a single invocation is stamped with the
+same Causation Id, and so is the Inbox entry recording that the request was handled. The
+two share a value, which is what lets a later duplicate find its own downstream messages.
+
+By default the Causation Id is **the handled request's own `Id`**. Handling `PlaceOrder`
+stamps the Inbox entry and the resulting `ProcessPayment` message with `PlaceOrder`'s id.
+You do not have to set anything.
+
+**How it travels.** The Causation Id rides in the pipeline's `RequestContext.Bag`, under the well-known key
+`RequestContextBagNames.CausationId` (the literal string `"Brighter-CausationId"`):
+
+- The Inbox handler runs first in the pipeline. If the Bag has no Causation Id yet, it
+  puts the request's `Id` there. If a value is already present, it is left alone — that is
+  the escape hatch for callers who need to control causation themselves.
+- Your handler runs and deposits messages. The Outbox `Add` reads the Causation Id out of
+  the same Bag and stores it against each message.
+- Your handler returns. The Inbox handler writes the Inbox entry, storing the same
+  Causation Id against it.
+
+Because the Bag belongs to the pipeline's `RequestContext`, everything in one invocation
+sees one value. This is also why your handler has to pass its `Context` through when it
+posts — see [You Must Thread Your RequestContext](#you-must-thread-your-requestcontext).
+
+**Causation Id is not Correlation Id.**
+Brighter already carries a `CorrelationId`, used to tie a reply back to its request in
+request-reply exchanges; the Causation Id is a separate value with a separate job, and
+neither is derived from the other. It is likewise distinct from `JobId` and `WorkflowId`,
+which are reserved for workflow orchestration.
+
+### What Happens on a Duplicate
+
+When the Inbox recognises a request it has already handled and the action is `Replay`:
+
+```
+Duplicate PlaceOrder arrives
+        │
+        ▼
+┌──────────────────────────────────────────────┐
+│ Inbox handler                                │
+│                                              │
+│   inbox.Exists(id, contextKey)  ──►  true    │
+│   onceOnlyAction == Replay      ──►  yes     │
+│         │                                    │
+│         ▼                                    │
+│   inbox.GetCausationId(id, contextKey)       │
+│         │  ──► the causation id stored when  │
+│         │      PlaceOrder was first handled  │
+│         ▼                                    │
+│   outbox.ReplayCausation(causationId)        │
+│         │  ──► clears the dispatched state   │
+│         │      of every message stored under │
+│         │      that causation id             │
+│         ▼                                    │
+│   return  ──►  PlaceOrderHandler never runs  │
+└──────────────────────────────────────────────┘
+        │
+        ▼   later, on the Sweeper's next interval
+┌──────────────────────────────────────────────┐
+│ Outbox Sweeper                               │
+│                                              │
+│   finds the now-undispatched ProcessPayment  │
+│   message and dispatches it to the broker    │
+└──────────────────────────────────────────────┘
+```
+
+Step by step:
+
+1. **The Inbox finds a duplicate.** `Exists` returns `true` for this request id and
+   context key.
+2. **The action is `Replay`**, so instead of throwing or logging a warning, the handler
+   takes the replay path.
+3. **The Inbox is asked for the Causation Id** it stored when the request was originally
+   handled.
+4. **The Outbox replays that causation.** Every message stored under that Causation Id has
+   its dispatched state cleared, which makes it outstanding again — the same state a
+   freshly deposited message is in.
+5. **The Inbox handler returns without calling your handler.** No business logic runs, so
+   nothing is charged, written, or called twice.
+6. **The Sweeper resends.** On its next pass it sees the outstanding messages and
+   dispatches them to the broker, exactly as it would for a newly deposited message.
+
+Note where step 6 sits. Replay does not send anything itself — it only changes rows in the
+Outbox — so the messages go out on the **Sweeper's next interval**, not the moment the
+duplicate arrives. A cascade across three steps therefore takes at least three Sweeper
+intervals to walk the flow forward. Size the interval accordingly if recovery time
+matters, and see [Before You Enable It](#before-you-enable-it) for why a Sweeper is not
+optional here.
+
+## Turning It On
+
+`Replay` is a third value of `OnceOnlyAction`, alongside `Throw` and `Warn`. You choose it
+the same way you choose those: per handler with the `[UseInbox]` attribute, or globally
+through `InboxConfiguration`. Whichever route you take, `onceOnly` must be `true` —
+without it the Inbox records requests but never checks for duplicates, so the replay path
+is never reached.
+
+### On a Handler
+
+Set `onceOnlyAction: OnceOnlyAction.Replay` on the attribute:
+
+```csharp
+using Paramore.Brighter;
+using Paramore.Brighter.Inbox;
+using Paramore.Brighter.Inbox.Attributes;
+
+public class ProcessPaymentHandler : RequestHandler<ProcessPayment>
+{
+    private readonly IAmACommandProcessor _commandProcessor;
+
+    public ProcessPaymentHandler(IAmACommandProcessor commandProcessor)
+    {
+        _commandProcessor = commandProcessor;
+    }
+
+    [UseInbox(step: 1, contextKey: typeof(ProcessPaymentHandler), onceOnly: true,
+        onceOnlyAction: OnceOnlyAction.Replay)]
+    public override ProcessPayment Handle(ProcessPayment command)
+    {
+        // ... take the payment ...
+
+        // Pass the pipeline's Context so ShipOrder is stored under this invocation's
+        // Causation Id — that is what a later replay will match on
+        _commandProcessor.Post(new ShipOrder { OrderId = command.OrderId },
+            Context as RequestContext);
+
+        return base.Handle(command);
+    }
+}
+```
+
+Two details carry over from any other Inbox configuration. `contextKey` disambiguates the
+request id when the same id reaches more than one pipeline — the handler's own type is the
+usual choice. And `step` places the Inbox in the pipeline; it must run before your handler,
+which it does by default (`HandlerTiming.Before`).
+
+The one detail specific to replay is the `Context` passed to `Post`. Without it the
+outgoing message is stored with no Causation Id and a later replay finds nothing to
+resend — silently. That failure is common enough to have
+[its own section below](#you-must-thread-your-requestcontext).
+
+For an async handler, use `[UseInboxAsync]` on a `RequestHandlerAsync<T>`:
+
+```csharp
+public class ProcessPaymentHandlerAsync : RequestHandlerAsync<ProcessPayment>
+{
+    private readonly IAmACommandProcessor _commandProcessor;
+
+    public ProcessPaymentHandlerAsync(IAmACommandProcessor commandProcessor)
+    {
+        _commandProcessor = commandProcessor;
+    }
+
+    [UseInboxAsync(step: 1, contextKey: typeof(ProcessPaymentHandlerAsync), onceOnly: true,
+        onceOnlyAction: OnceOnlyAction.Replay)]
+    public override async Task<ProcessPayment> HandleAsync(ProcessPayment command,
+        CancellationToken cancellationToken = default)
+    {
+        // ... take the payment ...
+
+        await _commandProcessor.PostAsync(new ShipOrder { OrderId = command.OrderId },
+            Context as RequestContext, cancellationToken: cancellationToken);
+
+        return await base.HandleAsync(command, cancellationToken);
+    }
+}
+```
+
+Pick the attribute that matches your handler — `[UseInbox]` for `RequestHandler<T>`,
+`[UseInboxAsync]` for `RequestHandlerAsync<T>`. Mixing them breaks the rule that
+[pipelines must be homogeneous](/contents/DispatchingARequest.md#pipelines-must-be-homogeneous),
+and [pipeline validation](/contents/PipelineValidation.md) reports it at startup.
+
+### Globally
+
+To make `Replay` the default for every handler, set `actionOnExists` when you construct
+the `InboxConfiguration` you hand to `AddConsumers`:
+
+```csharp
+private static void ConfigureBrighter(HostBuilderContext hostContext, IServiceCollection services)
+{
+    services.AddConsumers(options =>
+    {
+        options.InboxConfiguration = new InboxConfiguration(
+            inbox: new MySqlInbox(new RelationalDatabaseConfiguration(DbConnectionString())),
+            scope: InboxScope.Commands,
+            onceOnly: true,
+            actionOnExists: OnceOnlyAction.Replay);
+
+        // ... other consumer options
+    });
+}
+```
+
+`ActionOnExists` is set through the constructor and is read-only afterwards, so you choose
+replay when you build the configuration rather than flipping it on an existing instance.
+The remaining parameters behave exactly as they do for `Throw` and `Warn`; see
+[Inbox Configuration](/contents/BrighterBasicConfiguration.md#inbox) for the full set.
+
+`InboxScope.Commands` is the usual scope here. Replay resends a handler invocation's
+downstream messages, and it is commands — one request, one handler — where that maps
+cleanly; an event delivered to several handlers is a case worth understanding before you
+opt into it, covered under [Limitations](#limitations).
+
+A global setting still applies per handler, so a handler carrying its own `[UseInbox]`
+attribute keeps that attribute's `onceOnlyAction`, and a handler marked
+`[NoGlobalInbox]` opts out entirely. Setting `Replay` globally is therefore the
+straightforward way to satisfy the
+[every-step requirement](#every-already-seen-step-needs-replay) — it covers the whole
+cascade in one place.
+
+## You Must Thread Your RequestContext
+
+> **⚠ Required**: Every handler that deposits messages you want replayed must pass its own
+> `Context` to `Post` or `DepositPost`. Omit it and replay becomes a silent no-op — no
+> exception, no error log, nothing resent.
+
+This is the step most people miss, and because it fails silently it is worth getting right
+before you enable anything else.
+
+### Why it matters
+
+The Causation Id lives in the pipeline's `RequestContext.Bag`. The Inbox handler puts it
+there, and the Outbox `Add` reads it back out — but only from the context it is actually
+given. Call `Post` with no context and the Command Processor creates a **fresh**
+`RequestContext` for that call. The new context has an empty Bag, so:
+
+1. The outgoing message is stored with a `null` Causation Id.
+2. The Inbox entry still gets the right Causation Id, because the Inbox handler used the
+   pipeline's context.
+3. Later, a duplicate arrives. The Inbox hands over its Causation Id, the Outbox looks for
+   messages stored under it, and finds none — the messages are all sitting there with
+   `null`.
+
+The deposit worked. The dispatch worked. The Inbox recorded everything correctly. Only the
+link between them is missing, and nothing in normal operation reveals that until the day
+you need to replay.
+
+### The fix
+
+```csharp
+// ❌ Silent no-op under Replay — a fresh context, so the Causation Id is lost
+public override ProcessPayment Handle(ProcessPayment command)
+{
+    _commandProcessor.Post(new ShipOrder { OrderId = command.OrderId });
+    return base.Handle(command);
+}
+
+// ✅ Threads the pipeline's context, so the message is stored under this
+//    invocation's Causation Id and a later replay can match it
+public override ProcessPayment Handle(ProcessPayment command)
+{
+    _commandProcessor.Post(new ShipOrder { OrderId = command.OrderId },
+        Context as RequestContext);
+    return base.Handle(command);
+}
+```
+
+`Context` is typed as `IRequestContext?` on `RequestHandler<T>` and `RequestHandlerAsync<T>`,
+while `Post` takes a `RequestContext?`, so the `as RequestContext` cast is what makes this
+compile. With Brighter's own request context factory the cast always succeeds. If you have
+supplied a custom `IAmARequestContextFactory` that returns something other than
+`RequestContext`, the cast yields `null` — which puts you back in the ❌ case, and is
+covered under [When Replay Does Not Fire](#when-replay-does-not-fire).
+
+### Which calls this applies to
+
+Any call that puts a message in the Outbox takes a `RequestContext?` parameter, and all of
+them need yours:
+
+- `Post` and `PostAsync`
+- `DepositPost` and `DepositPostAsync`
+
+The rule is the same in each case: pass `Context as RequestContext` rather than letting the
+parameter default. This matters only for handlers whose messages you want replayed —
+posting from outside a handler pipeline, where there is no Causation Id to inherit, is
+unaffected.
+
+### The symptom
+
+There is no exception and no warning, so you have to know what to look for:
+
+- A duplicate arrives, the handler correctly does not run, and **no messages are resent**.
+  The Sweeper has nothing outstanding to pick up.
+- The Outbox rows for the original run have a `null` causation column.
+- The replay attempt is logged at **Debug** level, so at default log levels you see
+  nothing at all.
+- If you are collecting traces, the pipeline span carries a
+  `UseInboxHandler Duplicate Replay Skipped` event rather than
+  `UseInboxHandler Duplicate Replay` — see [Observability](#observability).
+
+If replay appears to do nothing, check the causation column on the Outbox rows first. A
+column full of nulls means the context was not threaded; that is the fastest way to
+confirm this particular fault rather than one of the
+[other reasons replay stays quiet](#when-replay-does-not-fire).
+
+## Before You Enable It
+
+Replay depends on six things being true at once. Most of them fail quietly — only the two
+marked as startup errors stop your host — so it is worth walking the list before you set
+`OnceOnlyAction.Replay` anywhere.
+
+| Requirement | How to satisfy it | What happens if you don't |
+|---|---|---|
+| The Inbox implements `IAmACausationTrackingInbox` | Every Brighter-maintained Inbox already does. A hand-written Inbox must implement it — see [Implementing Causation Tracking in Your Own Store](#implementing-causation-tracking-in-your-own-store) | Startup **error** from [pipeline validation](/contents/PipelineValidation.md): replay has no way to look up the original Causation Id |
+| The Outbox implements `IAmACausationTrackingOutbox` | Same — every Brighter-maintained Outbox does | Startup **error**. If there is no Outbox at all, you get a **warning** instead: the duplicate is skipped and nothing is resent |
+| The store schema carries the causation column | Run [box provisioning](/contents/BoxProvisioning.md) to bring the schema up to date; on DynamoDB, create the [Causation index](/contents/DynamoOutbox.md#replay-support-the-causation-index). See [Store Support](#store-support) for what each store needs | Startup **warning** only — the host starts. At runtime the store reports no causation support, duplicates are skipped, and nothing is resent |
+| An Outbox Sweeper is running | Register one with `.UseOutboxSweeper(...)` — see below | The messages are marked undispatched and stay that way. Nothing reaches the broker |
+| Handlers pass their `Context` when posting | `Context as RequestContext` on every `Post`/`DepositPost` — see [You Must Thread Your RequestContext](#you-must-thread-your-requestcontext) | Messages are stored with a `null` Causation Id. Replay finds nothing to resend, silently |
+| Every already-seen step is set to `Replay` | The attribute on each handler, or `actionOnExists` globally — see [Turning It On](#turning-it-on) | The cascade stops at the first step still on `Throw` or `Warn` — see [Every already-seen step needs Replay](#every-already-seen-step-needs-replay) |
+
+Note how much of this is warnings rather than errors. A schema that was never migrated
+does not fail startup; it produces a log line at boot and then a system that looks healthy
+and never replays anything. [When Replay Does Not Fire](#when-replay-does-not-fire) lists
+each of these symptoms with the message you will see.
+
+### Replay only ever sends through the Sweeper
+
+The Sweeper row deserves expanding, because replay has **no immediate-send path**. When a
+duplicate arrives, all the Outbox does is clear the dispatched state of the messages
+stored under that Causation Id. Something else has to notice they are outstanding and
+dispatch them, and that something is the Sweeper.
+
+This holds even if you never think about the Sweeper today. Code that calls `Post` gets
+its messages sent in-line, so a producer with no Sweeper can appear to work — but that
+in-line clear belongs to the deposit, not to replay. Nothing in the replay path sends
+anything.
+
+The `InMemoryOutbox` is no exception: it supports replay perfectly well, and it still
+needs a Sweeper to dispatch what replay marks outstanding.
+
+Register one on your producer registration:
+
+```csharp
+using Paramore.Brighter.Outbox.Hosting;
+
+services.AddBrighter()
+    .AddProducers(opt =>
+    {
+        opt.Outbox = new MySqlOutbox(new RelationalDatabaseConfiguration(DbConnectionString()));
+        // ... connection and transaction providers
+    })
+    .UseOutboxSweeper(opt =>
+    {
+        opt.TimerInterval = 5;                            // seconds between sweeps
+        opt.MinimumMessageAge = TimeSpan.FromSeconds(5);  // how settled a message must be
+        opt.BatchSize = 100;
+    });
+```
+
+The interval is your recovery latency. Each hop in a cascade waits for a sweep, so a
+three-step flow takes at least three intervals to walk forward.
+
+Running a Sweeper is not a replay-specific requirement — it is how Brighter guarantees
+delivery at all, and [You always need a Sweeper](/contents/BrighterOutboxSupport.md#you-always-need-a-sweeper)
+explains why, including how it interacts with transports such as RabbitMQ and Kafka that
+confirm sends asynchronously. Replay only makes the requirement unavoidable. If you scale
+your producer out, keep a
+[single Sweeper active with a distributed lock](/contents/DistributedLock.md).
+
+## Store Support
+
+Every Inbox and Outbox Brighter ships implements the causation-tracking role interfaces, so
+there is no store you have to swap out to use replay. What differs is whether the *store
+itself* can hold a Causation Id yet — a relational table needs a column, DynamoDB's Outbox
+needs an index, and a schemaless store needs nothing at all.
+
+Each store answers that question for itself, at runtime, through
+`SupportsCausationTracking()`. Some stores return `true` outright; the relational stores and
+the DynamoDB Outbox go and look.
+
+| Store | Inbox | Outbox | What you must do first |
+|---|---|---|---|
+| MSSQL, MySQL, PostgreSQL, SQLite | Needs the causation column | Needs the causation column | Run [box provisioning](/contents/BoxProvisioning.md#per-backend-support) to bring both boxes up to date — Outbox **V8**, Inbox **V3** (**V2** on PostgreSQL) |
+| Spanner | Needs the causation column | Needs the causation column | Same columns, but the Spanner provisioner is fresh-install-only. A new database gets the current shape; an existing one needs the column added by hand |
+| MongoDB | Nothing to do | Nothing to do | Nothing — the document model carries the field without a schema change |
+| Firestore | Nothing to do | Nothing to do | Nothing |
+| DynamoDB (and `.V4`) | Nothing to do | Needs the **Causation** global secondary index | Create the index — see [Replay Support: The Causation Index](/contents/DynamoOutbox.md#replay-support-the-causation-index) |
+| In-memory | Nothing to do | Nothing to do | Nothing — but you still need a Sweeper. Development and testing only |
+
+DynamoDB is the one asymmetric row. Its Inbox looks the Causation Id up by the table's own
+primary key, so it needs no index; its Outbox has to find every message carrying a given
+Causation Id, which is a query on a non-key attribute and therefore needs the GSI. The
+Outbox probes for that index with `DescribeTable` and reports no causation support if it is
+absent.
+
+**Both boxes have to be ready.** Replay reads the Causation Id from the Inbox and then asks
+the Outbox to replay it, so a migrated Outbox next to an un-migrated Inbox replays nothing —
+and so does the reverse. [Pipeline validation](/contents/PipelineValidation.md) reports each
+store separately at startup, but only as a warning: a half-migrated pair starts cleanly and
+then quietly does nothing. See [When Replay Does Not Fire](#when-replay-does-not-fire).
+
+**Column casing varies by backend.** PostgreSQL folds unquoted identifiers to lower case, so
+its column is `causationid`; MSSQL, MySQL, SQLite, and Spanner use `CausationId`. The sized
+backends also use different widths for the two boxes — 255 characters on the Outbox, 256 on
+the Inbox. If you are checking a migration by hand, or writing a query against the causation
+column, use the casing your own backend uses rather than the one you saw in another
+example.
+
+Migrating a live deployment is safe: an un-migrated store keeps accepting deposits, because
+the write path falls back to the old shape when the column is missing. That fallback, and
+the restart it implies once you *have* migrated, is covered under
+[Upgrading Without Migrating](#upgrading-without-migrating).
+
+## When Replay Does Not Fire
+
+Replay is quiet when it works and quiet when it doesn't. A duplicate arrives, your handler
+correctly does not run, and the Inbox handler returns — and from the outside that looks the
+same whether messages were resent or nothing happened at all. The replay attempt is logged
+at **Debug** level, so at default log levels a working replay and a broken one produce
+identical output: none.
+
+Two places tell you the truth. [Pipeline validation](/contents/PipelineValidation.md)
+catches the misconfigurations it can see at startup, and traces distinguish a real replay
+from a no-op at runtime — see [Observability](#observability). This section covers both,
+starting with what validation reports.
+
+### What validation reports at startup
+
+The `ReplayRequiresCausationTracking` rule runs as part of the handler pipeline checks, and
+only for pipelines that actually configure `OnceOnlyAction.Replay` — a pipeline on `Throw`
+or `Warn` produces nothing. It checks the Inbox, then the Outbox, and it probes the live
+stores for their schema capability rather than assuming it.
+
+| Finding | Severity | Cause | Fix |
+|---|---|---|---|
+| Inbox is not causation-tracking | **Error** | The configured Inbox does not implement `IAmACausationTrackingInbox`, so there is no way to look up the original Causation Id | Use a Brighter-maintained Inbox, or implement the interface — see [Implementing Causation Tracking in Your Own Store](#implementing-causation-tracking-in-your-own-store) |
+| Inbox schema does not support it | Warning | The Inbox implements the interface, but the live store reports no causation support — usually an un-migrated schema | Migrate the Inbox. See [Store Support](#store-support) |
+| No Outbox to replay | Warning | Replay is configured on a handler with no Outbox injected | Expected for a terminal step that deposits nothing. Otherwise, configure an Outbox |
+| Outbox is not causation-tracking | **Error** | The configured Outbox does not implement `IAmACausationTrackingOutbox`, so the dispatched state of the original messages cannot be reset | Use a Brighter-maintained Outbox, or implement the interface |
+| Outbox schema does not support it | Warning | The Outbox implements the interface, but the live store reports no causation support — an un-migrated schema, or on DynamoDB a missing [Causation index](/contents/DynamoOutbox.md#replay-support-the-causation-index) | Migrate the Outbox, or create the index |
+| Capability probe failed | Warning | The probe itself threw — the store was unreachable, or the connecting account cannot read the schema | Fix connectivity or permissions. Until you do, the store's capability is unknown and its schema finding is suppressed |
+
+Each message is prefixed with the handler it came from — `Handler 'ProcessPaymentHandler'`.
+An unconfigured Inbox renders as `'(none)'` in the first message. The messages read:
+
+```
+OnceOnlyAction.Replay requires a causation-tracking inbox, but the configured
+inbox 'InMemoryInbox' does not implement IAmACausationTrackingInbox — Replay
+cannot find the causation id of the original handling
+
+OnceOnlyAction.Replay requires causation tracking, but the inbox store schema
+does not support it — migrate the inbox schema to add the CausationId column
+for Replay to work
+
+OnceOnlyAction.Replay has no outbox to replay — on a duplicate the handler is
+skipped and no messages are resent (Replay is a graceful terminal step without
+an outbox)
+
+OnceOnlyAction.Replay requires a causation-tracking outbox, but the configured
+outbox 'MySqlOutbox' does not implement IAmACausationTrackingOutbox — Replay
+cannot reset the dispatched state of the original messages
+
+OnceOnlyAction.Replay requires causation tracking, but the outbox store schema
+does not support it — migrate the outbox schema to add the CausationId column
+for Replay to work
+
+OnceOnlyAction.Replay could not verify causation-tracking support on the outbox
+store — the schema capability probe failed (SqlException: Login failed for user
+'brighter'). Ensure the store is reachable and its schema is migrated before
+relying on Replay
+```
+
+Two details worth knowing when you read the output. Only the two "does not implement"
+findings are **Errors**; everything else is a Warning, which means a host with a completely
+un-migrated schema starts perfectly cleanly and then never replays anything. And the Inbox
+findings come first: if there is no Outbox, or the Outbox is not causation-tracking,
+validation stops there and reports nothing about the Outbox schema — fix what it reports
+and run again rather than assuming the list is exhaustive.
+
+### The failures validation cannot see
+
+Everything above is visible from your configuration at startup. The rest is not — these
+produce no finding, no exception, and no log above Debug. They are the reasons a correctly
+validated system still replays nothing.
+
+**Your handler did not thread its `Context`.** The outgoing messages were stored with a
+`null` Causation Id, so the Outbox finds nothing under the Inbox's id. This is the most
+common cause by a wide margin; check the causation column on the Outbox rows first. See
+[You Must Thread Your RequestContext](#you-must-thread-your-requestcontext).
+
+**A custom request context factory.** If you have supplied an `IAmARequestContextFactory`
+that returns something other than a `RequestContext`, the Inbox handler cannot use the
+pipeline's context at all and falls back to a throwaway whose Bag never reaches the Outbox.
+This one does leave a trace: a single warning, logged once per process the first time a
+Replay pipeline hits it.
+
+```
+A custom IRequestContext (not a RequestContext) was supplied; the causation id
+cannot flow to downstream handlers, so OnceOnlyAction.Replay will be a no-op
+```
+
+Treat "once" as best effort rather than a guarantee — under concurrent first hits you may
+see it a couple of times.
+
+**The Inbox entry predates causation tracking.** An entry written before you migrated the
+schema, or before you turned replay on, has no Causation Id stored against it. There is no
+backfill, and there is nothing to reconstruct it from: the link between an Inbox entry and
+the messages it produced only exists if it was recorded at the time. Requests handled from
+now on are fine; historical ones can never be replayed.
+
+**A downstream step is still on `Throw` or `Warn`.** Replay fires correctly at the step you
+re-sent, and the cascade stops at the first handler that is not configured for it. The
+symptom is distinctive — the flow moves forward by exactly one hop and stalls again. See
+[Every already-seen step needs Replay](#every-already-seen-step-needs-replay).
+
+**The step has no Outbox at all.** A handler that deposits nothing has nothing to replay,
+so the duplicate is simply skipped. That is correct behaviour for a terminal step, and
+validation says so with a warning rather than an error.
+
+**No Sweeper is running.** Replay did its job — the messages are outstanding in the
+Outbox — but nothing is dispatching them. Check whether the rows have had their dispatched
+state cleared: if they have, the fault is downstream of replay, in the Sweeper. See
+[Replay only ever sends through the Sweeper](#replay-only-ever-sends-through-the-sweeper).
+
+## Upgrading Without Migrating
+
+Taking a Brighter version that has causation tracking does not oblige you to migrate
+anything. An un-migrated store keeps depositing exactly as it did before — same INSERT, same
+columns, same behaviour — and you migrate when you decide to adopt replay, not when you take
+the package.
+
+That works because the stores check their own schema rather than assuming it. Each
+relational store probes once for the causation column, and the answer gates two things: what
+`SupportsCausationTracking()` reports to
+[pipeline validation](/contents/PipelineValidation.md), and which INSERT the write path
+uses. Column present, and `Add` writes the Causation Id along with the message. Column
+absent, and `Add` falls back to the original INSERT and writes nothing extra.
+
+The read path is gated by the same answer, so an un-migrated store degrades rather than
+failing:
+
+- The Inbox returns `null` from `GetCausationId` instead of selecting a column that is not
+  there.
+- The Outbox returns `false` from `ReplayCausation` instead of issuing an `UPDATE ... WHERE
+  CausationId = @id` against a missing column.
+
+That second one covers the mixed state, where you migrate one box and not the other. A
+migrated Inbox hands over a perfectly good Causation Id, and an un-migrated Outbox declines
+it and reports that nothing was resent — rather than throwing a SQL error into your consumer
+pipeline.
+
+DynamoDB works the same way with a different question: its Outbox probes `DescribeTable` for
+the Causation index rather than probing for a column, and writing the attribute to a table
+without the index is a harmless no-op.
+
+### The probe is memoized, so migrating mid-process needs a restart
+
+The probe runs once per store instance and the result is cached for that instance's
+lifetime. It is never re-checked and never invalidated. Since your stores are typically
+singletons, "once per store instance" means once per process.
+
+That is what you want for throughput — no schema query per deposit — but it has one
+operational consequence:
+
+> **⚠ A store built before the migration caches "no causation support" and keeps that answer
+> until the process restarts.** Migrating the database under a running host does not turn
+> replay on in that host.
+
+Usually this never comes up. [Box provisioning](/contents/BoxProvisioning.md) runs at host
+startup, before your stores handle any traffic, so the first probe already sees the migrated
+schema. You hit it when the migration happens somewhere else — a DBA applying the DDL by
+hand, a separate provisioning job, a release pipeline that migrates while the previous
+version is still serving. In each case the fix is the same: restart the hosts after
+migrating. See [Upgrading Existing Deployments](/contents/BoxProvisioningUpgrade.md) for
+what to expect from a migration run and what to check afterwards.
+
+The symptom is worth recognising, because it looks exactly like a schema problem you have
+already fixed: the database has the column, `psql` or SSMS confirms it, and startup
+validation still warns that the store schema does not support causation tracking. It is
+reporting what the store probed, which may be older than what you are looking at.
+
+### Migrating does not backfill
+
+One last consequence of migrating late. Inbox entries written before the migration have no
+Causation Id, and adding the column does not go back and work out what it should have been —
+the link between an entry and the messages it produced exists only if it was recorded while
+the request was being handled. Requests handled after the migration replay normally;
+requests handled before it never will. If you are enabling replay to recover a flow that is
+stalled *right now*, that flow's original handling predates the column, and replay cannot
+help with it.
+
+## Observability
+
+Because replay is silent at default log levels, traces are the practical way to see it
+working. The Inbox handler records what it did as an **event on the existing pipeline span** —
+it creates no span of its own — so you find it on the span for the request that turned out to
+be a duplicate.
+
+| Path | Event name | Tags |
+|---|---|---|
+| First handling — the entry is stored | `UseInboxHandler Add` | request id |
+| Duplicate, action is `Throw` | `UseInboxHandler Duplicate Throw` | request id |
+| Duplicate, action is `Warn` | `UseInboxHandler Duplicate Warn` | request id |
+| Duplicate, action is `Replay` — messages resent | `UseInboxHandler Duplicate Replay` | request id, Causation Id |
+| Duplicate, action is `Replay` — nothing resent | `UseInboxHandler Duplicate Replay Skipped` | request id, Causation Id (null) |
+
+The event names are the same on the sync and async handlers — there is no
+`UseInboxHandlerAsync` variant to look for.
+
+The tags are `paramore.brighter.request.id` and, on the two replay events,
+`paramore.brighter.causation_id`. The Causation Id tag is what lets you follow a replay:
+take its value, and every Outbox row it resent carries the same one.
+
+### Replay versus Replay Skipped
+
+That last pair of rows is the most useful thing on the page for anyone operating this
+feature. `Replay` and `Replay Skipped` are the difference between "the duplicate resent its
+messages" and "the duplicate resent nothing" — a distinction that produces no other visible
+signal anywhere.
+
+`Replay Skipped` is emitted whenever no messages went out: the Inbox held no Causation Id
+for that entry, or the Outbox declined the replay because its schema does not support
+causation tracking. Both are covered under
+[When Replay Does Not Fire](#when-replay-does-not-fire). A null `paramore.brighter.causation_id`
+tag alongside the Skipped event narrows it to the first case.
+
+If you alert on anything here, alert on `Replay Skipped`. It means a duplicate arrived at a
+handler you deliberately configured for replay, and the recovery you were counting on did
+not happen.
+
+### Turning the events on
+
+The events are written only when there is a span to write them to and the pipeline's
+`InstrumentationOptions` include `InstrumentationOptions.Brighter`. If you have narrowed
+instrumentation to trim trace volume, you will have narrowed these away too. See
+[Configurable Instrumentation](/contents/Telemetry.md#configurable-instrumentation) for the
+options, and [Inbox Tracing](/contents/Telemetry.md#inbox-tracing) for the spans the Inbox
+produces around them.
+
+Two log lines complement the events: the replay attempt itself, at **Debug** — so raise the
+level for `UseInboxHandler` if you want it in logs rather than traces — and the
+once-per-process `CustomContextDisablesReplay` warning, quoted in full under
+[The failures validation cannot see](#the-failures-validation-cannot-see).
+
+### The re-dispatch is a separate trace
+
+Do not expect the resent messages to appear under the trace that triggered the replay. They
+will not, and nothing is broken.
+
+The replay only clears dispatched state; the [Sweeper](#replay-only-ever-sends-through-the-sweeper)
+does the sending, later, on its own schedule. It starts its own `Activity` for each sweep,
+and a single sweep may carry messages from several unrelated replays, so there is no parent
+span to attach to — a link would have to be one-to-many and would tie the dispatch to
+whichever replay happened to be first. The Causation Id tag is the join instead: it appears
+on the replay event, and it is stored on every message the sweep picks up.
+
+For the same reason, the elapsed time between the replay event and the messages arriving is
+Sweeper latency, not handler latency. If a cascade looks slow in your traces, look at
+`TimerInterval` and `MinimumMessageAge` before you look at your handlers.
+
+## Limitations
+
+Replay is a small mechanism — re-deliver messages that were already recorded — and most of
+its limitations follow from how small it is.
+
+### It is not orchestration
+
+The cascade can look like a workflow engine walking a process forward, and it is worth being
+clear that it is not one. There is no coordinator: nothing holds a model of the flow, knows
+which step it reached, or decides what should happen next. Each step advances only because
+its own Inbox happens to be configured for replay, and the flow stops wherever that stops
+being true.
+
+Nothing follows from that beyond re-delivery, so:
+
+- **There is no compensation.** Replay moves a stalled flow forward. It cannot unwind one,
+  and a step whose original run was wrong stays wrong — its stored messages are exactly what
+  gets resent.
+- **There is no ordering guarantee.** Messages resent under one Causation Id are made
+  outstanding together and the Sweeper dispatches them in whatever order it picks them up.
+- **There is no completion signal.** Nothing tells you the flow finished, or that it stalled
+  again at a later step.
+
+If you need a coordinator, compensation, or a durable model of where a process has got to,
+you need a workflow, not replay.
+
+### One Causation Id can cover more than one handler
+
+The default Causation Id is the handled request's own `Id`. If that id reaches several
+`[UseInbox]` handlers, every message any of them deposited is stored under the same value,
+and a replay triggered by any one of them resends all of them.
+
+This is intended. It also rarely bites, because `[UseInbox]` is normally applied to Commands
+— one request, one handler — rather than to Events, which are delivered to many. It is worth
+thinking about before you put replay on an event.
+
+If you need finer control, set the Causation Id yourself. The Inbox handler only supplies a
+default when the Bag has no value, so a value you put there first wins:
+
+```csharp
+using Paramore.Brighter;
+
+var context = new RequestContext();
+context.Bag[RequestContextBagNames.CausationId] = batchId;
+
+// Everything this invocation deposits is stored under batchId, and a replay
+// triggered by this request resends exactly that set
+_commandProcessor.Send(new ProcessPayment { OrderId = orderId }, context);
+```
+
+This works wherever you control the `RequestContext` handed to the Command Processor. For
+requests arriving from a broker the pump builds the context, so the default applies unless
+you have replaced the context factory.
+
+### A replayed message can be dispatched twice
+
+Replay clears dispatched state while the Sweeper may be mid-pass over the same rows. The
+worst case is that a message goes out twice.
+
+That is not a new hazard. Brighter's delivery guarantee is at-least-once with or without
+replay, so a consumer that could not cope with a duplicate was already exposed. The Inbox on
+the receiving side is the answer, as it is for every other source of duplicates.
+
+### Historical entries can never be replayed
+
+An Inbox entry written before causation tracking was in place has no Causation Id, nothing
+backfills it, and a duplicate that lands on it produces a
+[`Replay Skipped` event](#replay-versus-replay-skipped). See
+[Migrating does not backfill](#migrating-does-not-backfill).
+
+### Replaying a large causation is one write
+
+Clearing the dispatched state of every message under a Causation Id is a single statement,
+and its cost scales with how many messages that handler deposited. The V8 Outbox migration
+indexes the causation column precisely so this stays cheap; on DynamoDB the same job is done
+by the Causation index. A handler that deposits a handful of messages per invocation — the
+normal case — is not something you need to think about.
+
+## A Worked Example
+
+Here is the stalled order from the top of the page, followed all the way through: Payment
+handled `ProcessPayment` and deposited `ShipOrder`, but Shipping never received it. Both
+handlers are configured for replay; only Payment has ever run.
+
+```csharp
+using Paramore.Brighter;
+using Paramore.Brighter.Inbox;
+using Paramore.Brighter.Inbox.Attributes;
+
+// Payment service — has already handled this command once
+public class ProcessPaymentHandler : RequestHandler<ProcessPayment>
+{
+    private readonly IAmACommandProcessor _commandProcessor;
+    private readonly IPaymentGateway _payments;
+
+    public ProcessPaymentHandler(IAmACommandProcessor commandProcessor, IPaymentGateway payments)
+    {
+        _commandProcessor = commandProcessor;
+        _payments = payments;
+    }
+
+    [UseInbox(step: 1, contextKey: typeof(ProcessPaymentHandler), onceOnly: true,
+        onceOnlyAction: OnceOnlyAction.Replay)]
+    public override ProcessPayment Handle(ProcessPayment command)
+    {
+        _payments.Charge(command.OrderId, command.Amount);
+
+        // Threading Context stores ShipOrder under this invocation's Causation Id
+        _commandProcessor.Post(new ShipOrder { OrderId = command.OrderId },
+            Context as RequestContext);
+
+        return base.Handle(command);
+    }
+}
+
+// Shipping service — has never seen this order
+public class ShipOrderHandler : RequestHandler<ShipOrder>
+{
+    private readonly IAmACommandProcessor _commandProcessor;
+    private readonly ICourier _courier;
+
+    public ShipOrderHandler(IAmACommandProcessor commandProcessor, ICourier courier)
+    {
+        _commandProcessor = commandProcessor;
+        _courier = courier;
+    }
+
+    [UseInbox(step: 1, contextKey: typeof(ShipOrderHandler), onceOnly: true,
+        onceOnlyAction: OnceOnlyAction.Replay)]
+    public override ShipOrder Handle(ShipOrder command)
+    {
+        var consignment = _courier.Book(command.OrderId);
+
+        _commandProcessor.Post(new OrderShipped { OrderId = command.OrderId, Consignment = consignment },
+            Context as RequestContext);
+
+        return base.Handle(command);
+    }
+}
+```
+
+`ShipOrderHandler` is configured for replay even though it has never run. That costs nothing
+while its Inbox is empty, and it means the step is ready if the flow ever has to be walked
+forward *past* it.
+
+### The original run
+
+1. **`ProcessPayment` arrives** at the Payment service. Its Inbox has no entry for this id,
+   so the pipeline continues into the handler. The Inbox handler first stamps the Bag with
+   the Causation Id — the command's own `Id`, call it `pay-1`.
+2. **The handler charges the card and posts `ShipOrder`**, passing `Context as
+   RequestContext`. The Outbox stores `ShipOrder` with `CausationId = pay-1`.
+3. **The handler returns and the Inbox entry is written**, also carrying `pay-1`. Note the
+   order: the entry is written *after* your handler completes, not before.
+4. **`ShipOrder` is dispatched** to the broker and never arrives at a consumer — the queue is
+   misbound, or Shipping is down and the message ends up dead-lettered. Shipping's Inbox
+   stays empty.
+
+At this point the money is taken, no parcel is moving, and the two stores hold:
+
+| Store | Contents |
+|---|---|
+| Payment Inbox | one entry for `ProcessPayment`, `CausationId = pay-1` |
+| Payment Outbox | one `ShipOrder` message, `CausationId = pay-1`, marked dispatched |
+| Shipping Inbox | empty |
+
+### The recovery
+
+5. **You re-send `ProcessPayment`** — the same command, the same id.
+6. **Payment's Inbox finds the duplicate.** The action is `Replay`, so the Inbox handler asks
+   for the stored Causation Id, gets `pay-1`, and calls `ReplayCausation("pay-1")` on the
+   Outbox. Every message stored under `pay-1` — the one `ShipOrder` — has its dispatched
+   state cleared and becomes outstanding again.
+7. **`ProcessPaymentHandler` never runs.** The card is not charged a second time, and no new
+   `ShipOrder` is generated. The pipeline span picks up a `UseInboxHandler Duplicate Replay`
+   event tagged with `pay-1`.
+8. **The Sweeper's next pass** finds the outstanding `ShipOrder` and dispatches it. It is the
+   *same* message, with the same message id and the same body as the one deposited in step 2.
+9. **Shipping receives `ShipOrder`.** Its Inbox has never seen this id, so there is no
+   duplicate to act on and `ShipOrderHandler` runs normally — for the first time. The courier
+   is booked, `OrderShipped` is deposited under a fresh Causation Id, and Shipping writes its
+   own Inbox entry.
+
+| Store | Contents after recovery |
+|---|---|
+| Payment Inbox | unchanged — still one entry, `CausationId = pay-1` |
+| Payment Outbox | the same `ShipOrder` message, dispatched again |
+| Shipping Inbox | one entry for `ShipOrder` |
+| Shipping Outbox | one `OrderShipped` message under its own Causation Id |
+
+The flow reached the step that had never run, and the step that had already run was skipped
+rather than repeated. Nothing was recomputed: the `ShipOrder` that finally arrived is the
+one Payment produced an hour earlier.
+
+### What backs this up
+
+Brighter's test suite verifies this mechanism end to end in
+`Paramore.Brighter.Core.Tests/OnceOnly/When_a_seen_message_is_replayed_end_to_end.cs`, which
+is the reference implementation to read — there is no sample application for replay yet. Two
+differences from the walkthrough above are worth knowing if you go and read it:
+
+- **The test covers one step, not a cascade.** It has a single handler forwarding a single
+  event, and proves that a duplicate resends that event without re-running the handler. The
+  two-step version above extrapolates from that; each hop is the same mechanism repeated.
+- **The test does not run a Sweeper.** It calls `ClearOutbox` directly to re-dispatch what
+  replay made outstanding, because a background Sweeper would make the test timing-dependent.
+  Replay's own effect stops at "the message is outstanding again" — in production, step 8 is
+  the Sweeper's job.
+
+## Why It Works This Way
+
+Three of replay's design decisions shape how you use it, and each rules out an approach that
+looks simpler at first.
+
+**Why not just re-run the handler?** Because that is the one thing the Inbox exists to
+prevent. If re-running were safe you would not need an Inbox in front of the handler at all,
+and the flows that need replay are exactly the ones where a second run charges a card or
+ships a parcel twice. There is a subtler reason too: a handler re-run an hour later reads
+the state of an hour later, so it could legitimately produce *different* messages from the
+ones the original run produced — see
+[The same messages, not new ones](#the-same-messages-not-new-ones).
+
+**Why a new id rather than one Brighter already carries?** Both obvious candidates mean
+something else. `CorrelationId` ties a reply to its request in request-reply exchanges, and
+overloading it would leave two unrelated relationships sharing one field. `JobId` identifies
+a whole workflow instance, so replaying by it would resend every message from every step of
+that job rather than the messages from the one step you are recovering. The Causation Id is
+narrower than either on purpose: it names a single handler invocation and the messages that
+came out of it.
+
+**Why the Sweeper rather than sending immediately?** Because the Outbox already has a
+component whose entire job is dispatching outstanding messages, and that reduces replay to a
+change of state — mark these rows outstanding — with no new dispatch path to build, secure,
+or reason about. The replayed messages then inherit everything the Sweeper already provides:
+the same batching, the same retry behaviour, the same delivery guarantees as any other
+outstanding message. You pay for it in latency, one sweep interval per hop, which is the
+trade the [Sweeper section](#replay-only-ever-sends-through-the-sweeper) asks you to size for.
+
+The full rationale, including the alternatives that were considered and rejected, is in
+[ADR 0057 — Replay Outbox Messages on Inbox Duplicate Detection](https://github.com/BrighterCommand/Brighter/blob/master/docs/adr/0057-replay-outbox-on-inbox-duplicate.md).
+Note the filename: several ADRs share the number 0057.
+
+## Implementing Causation Tracking in Your Own Store
+
+> This section is for people **writing** an Inbox or Outbox — a backend Brighter does not
+> ship, or a wrapper of your own. If you are using a Brighter-maintained store, it already
+> implements everything below; see [Store Support](#store-support) instead.
+
+Causation tracking is an **optional role interface** on each box, separate from the core
+Inbox and Outbox interfaces. A store that does not implement it keeps working exactly as
+before — it simply never participates in replay.
+
+### The two interfaces
+
+Both live in the `Paramore.Brighter` namespace.
+
+`IAmACausationTrackingInbox` has three jobs:
+
+| Member | What your implementation must do |
+|---|---|
+| `SupportsCausationTracking()` / `…Async()` | Report whether the **live** store can hold a Causation Id right now |
+| `GetCausationId(id, contextKey, …)` / `…Async()` | Return the Causation Id stored against an entry, or `null` if there is none |
+| *(your `Add`)* | Read the Causation Id out of the request context and store it with the entry |
+
+`IAmACausationTrackingOutbox` mirrors it:
+
+| Member | What your implementation must do |
+|---|---|
+| `SupportsCausationTracking()` / `…Async()` | As above |
+| `ReplayCausation(causationId, …)` / `…Async()` | Clear the dispatched state of every message stored under that Causation Id, so the Sweeper resends them. Return `true` if you did it, `false` if it was a no-op |
+| *(your `Add`)* | Read the Causation Id out of the request context and store it with the message |
+
+Note that storing the Causation Id is **not** on either interface. It happens inside your
+`Add`, which already receives the `RequestContext` it needs:
+
+```csharp
+using Paramore.Brighter;
+
+private static string? ReadCausationId(RequestContext? requestContext)
+    => requestContext?.Bag.TryGetValue(RequestContextBagNames.CausationId, out var value) == true
+        ? value as string
+        : null;
+```
+
+### Three rules that are easy to get wrong
+
+**`SupportsCausationTracking()` must report the live state, not your intent.** It is not
+"does this class implement the interface" — the class obviously does, or the method would not
+be there. It is "can the store *this instance is talking to* hold a Causation Id today". For a
+schemaless store that is genuinely always `true`. For anything with a schema, go and look:
+Brighter's relational stores query for the column, and its DynamoDB Outbox calls
+`DescribeTable` for the index. Returning an optimistic `true` makes
+[pipeline validation](/contents/PipelineValidation.md) pass and then fails at runtime, which
+is precisely the outcome the method exists to prevent.
+
+**Never throw for an unsupported store — degrade.** `GetCausationId` returns `null` and
+`ReplayCausation` returns `false`. A duplicate arriving at an un-migrated store must not
+unwind the consumer pipeline with a schema error, and the `false` return is what lets
+Brighter record a
+[`Replay Skipped` event](#replay-versus-replay-skipped) rather than claiming a replay that
+never happened.
+
+**Gate your own write path on the same answer.** If your `Add` unconditionally writes a
+Causation Id, an un-migrated store starts failing deposits the moment someone upgrades. Ask
+the same probe, and fall back to your original write when it says no. If the probe is
+expensive, memoize it — and read
+[Upgrading Without Migrating](#upgrading-without-migrating) for the restart consequence that
+memoizing carries.
+
+### A skeleton
+
+```csharp
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Paramore.Brighter;
+
+public class MyOutbox : IAmAnOutboxSync<Message, MyTransaction>, IAmACausationTrackingOutbox
+{
+    private bool? _causationSupported;
+
+    // ... the core Outbox members: Get, MarkDispatched, OutstandingMessages, Delete ...
+
+    public void Add(Message message, RequestContext requestContext, int outBoxTimeout = -1,
+        IAmABoxTransactionProvider<MyTransaction>? transactionProvider = null)
+    {
+        var causationId = ReadCausationId(requestContext);
+
+        // Gate the write on the same probe: an un-migrated store keeps its original shape
+        if (SupportsCausationTracking())
+            StoreWithCausation(message, causationId);
+        else
+            Store(message);
+    }
+
+    public bool SupportsCausationTracking()
+        => _causationSupported ??= CausationColumnExists();   // a live check, memoized
+
+    public Task<bool> SupportsCausationTrackingAsync(CancellationToken cancellationToken = default)
+        => Task.FromResult(SupportsCausationTracking());
+
+    public bool ReplayCausation(string causationId, RequestContext? requestContext,
+        Dictionary<string, object>? args = null)
+    {
+        // A no-op, not an exception, when the store cannot support it
+        if (!SupportsCausationTracking())
+            return false;
+
+        foreach (var message in FindByCausation(causationId))
+            ClearDispatchedState(message);   // the Sweeper takes it from here
+
+        return true;
+    }
+
+    public Task<bool> ReplayCausationAsync(string causationId, RequestContext? requestContext,
+        Dictionary<string, object>? args = null, CancellationToken cancellationToken = default)
+        => Task.FromResult(ReplayCausation(causationId, requestContext, args));
+}
+```
+
+The Inbox side is the same shape: probe, store the Causation Id in `Add` when the probe says
+you can, and return it from `GetCausationId` — or `null`.
+
+### Registration
+
+Nothing extra to do. `AddProducers` checks whether your Outbox implements
+`IAmACausationTrackingOutbox` and registers the same instance under that interface as well.
+The Inbox handler takes it as an optional constructor dependency, so an Outbox that does not
+implement the role resolves to `null` and the handler degrades to a plain skip.
+
+## Further Reading
+
+- [Inbox Support](/contents/BrighterInboxSupport.md) — configuring an Inbox, and the other
+  `OnceOnlyAction` values
+- [Outbox Support](/contents/BrighterOutboxSupport.md) — the Outbox, the Sweeper, and
+  delivery guarantees
+- [Outbox Pattern](/contents/OutboxPattern.md) — why the Outbox exists at all
+- [Box Provisioning](/contents/BoxProvisioning.md) — bringing a store schema up to the
+  version replay needs
+- [Upgrading Existing Deployments](/contents/BoxProvisioningUpgrade.md) — what a migration
+  run does, and what to check afterwards
+- [Pipeline Validation](/contents/PipelineValidation.md) — the startup checks, including the
+  replay rule
+- [DynamoDb Outbox](/contents/DynamoOutbox.md) — including the Causation index replay needs
+- [Telemetry](/contents/Telemetry.md) — the tracing the span events attach to
+- [Glossary](/contents/Glossary.md) — Causation Id, Replay, Inbox, Outbox, Sweeper
+- [ADR 0057 — Replay Outbox Messages on Inbox Duplicate Detection](https://github.com/BrighterCommand/Brighter/blob/master/docs/adr/0057-replay-outbox-on-inbox-duplicate.md)
+  — the design rationale

--- a/contents/ReplayOnSeen.md
+++ b/contents/ReplayOnSeen.md
@@ -159,13 +159,13 @@ Duplicate PlaceOrder arrives
 │         │                                    │
 │         ▼                                    │
 │   inbox.GetCausationId(id, contextKey)       │
-│         │  ──► the causation id stored when  │
+│         │  ──► the Causation Id stored when  │
 │         │      PlaceOrder was first handled  │
 │         ▼                                    │
 │   outbox.ReplayCausation(causationId)        │
 │         │  ──► clears the dispatched state   │
 │         │      of every message stored under │
-│         │      that causation id             │
+│         │      that Causation Id             │
 │         ▼                                    │
 │   return  ──►  PlaceOrderHandler never runs  │
 └──────────────────────────────────────────────┘
@@ -417,7 +417,7 @@ marked as startup errors stop your host — so it is worth walking the list befo
 
 | Requirement | How to satisfy it | What happens if you don't |
 |---|---|---|
-| The Inbox implements `IAmACausationTrackingInbox` | Every Brighter-maintained Inbox already does. A hand-written Inbox must implement it — see [Implementing Causation Tracking in Your Own Store](#implementing-causation-tracking-in-your-own-store) | Startup **error** from [pipeline validation](/contents/PipelineValidation.md): replay has no way to look up the original Causation Id |
+| The Inbox implements `IAmACausationTrackingInbox` | Every Brighter-maintained Inbox already does. A hand-written Inbox must implement it — see [Implementing Causation Tracking in Your Own Store](/contents/CausationTrackingStores.md) | Startup **error** from [pipeline validation](/contents/PipelineValidation.md): replay has no way to look up the original Causation Id |
 | The Outbox implements `IAmACausationTrackingOutbox` | Same — every Brighter-maintained Outbox does | Startup **error**. If there is no Outbox at all, you get a **warning** instead: the duplicate is skipped and nothing is resent |
 | The store schema carries the causation column | Run [box provisioning](/contents/BoxProvisioning.md) to bring the schema up to date; on DynamoDB, create the [Causation index](/contents/DynamoOutbox.md#replay-support-the-causation-index). See [Store Support](#store-support) for what each store needs | Startup **warning** only — the host starts. At runtime the store reports no causation support, duplicates are skipped, and nothing is resent |
 | An Outbox Sweeper is running | Register one with `.UseOutboxSweeper(...)` — see below | The messages are marked undispatched and stay that way. Nothing reaches the broker |
@@ -517,6 +517,10 @@ the write path falls back to the old shape when the column is missing. That fall
 the restart it implies once you *have* migrated, is covered under
 [Upgrading Without Migrating](#upgrading-without-migrating).
 
+Writing your own Inbox or Outbox, rather than using one Brighter ships? The role interfaces
+it has to implement, and the three rules that are easy to get wrong, are covered in
+[Implementing Causation Tracking in Your Own Store](/contents/CausationTrackingStores.md).
+
 ## When Replay Does Not Fire
 
 Replay is quiet when it works and quiet when it doesn't. A duplicate arrives, your handler
@@ -539,7 +543,7 @@ stores for their schema capability rather than assuming it.
 
 | Finding | Severity | Cause | Fix |
 |---|---|---|---|
-| Inbox is not causation-tracking | **Error** | The configured Inbox does not implement `IAmACausationTrackingInbox`, so there is no way to look up the original Causation Id | Use a Brighter-maintained Inbox, or implement the interface — see [Implementing Causation Tracking in Your Own Store](#implementing-causation-tracking-in-your-own-store) |
+| Inbox is not causation-tracking | **Error** | The configured Inbox does not implement `IAmACausationTrackingInbox`, so there is no way to look up the original Causation Id | Use a Brighter-maintained Inbox, or implement the interface — see [Implementing Causation Tracking in Your Own Store](/contents/CausationTrackingStores.md) |
 | Inbox schema does not support it | Warning | The Inbox implements the interface, but the live store reports no causation support — usually an un-migrated schema | Migrate the Inbox. See [Store Support](#store-support) |
 | No Outbox to replay | Warning | Replay is configured on a handler with no Outbox injected | Expected for a terminal step that deposits nothing. Otherwise, configure an Outbox |
 | Outbox is not causation-tracking | **Error** | The configured Outbox does not implement `IAmACausationTrackingOutbox`, so the dispatched state of the original messages cannot be reset | Use a Brighter-maintained Outbox, or implement the interface |
@@ -551,7 +555,7 @@ An unconfigured Inbox renders as `'(none)'` in the first message. The messages r
 
 ```
 OnceOnlyAction.Replay requires a causation-tracking inbox, but the configured
-inbox 'InMemoryInbox' does not implement IAmACausationTrackingInbox — Replay
+inbox 'MyCustomInbox' does not implement IAmACausationTrackingInbox — Replay
 cannot find the causation id of the original handling
 
 OnceOnlyAction.Replay requires causation tracking, but the inbox store schema
@@ -563,7 +567,7 @@ skipped and no messages are resent (Replay is a graceful terminal step without
 an outbox)
 
 OnceOnlyAction.Replay requires a causation-tracking outbox, but the configured
-outbox 'MySqlOutbox' does not implement IAmACausationTrackingOutbox — Replay
+outbox 'MyCustomOutbox' does not implement IAmACausationTrackingOutbox — Replay
 cannot reset the dispatched state of the original messages
 
 OnceOnlyAction.Replay requires causation tracking, but the outbox store schema
@@ -576,7 +580,12 @@ store — the schema capability probe failed (SqlException: Login failed for use
 relying on Replay
 ```
 
-Two details worth knowing when you read the output. Only the two "does not implement"
+Note the store names in the two "does not implement" messages. Every Inbox and Outbox
+Brighter ships implements the role interfaces, so those two findings can only ever name a
+store you wrote yourself — a Brighter-maintained store that is merely un-migrated produces
+the *schema* warning instead.
+
+Two more details worth knowing when you read the output. Only the two "does not implement"
 findings are **Errors**; everything else is a Warning, which means a host with a completely
 un-migrated schema starts perfectly cleanly and then never replays anything. And the Inbox
 findings come first: if there is no Outbox, or the Outbox is not causation-tracking,
@@ -1006,134 +1015,6 @@ The full rationale, including the alternatives that were considered and rejected
 [ADR 0057 — Replay Outbox Messages on Inbox Duplicate Detection](https://github.com/BrighterCommand/Brighter/blob/master/docs/adr/0057-replay-outbox-on-inbox-duplicate.md).
 Note the filename: several ADRs share the number 0057.
 
-## Implementing Causation Tracking in Your Own Store
-
-> This section is for people **writing** an Inbox or Outbox — a backend Brighter does not
-> ship, or a wrapper of your own. If you are using a Brighter-maintained store, it already
-> implements everything below; see [Store Support](#store-support) instead.
-
-Causation tracking is an **optional role interface** on each box, separate from the core
-Inbox and Outbox interfaces. A store that does not implement it keeps working exactly as
-before — it simply never participates in replay.
-
-### The two interfaces
-
-Both live in the `Paramore.Brighter` namespace.
-
-`IAmACausationTrackingInbox` has three jobs:
-
-| Member | What your implementation must do |
-|---|---|
-| `SupportsCausationTracking()` / `…Async()` | Report whether the **live** store can hold a Causation Id right now |
-| `GetCausationId(id, contextKey, …)` / `…Async()` | Return the Causation Id stored against an entry, or `null` if there is none |
-| *(your `Add`)* | Read the Causation Id out of the request context and store it with the entry |
-
-`IAmACausationTrackingOutbox` mirrors it:
-
-| Member | What your implementation must do |
-|---|---|
-| `SupportsCausationTracking()` / `…Async()` | As above |
-| `ReplayCausation(causationId, …)` / `…Async()` | Clear the dispatched state of every message stored under that Causation Id, so the Sweeper resends them. Return `true` if you did it, `false` if it was a no-op |
-| *(your `Add`)* | Read the Causation Id out of the request context and store it with the message |
-
-Note that storing the Causation Id is **not** on either interface. It happens inside your
-`Add`, which already receives the `RequestContext` it needs:
-
-```csharp
-using Paramore.Brighter;
-
-private static string? ReadCausationId(RequestContext? requestContext)
-    => requestContext?.Bag.TryGetValue(RequestContextBagNames.CausationId, out var value) == true
-        ? value as string
-        : null;
-```
-
-### Three rules that are easy to get wrong
-
-**`SupportsCausationTracking()` must report the live state, not your intent.** It is not
-"does this class implement the interface" — the class obviously does, or the method would not
-be there. It is "can the store *this instance is talking to* hold a Causation Id today". For a
-schemaless store that is genuinely always `true`. For anything with a schema, go and look:
-Brighter's relational stores query for the column, and its DynamoDB Outbox calls
-`DescribeTable` for the index. Returning an optimistic `true` makes
-[pipeline validation](/contents/PipelineValidation.md) pass and then fails at runtime, which
-is precisely the outcome the method exists to prevent.
-
-**Never throw for an unsupported store — degrade.** `GetCausationId` returns `null` and
-`ReplayCausation` returns `false`. A duplicate arriving at an un-migrated store must not
-unwind the consumer pipeline with a schema error, and the `false` return is what lets
-Brighter record a
-[`Replay Skipped` event](#replay-versus-replay-skipped) rather than claiming a replay that
-never happened.
-
-**Gate your own write path on the same answer.** If your `Add` unconditionally writes a
-Causation Id, an un-migrated store starts failing deposits the moment someone upgrades. Ask
-the same probe, and fall back to your original write when it says no. If the probe is
-expensive, memoize it — and read
-[Upgrading Without Migrating](#upgrading-without-migrating) for the restart consequence that
-memoizing carries.
-
-### A skeleton
-
-```csharp
-using System.Collections.Generic;
-using System.Threading;
-using System.Threading.Tasks;
-using Paramore.Brighter;
-
-public class MyOutbox : IAmAnOutboxSync<Message, MyTransaction>, IAmACausationTrackingOutbox
-{
-    private bool? _causationSupported;
-
-    // ... the core Outbox members: Get, MarkDispatched, OutstandingMessages, Delete ...
-
-    public void Add(Message message, RequestContext requestContext, int outBoxTimeout = -1,
-        IAmABoxTransactionProvider<MyTransaction>? transactionProvider = null)
-    {
-        var causationId = ReadCausationId(requestContext);
-
-        // Gate the write on the same probe: an un-migrated store keeps its original shape
-        if (SupportsCausationTracking())
-            StoreWithCausation(message, causationId);
-        else
-            Store(message);
-    }
-
-    public bool SupportsCausationTracking()
-        => _causationSupported ??= CausationColumnExists();   // a live check, memoized
-
-    public Task<bool> SupportsCausationTrackingAsync(CancellationToken cancellationToken = default)
-        => Task.FromResult(SupportsCausationTracking());
-
-    public bool ReplayCausation(string causationId, RequestContext? requestContext,
-        Dictionary<string, object>? args = null)
-    {
-        // A no-op, not an exception, when the store cannot support it
-        if (!SupportsCausationTracking())
-            return false;
-
-        foreach (var message in FindByCausation(causationId))
-            ClearDispatchedState(message);   // the Sweeper takes it from here
-
-        return true;
-    }
-
-    public Task<bool> ReplayCausationAsync(string causationId, RequestContext? requestContext,
-        Dictionary<string, object>? args = null, CancellationToken cancellationToken = default)
-        => Task.FromResult(ReplayCausation(causationId, requestContext, args));
-}
-```
-
-The Inbox side is the same shape: probe, store the Causation Id in `Add` when the probe says
-you can, and return it from `GetCausationId` — or `null`.
-
-### Registration
-
-Nothing extra to do. `AddProducers` checks whether your Outbox implements
-`IAmACausationTrackingOutbox` and registers the same instance under that interface as well.
-The Inbox handler takes it as an optional constructor dependency, so an Outbox that does not
-implement the role resolves to `null` and the handler degrades to a plain skip.
-
 ## Further Reading
 
 - [Inbox Support](/contents/BrighterInboxSupport.md) — configuring an Inbox, and the other
@@ -1147,6 +1028,8 @@ implement the role resolves to `null` and the handler degrades to a plain skip.
   run does, and what to check afterwards
 - [Pipeline Validation](/contents/PipelineValidation.md) — the startup checks, including the
   replay rule
+- [Implementing Causation Tracking in Your Own Store](/contents/CausationTrackingStores.md) —
+  the role interfaces to implement if you write your own Inbox or Outbox
 - [DynamoDb Outbox](/contents/DynamoOutbox.md) — including the Causation index replay needs
 - [Telemetry](/contents/Telemetry.md) — the tracing the span events attach to
 - [Glossary](/contents/Glossary.md) — Causation Id, Replay, Inbox, Outbox, Sweeper

--- a/contents/S3LuggageStore.md
+++ b/contents/S3LuggageStore.md
@@ -10,7 +10,7 @@ To use the **S3LuggageStore** you need to include the following NuGet package:
 **AWS SDK v4** (recommended for new projects):
 * **Paramore.Brighter.Transformers.AWS.V4**
 
-See [AWS Configuration](/contents/AWSSQSConfiguration.md#migration-guidance) for migration guidance between v3 and v4.
+See [AWS Configuration](/contents/AWSSQSConfiguration.md#migrating-from-aws-sdk-v3-to-v4) for migration guidance between v3 and v4.
 
 We then need to configure our **S3LuggageStore** and register it with our IoC container. Our **ClaimCheckTransformer** has a dependency on **IAmAStorageProviderAsync** and at runtime, when our [** **IAmAMessageTransformerFactory**](/contents/MessageMappers.md#message-transformer-factory) creates an instance it needs to be able to resolve that dependency. For this reason you need to register the implementation, in this case **S3LuggageStore** with the IoC container to allow it to resolve the dependency.
 

--- a/contents/ShowMeTheCode.md
+++ b/contents/ShowMeTheCode.md
@@ -215,7 +215,7 @@ services.AddProducers(options =>
 Once you're comfortable with these basics:
 
 1. **Add Transactional Messaging** - Use [DepositPost and ClearOutbox](/contents/BrighterOutboxSupport.md) for guaranteed message delivery
-2. **Add Deduplication** - Use [Inbox Pattern](/contents/InboxConfiguration.md) to handle duplicate messages
+2. **Add Deduplication** - Use [Inbox Pattern](/contents/BrighterInboxSupport.md) to handle duplicate messages
 3. **Production Outbox** - Replace InMemory with [database-backed Outbox](/contents/BrighterOutboxSupport.md)
 4. **Explore Samples** - See the [WebAPI Sample](https://github.com/BrighterCommand/Brighter/tree/master/samples/WebAPI) for production patterns
 

--- a/contents/V10MigrationGuide.md
+++ b/contents/V10MigrationGuide.md
@@ -512,7 +512,7 @@ new KafkaSubscription(
 );
 ```
 
-**See also**: [Dynamic Deserialization Documentation](/contents/DynamicDeserialization.md)
+**See also**: [Dynamic Deserialization Documentation](/contents/DynamicMessageDeserialization.md)
 
 ### 4. OpenTelemetry Semantic Conventions
 

--- a/contents/V10MigrationGuide.md
+++ b/contents/V10MigrationGuide.md
@@ -329,6 +329,33 @@ public class MyHandler : RequestHandlerAsync<MyCommand>
 }
 ```
 
+#### `InstrumentationOptions` (added in 10.7.0)
+
+**Breaking Change**: `IRequestContext` gains a required `InstrumentationOptions` member.
+
+It carries the instrumentation options configured for the pipeline that created the
+context, so middleware handlers can gate their own telemetry — on
+`InstrumentationOptions.Brighter`, for example — without needing to know how the
+Command Processor was configured.
+
+This is **source-breaking for direct implementors of `IRequestContext` only**.
+`Paramore.Brighter` targets `netstandard2.0`, which has no default interface members, so
+the member is plain and abstract: any third-party or test type implementing the interface
+fails to compile until it adds one line.
+
+```csharp
+public class MyRequestContext : IRequestContext
+{
+    // ... other members
+
+    // 10.7.0: add this
+    public InstrumentationOptions InstrumentationOptions { get; set; } = InstrumentationOptions.All;
+}
+```
+
+The shipped `RequestContext` already implements it, defaulting to
+`InstrumentationOptions.All`, so code that uses the shipped context needs no change.
+
 ### 6. Request Id and CorrelationId type change
 
 In V9 the `Request` type used a `Guid` to represent the identity of a `Command` or `Event`. In V10, as part of a move away from primitives, we have changed this to be a type `Id`. An `Id` can be constructed from a `string` using its `ToString()` method. If you have used a `Guid` then you will need to turn the `Guid` into a `string`.

--- a/spec/.current-spec
+++ b/spec/.current-spec
@@ -1,1 +1,1 @@
-007-distributed_lock
+008-replay_on_seen

--- a/spec/008-replay_on_seen/README.md
+++ b/spec/008-replay_on_seen/README.md
@@ -1,0 +1,66 @@
+# Spec 008: Replay On Seen
+
+**Created:** 2026-08-01
+**Status:** Implementation Phase — requirements, design, and tasks all approved
+(2026-08-01 / 2026-08-02 / 2026-08-02)
+
+## Topic Overview
+
+Brighter's Inbox provides duplicate detection via the `UseInbox`/`OnceOnly`
+attribute. Historically, when the Inbox saw a message it had already processed it
+either threw (`OnceOnlyAction.Throw`) or warned and skipped (`OnceOnlyAction.Warn`) —
+in neither case were the downstream messages originally produced by that handler
+resent. That leaves no way to re-trigger a partially-completed workflow: the handler
+is correctly skipped, but the consumers downstream of it never hear anything.
+
+**Replay on seen** closes that gap. A **Causation Id** links an incoming Inbox entry
+to the outgoing Outbox messages produced while handling it. When the Inbox detects a
+duplicate and replay is enabled, Brighter clears `DispatchedAt` on the Outbox messages
+sharing that Causation Id, so the Outbox Sweeper re-dispatches the *same* outgoing
+messages. The handler is not re-executed; only its direct effects are replayed.
+
+This documentation needs to explain what Causation Id is (and how it differs from
+Correlation Id), how to enable replay on duplicate detection, the prerequisites
+(an Outbox, a Sweeper, and store support for `CausationId`), the schema evolution
+delivered through BoxProvisioning, the startup pipeline validation that guards the
+configuration, and the observability and gotchas around replay.
+
+**Primary source material:**
+
+- Brighter spec: `../Brighter/specs/0027-replay-matching-outbox-events-when-inbox-has-already-seen/`
+  (`README.md`, `requirements.md`, `tasks.md`, and the review documents)
+- ADR: `../Brighter/docs/adr/0057-replay-outbox-on-inbox-duplicate.md`
+- Tests: `../Brighter/tests/Paramore.Brighter.Core.Tests/OnceOnly/When_a_seen_message_is_replayed_end_to_end.cs`
+- Linked issue: BrighterCommand/Brighter#2541
+- Release notes: `../Brighter/release_notes.md`
+
+## Status Checklist
+
+- [x] Requirements gathered (`requirements.md`)
+- [x] Requirements reviewed and approved (2026-08-01)
+- [x] Documentation outline created (`design.md`)
+- [x] Outline reviewed and approved (2026-08-02)
+- [x] Writing tasks identified (`tasks.md`)
+- [x] Tasks reviewed and approved (2026-08-02)
+- [ ] Writing complete
+- [ ] Documentation reviewed
+- [ ] Spec closed
+
+## Next Steps
+
+1. Review existing documentation in SUMMARY.md for related content
+   (Inbox / `OnceOnly`, Outbox, Outbox Sweeper, BoxProvisioning / database migration,
+   pipeline validation at startup — see specs 003 and 005)
+2. Identify source material (source code, ADRs, release notes, samples)
+3. Identify gaps in current documentation
+4. Create requirements document
+5. Get requirements approved before proceeding
+
+## Notes
+
+- Follow CLAUDE.md guidelines for documentation standards
+- Reference source code in ../Brighter and ../Darker as needed
+- Ensure SUMMARY.md is updated when new files are created
+- Related existing specs: `003-pipeline-validation-at-startup` (validation of the
+  replay configuration at startup) and `005-database_migration` (BoxProvisioning,
+  which delivers the `CausationId` column)

--- a/spec/008-replay_on_seen/README.md
+++ b/spec/008-replay_on_seen/README.md
@@ -1,8 +1,7 @@
 # Spec 008: Replay On Seen
 
 **Created:** 2026-08-01
-**Status:** Implementation Phase — requirements, design, and tasks all approved
-(2026-08-01 / 2026-08-02 / 2026-08-02)
+**Status:** Writing and review complete (2026-08-03) — ready to close
 
 ## Topic Overview
 
@@ -42,9 +41,52 @@ configuration, and the observability and gotchas around replay.
 - [x] Outline reviewed and approved (2026-08-02)
 - [x] Writing tasks identified (`tasks.md`)
 - [x] Tasks reviewed and approved (2026-08-02)
-- [ ] Writing complete
-- [ ] Documentation reviewed
+- [x] Writing complete (2026-08-03)
+- [x] Documentation reviewed (2026-08-03)
 - [ ] Spec closed
+
+### Closing note (2026-08-03)
+
+All 33 tasks complete; every requirement P0-1 through P2-20 is covered. **Nothing was
+dropped** — including P2-19, which the tasks flagged as the item to cut if effort ran
+short.
+
+**Deliverables:** `contents/ReplayOnSeen.md` (1,037 lines) and
+`contents/CausationTrackingStores.md` (151 lines), plus updates to nine existing pages
+(`BrighterInboxSupport`, `BrighterOutboxSupport`, `BrighterBasicConfiguration`,
+`PipelineValidation`, `DynamoOutbox`, `Glossary`, `BoxProvisioning`,
+`BoxProvisioningUpgrade`, `V10MigrationGuide`) and two `SUMMARY.md` entries.
+
+**QA checklist result:**
+
+- *Code* — all 12 examples verified against V10 source in Task 4.3. Every C# block is
+  fenced `csharp`; the three unlabelled fences are plain-text output (the flow diagram
+  and two quoted log blocks) and correctly carry no language. Three defects were found
+  and fixed, notably two quoted validation errors naming stores that always implement
+  the role interfaces and so could never produce them.
+- *Content* — terminology matches the Glossary and design §Style Notes (Task 4.5, 5
+  fixes). No "idempotent"; "cascade" stays descriptive; the page title never leaks into
+  prose as a pseudo-term.
+- *Structure* — both pages are in `SUMMARY.md`; `linkcheck.py` exits 0 across 108 files;
+  each page ends in Further Reading.
+- *Accuracy* — claims checked against source, not release notes alone. The
+  `CausationIndexName` guidance was reversed to match `DynamoDbConfiguration.cs`, which
+  says "Leave this at the default".
+
+**Deliberate deviations, all recorded in `design.md` §Style Notes:** no Sample Code
+section (no sample in `Brighter/samples/` uses replay — the end-to-end test is cited
+instead); "You Must Thread Your RequestContext" is an H2 prerequisite rather than a
+pitfall; store support is a matrix rather than per-store pages; and the
+`BoxProvisioning.md` corrections belong to spec 005's pages but are fixed here.
+
+**Known gap, out of scope:** `ReplayOnSeen.md` is 1,037 lines against a design target of
+450–520. The target was mis-estimated at design time by roughly 2.2×, not overrun; the
+sanctioned custom-store split removed 128 lines and could not close that distance. The
+page sits within repo norms (`QueryPatterns.md` 1,289; `CQRSWithBrighterAndDarker.md`
+1,142). See Task 4.2 for the full reasoning.
+
+Separately, Task 4.4 recorded 10 pre-existing orphan pages absent from `SUMMARY.md`,
+none introduced by this spec. They deserve their own change.
 
 ## Next Steps
 

--- a/spec/008-replay_on_seen/design.md
+++ b/spec/008-replay_on_seen/design.md
@@ -1,0 +1,487 @@
+# Design: Spec 008 — Replay On Seen
+
+**Created:** 2026-08-01
+**Status:** Approved 2026-08-02
+**Traces to:** `requirements.md` (approved 2026-08-01)
+
+Scope items are referenced as **[P0-n]**, **[P1-n]**, **[P2-n]** throughout, matching
+the numbered list in `requirements.md`.
+
+## Documentation Structure
+
+One new page carries the feature. Seven existing pages gain a hook into it, so a
+reader arriving from any direction — the Inbox, the Outbox, a validation error, a
+DynamoDB table, the Glossary — finds their way in.
+
+```
+contents/
+├── ReplayOnSeen.md                 ← NEW. The feature page.
+│
+├── BrighterInboxSupport.md         ← Replay row in the OnceOnlyAction table  [P0-9]
+├── BrighterOutboxSupport.md        ← note in "You always need a Sweeper"     [P0-7]
+├── BrighterBasicConfiguration.md   ← Replay in the ActionOnExists bullet     (added at review)
+├── PipelineValidation.md           ← ReplayRequiresCausationTracking rule    [P1-12]
+├── DynamoOutbox.md                 ← the Causation GSI section               [P1-11]
+├── BoxProvisioning.md              ← corrected version matrix                [P0-10]
+├── BoxProvisioningUpgrade.md       ← refreshed V-current examples            [P0-10]
+├── Glossary.md                     ← Causation Id, Replay (Inbox)            [P1-15]
+└── V10MigrationGuide.md            ← IRequestContext.InstrumentationOptions  [P2-19]
+```
+
+### Reading order
+
+The page assumes the reader knows what an Inbox and an Outbox are. It does not
+re-teach them.
+
+```
+BrighterInboxSupport.md  ─┐
+BrighterOutboxSupport.md ─┼─►  ReplayOnSeen.md  ─┬─►  BoxProvisioning.md      (migrate the schema)
+PipelineValidation.md    ─┘                      ├─►  DynamoOutbox.md         (create the GSI)
+                                                 ├─►  PipelineValidation.md   (read the findings)
+                                                 └─►  Telemetry.md            (trace the replay)
+```
+
+Within `ReplayOnSeen.md` the order is deliberately **problem → concept → cascade →
+turn it on → prove it works → what breaks it**. The cascade comes before
+configuration because a reader who has not grasped that every step needs its own
+`Replay` will configure one handler and conclude the feature is broken.
+
+## File-by-File Outline
+
+---
+
+### 1. `contents/ReplayOnSeen.md` — NEW
+
+**Purpose:** Explain what replay on seen does, when to reach for it, how to turn
+it on, and every way it can silently fail to fire.
+
+**Target length:** 450–520 lines. Deliberately over the 400 first floated at
+design review: all P2 content is **kept** (the walkthrough, the custom-store
+notes, and the design-rationale section), and completeness is worth the length
+here. `CLAUDE.md` suggests considering a split past ~500 lines — if the page
+lands materially above that, split the **custom-store implementation notes**
+[P2-18] into their own page rather than cutting reader-facing material. That is
+the only section aimed at a different audience (people writing a store, not
+people using one), so it is the clean seam.
+
+**Type:** Conceptual + how-to hybrid (per `CLAUDE.md` documentation types).
+
+#### Section outline
+
+```
+# Replay On Seen                                                    (H1)
+
+  Intro — 3 sentences. A duplicate normally means "skip". Replay makes it
+  mean "resend what this step already produced". Links: Inbox, Outbox.
+
+## The Problem: A Workflow That Stalls Halfway                      (H2)   [P0-1]
+  - Concrete scenario: Order → Payment → Shipping. Payment's handler ran and
+    deposited ShipOrder, but Shipping never processed it.
+  - Re-send OrderPlaced today: the Inbox throws or warns. Nothing moves.
+  - Why the Inbox alone is not idempotency: it protects the handler's side
+    effects but swallows the messages downstream steps are waiting for.
+
+## How Replay Walks the Flow Forward                                (H2)   [P0-1]
+  - The cascade, stated plainly: re-send the message at the front; every
+    handler that already ran skips its work but re-raises what it produced;
+    the flow advances a step at a time until it reaches the handler that
+    never ran, which executes normally.
+  - Explicit: the handler is NOT re-executed. The *same* stored messages are
+    re-dispatched — not newly generated ones. (Why that matters: state may
+    have moved on; regenerating could produce different messages.)
+  - Callout box: **every already-seen step needs `OnceOnlyAction.Replay`.** A
+    step still set to Throw or Warn stops the cascade dead and the flow never
+    reaches the failure.                                                   [P0-8]
+
+## Causation Id                                                     (H2)   [P0-2]
+  - Definition: one handler invocation's outgoing messages share one Causation
+    Id. Default value is the request's `Id`.
+  - How it travels: `RequestContext.Bag`, key `RequestContextBagNames.CausationId`
+    (`"Brighter-CausationId"`). The Inbox stamps it; the Outbox `Add` reads it.
+  - Distinguish from **Correlation Id** (request-reply). One sentence, no more.
+  - Stored in both boxes — that is what lets a duplicate find its own messages.
+
+### What Happens on a Duplicate                                     (H3)   [P0-3]
+  - Flow diagram (fenced text, adapted from ADR 0057).
+  - Numbered walkthrough matching the diagram: Exists() → true; action is
+    Replay; GetCausationId from the Inbox; ReplayCausation on the Outbox
+    clears DispatchedAt; handler returns without running; the Sweeper
+    re-dispatches on its next pass.
+  - State the latency consequence: replay is not immediate — it happens on the
+    Sweeper's next interval.
+
+## Turning It On                                                    (H2)   [P0-4]
+
+### On a Handler                                                    (H3)
+  - `[UseInbox(...onceOnlyAction: OnceOnlyAction.Replay)]` — Example 1.
+  - Async variant — Example 2. Link to pipelines-must-be-homogeneous.
+
+### Globally                                                        (H3)
+  - `AddConsumers(options => options.InboxConfiguration = new InboxConfiguration(
+    ..., actionOnExists: OnceOnlyAction.Replay))` — Example 3.
+  - Note `ActionOnExists` is constructor-set, not a settable property.
+  - Cross-link BrighterBasicConfiguration.md#inbox.
+
+## You Must Thread Your RequestContext                              (H2)   [P0-5]
+  - Its own H2, immediately after configuration — this is the failure everyone
+    hits. Warning callout.
+  - Why: the causation id lives in the pipeline's RequestContext.Bag. Post
+    without a context and the CommandProcessor makes a fresh one; the id is
+    lost; the message stores a null CausationId; replay later matches nothing.
+  - ❌ / ✅ pair — Example 4.
+  - Applies to Post, PostAsync, DepositPost, DepositPostAsync.
+  - Symptom to recognise: replay runs, logs nothing wrong, resends nothing.
+
+## Before You Enable It                                             (H2)   [P0-6, P0-7]
+  - Checklist table: requirement | how to satisfy | what happens if you don't.
+    - Inbox implements IAmACausationTrackingInbox
+    - Outbox implements IAmACausationTrackingOutbox
+    - store schema migrated (SupportsCausationTracking() true)
+    - an Outbox Sweeper is running
+    - handlers thread Context
+    - every already-seen step set to Replay
+  - Sweeper sub-point: replay only ever happens through the Sweeper — there is
+    no immediate-send path. Link to "You always need a Sweeper" rather than
+    restating it; that section already covers the in-memory Outbox and the
+    RabbitMQ/Kafka async-confirmation case.
+
+## Store Support                                                    (H2)   [P1-11]
+  - Matrix table: store | Inbox | Outbox | what you must do first.
+  - Relational: Outbox V8 / Inbox V3 (PostgreSQL Inbox V2) via BoxProvisioning.
+  - Spanner: via its provisioner; live column probe.
+  - MongoDb, Firestore: schemaless, nothing to do.
+  - DynamoDB: Inbox nothing to do; **Outbox needs the Causation GSI** → link to
+    DynamoOutbox.md.
+  - In-memory: works, development only.
+  - Note: the column is `causationid` on PostgreSQL, `CausationId` elsewhere.
+
+## When Replay Does Not Fire                                        (H2)   [P1-12, P1-16]
+  - Startup findings table: finding | severity | cause | fix. Five rows from
+    the ReplayRequiresCausationTracking rule.
+  - Then the runtime silences (no startup error, nothing resent):
+    - handler did not thread Context → null CausationId
+    - entry predates the migration → null CausationId, no backfill
+    - a downstream step is set to Throw/Warn → cascade stops there
+    - custom IAmARequestContextFactory returning a non-RequestContext →
+      one-time CustomContextDisablesReplay warning
+    - no Outbox at all (terminal step) → safe no-op, validation warns
+
+## Upgrading Without Migrating                                      (H2)   [P1-13]
+  - The write-path gate: relational stores probe once per store instance for
+    the causation column and fall back to the old INSERT when absent, so
+    deposits are unchanged on an un-migrated schema.
+  - Consequence: the probe result is memoized and never invalidated —
+    provisioning that runs after a store instance was built needs a restart.
+  - Link BoxProvisioningUpgrade.md.
+
+## Observability                                                    (H2)   [P1-14]
+  - Span events table: path | event name | tags.
+  - The paramore.brighter.causation_id tag on the Replay event.
+  - CustomContextDisablesReplay warning log.
+  - Why the re-dispatch is a separate trace with no parent link (the sweep is
+    asynchronous and may carry many replays).
+  - Link Telemetry.md.
+
+## Limitations                                                      (H2)   [P1-16]
+  - Not saga orchestration: no coordinator, no compensation, no ordering.
+  - Shared Causation Id when one message id reaches several [UseInbox]
+    handlers — a replay resends all of them. Intended; note UseInbox is
+    normally on Commands (one handler). Escape hatch: set your own Causation
+    Id in the Bag before the Inbox handler runs.
+  - Sweeper race: a message may go twice. Downstream de-duplication handles it.
+  - Historical rows have no Causation Id and can never be replayed.
+
+## A Worked Example                                                 (H2)   [P2-17]
+  - The end-to-end scenario from the test: command handled and a downstream
+    event deposited; the same command posted again; the event re-sent without
+    the handler running. Narrate it as numbered steps against Example 5's
+    handlers, noting what each store holds at each point.
+  - Cite the test as the reference implementation (there is no sample app).
+
+## Why It Works This Way                                            (H2)   [P2-20]
+  - Short rationale section, three paragraphs, drawn from ADR 0057's
+    Alternatives Considered:
+    - Why not re-execute the handler? That defeats the Inbox — the whole point
+      is that re-running is unsafe — and state may have moved on, so it could
+      produce *different* messages. Replay resends the originals.
+    - Why not reuse `CorrelationId`? It means request-reply; overloading it
+      would conflate two unrelated relationships.
+    - Why the Sweeper rather than an immediate send? The dispatch machinery
+      already exists; replay only has to mark messages undispatched.
+
+## Implementing Causation Tracking in Your Own Store                (H2)   [P2-18]
+  - For readers writing a custom Inbox or Outbox, not for users.
+  - The two role interfaces and what each method must do.
+  - `SupportsCausationTracking()` must report the **live** state honestly —
+    it is a runtime probe, not a static capability, because pipeline
+    validation trusts it to decide whether Replay can work.
+  - Skeleton — Example 12.
+
+## Further Reading                                                  (H2)
+  - Inbox Support, Outbox Support, Outbox Pattern, Box Provisioning,
+    Upgrading Existing Deployments, Pipeline Validation, DynamoDb Outbox,
+    Telemetry, Glossary.
+  - ADR 0057 for the full design record.
+```
+
+**Glossary terms used:** Inbox, Outbox, Sweeper, Migration Chain (all existing);
+**Causation Id**, **Replay** (both new — defined here, summarised in the Glossary).
+
+**Cross-links out:** `BrighterInboxSupport.md`, `BrighterOutboxSupport.md`
+(`#you-always-need-a-sweeper`), `OutboxPattern.md`, `BrighterBasicConfiguration.md#inbox`,
+`BoxProvisioning.md`, `BoxProvisioningUpgrade.md`, `PipelineValidation.md`,
+`DynamoOutbox.md`, `Telemetry.md`, `Glossary.md`,
+`BuildingAnAsyncPipeline.md` (Russian Doll), `DispatchingARequest.md#pipelines-must-be-homogeneous`.
+
+**All P2 content is included** — the walkthrough [P2-17], the custom-store notes
+[P2-18], and the rationale section [P2-20]. Nothing here is conditional on length.
+
+---
+
+### 2. `contents/BrighterInboxSupport.md` — UPDATE  [P0-9]
+
+**Purpose of change:** The `OnceOnlyAction` list and behaviour table are the
+canonical reference for what a duplicate does. They currently know only two of
+three actions.
+
+| Location | Change |
+| :--- | :--- |
+| Line 35–38 (the `OnceOnlyAction` bullet) | Add a third sub-bullet: `Replay` — resend the messages this handler produced the first time, without re-running it. Link `ReplayOnSeen.md`. |
+| Lines 41–45 (behaviour table) | Add one row: `true` / `Replay` → "If a duplicate is found, replays the Outbox messages produced during the original handling and **stops** processing. Otherwise, processes it." |
+| After the table (~line 47) | Two-sentence paragraph pointing at `ReplayOnSeen.md`, naming the prerequisites in one breath (causation-tracking stores, migrated schema, a Sweeper) so nobody enables it from this page alone. |
+
+**Do not** expand this page further — the Inbox page stays about the Inbox.
+
+---
+
+### 3. `contents/BrighterOutboxSupport.md` — UPDATE  [P0-7]
+
+**Purpose of change:** A reader on the Outbox page should learn that something
+outside the Outbox can reset dispatch state.
+
+| Location | Change |
+| :--- | :--- |
+| `### You always need a Sweeper` (line 182) | Append a short paragraph: replay clears `DispatchedAt` so the Sweeper resends — it is the *only* replay path, there is no immediate-send equivalent. Link `ReplayOnSeen.md`. |
+| `### Consumer: Using Inbox for Deduplication` (line 432) | One sentence at the end: if a duplicate should push a stalled flow forward rather than be dropped, see `ReplayOnSeen.md`. |
+
+That section already explains the in-memory Outbox's Sweeper dependency and the
+RabbitMQ/Kafka asynchronous-confirmation case, so the new page **links** here
+rather than repeating it.
+
+---
+
+### 4. `contents/BrighterBasicConfiguration.md` — UPDATE  *(added at design review, approved 2026-08-02)*
+
+Found while designing the global-configuration example: line 884 enumerates
+`ActionOnExists` as "`OnceOnlyAction.Throw` … the alternative is
+`OnceOnlyAction.Warn`" — a closed list of two, now wrong. The change is one
+sentence.
+
+| Location | Change |
+| :--- | :--- |
+| Line 884 (`ActionOnExists` bullet) | Add `OnceOnlyAction.Replay` as the third option, one clause, linking `ReplayOnSeen.md`. |
+
+---
+
+### 5. `contents/PipelineValidation.md` — UPDATE  [P1-12]
+
+| Location | Change |
+| :--- | :--- |
+| `### Handler Pipeline Checks (AddBrighter)` rule table (~line 38) | Add one row: **Replay requires causation tracking** / Error + Warning / "When a pipeline is configured with `OnceOnlyAction.Replay`, checks that the Inbox and Outbox both implement causation tracking and that their schemas support it." |
+| "Example error messages" block (~line 44) | Add two of the five messages verbatim — one Error (Outbox missing the interface), one Warning (schema not migrated). |
+| End of `## Common Mistakes and Fixes` — **after the `### Missing Handler for Subscription` section ends, immediately before `## Further Reading` (line 323)** | New `### Replay Without Causation Tracking` following the established **Before** (warning) / **After** (fixed) shape — Example 7. |
+
+The five findings enumerated in full belong on `ReplayOnSeen.md`; this page keeps
+its existing summary-table density.
+
+---
+
+### 6. `contents/DynamoOutbox.md` — UPDATE  [P1-11]
+
+**Purpose of change:** This is the one store where Replay needs infrastructure
+Brighter does not provision. The page has **no** table-provisioning content
+today, so this is new material rather than an amendment.
+
+| Location | Change |
+| :--- | :--- |
+| New `## Replay Support: The Causation Index` after the handler example (~line 89) | New table → the GSI comes for free from `DynamoDbTableFactory` (Example 8). Existing table → an explicit `UpdateTable` with `GlobalSecondaryIndexUpdates` (Example 9). Note AWS backfills a GSI asynchronously, so `SupportsCausationTracking()` — a live `DescribeTable` probe — keeps reporting false until the index is `ACTIVE`; a restart immediately after adding it will still fail validation. Consequence of skipping: validation reports the Outbox unsupported and Replay never fires. Link `ReplayOnSeen.md`. |
+
+Index name comes from `DynamoDbConfiguration.CausationIndexName`, default
+`"Causation"` — state the default and that it is configurable.
+
+---
+
+### 7. `contents/BoxProvisioning.md` — UPDATE  [P0-10]
+
+**These are factual corrections, not additions.** The page currently states
+versions the shipped catalogs contradict.
+
+| Location | Current | Correct to |
+| :--- | :--- | :--- |
+| Line 93 (MSSQL row) | Outbox `V1..V7`, Inbox `V1..V2` | Outbox `V1..V8`, Inbox `V1..V3` |
+| Line 94 (PostgreSQL row) | Outbox `V1..V7`, Inbox `V1 only` | Outbox `V1..V8`, Inbox `V1..V2` |
+| Line 95 (MySQL row) | Outbox `V1..V7`, Inbox `V1..V2` | Outbox `V1..V8`, Inbox `V1..V3` |
+| Line 96 (SQLite row) | Outbox `V1..V7`, Inbox `V1..V2` | Outbox `V1..V8`, Inbox `V1..V3` |
+| Line 101 (version prose) | "…V7 added `DataRef` and `SpecVersion`" | Append: "V8 added `CausationId` and the replay index." |
+| Line 108 (asymmetry table) | "PostgreSQL — Inbox is V1-only" | Now V1..V2; rewrite as "the PostgreSQL Inbox chain is one version shorter than the others" |
+| Line 116 (the V1-only explanation) | "…no V2 exists. The chain is intentionally shorter." | Keep the historical explanation for why PostgreSQL skipped the `ContextKey` migration, but correct the conclusion: it now has a V2 — the `causationid` migration — so the chain is shorter by one, not absent. |
+
+Also add: the Outbox V8 migration is the first to create an **index** rather than
+only columns.
+
+**Verify every number against the `*MigrationCatalog.cs` sources when writing** —
+per the requirements' accuracy constraint. Values confirmed at design time:
+MsSql/MySql/PostgreSql/Sqlite Outbox `Version: 8`; MsSql/MySql/Sqlite Inbox
+`Version: 3`; PostgreSql Inbox `Version: 2, Description: "Add causationid column"`.
+
+---
+
+### 8. `contents/BoxProvisioningUpgrade.md` — UPDATE  [P0-10]
+
+| Location | Change |
+| :--- | :--- |
+| Line 15 | "originally created at V4 and the current Brighter ships V7 … applies V5, V6, V7" → ships **V8**, applies V5–V8 |
+| Line 63 | "originally at V4 against a Brighter release that ships V7" → **V8** |
+| Line 79 | "New columns added by V5–V7" → **V5–V8** |
+| Line 130 | "If V5, V6, and V7 are pending and V7 fails" → **V5–V8 pending and V8 fails** |
+| `## What to verify after upgrade` (~line 53) | New bullet: if you intend to use Replay, verify the causation column landed — until it does, `SupportsCausationTracking()` returns false and startup validation warns. Link `ReplayOnSeen.md`. |
+
+The sample log output at line 63 must be regenerated consistently, not
+hand-patched — check every version number in that block.
+
+---
+
+### 9. `contents/Glossary.md` — UPDATE  [P1-15]
+
+Two entries, following the existing `### Term` / definition / `See:` shape.
+
+| Term | Placement | Definition sketch |
+| :--- | :--- | :--- |
+| **Causation Id** | `## Patterns`, after `### Inbox` (line ~179) | The identifier linking an Inbox entry to the Outbox messages produced while handling it. One handler invocation's outgoing messages share one Causation Id; it defaults to the request's id. Distinct from Correlation Id, which links a request to its reply. `See: [Replay On Seen](/contents/ReplayOnSeen.md)` |
+| **Replay (Inbox)** | Immediately after Causation Id | The `OnceOnlyAction` that makes duplicate detection re-dispatch the Outbox messages produced during the original handling, instead of throwing or warning. The handler does not re-run. `See: [Replay On Seen](/contents/ReplayOnSeen.md)` |
+
+**Also fix while in this file (approved 2026-08-02):** `Glossary.md:178` — the
+existing `### Inbox` entry links to `/contents/InboxConfiguration.md`, **which
+does not exist and never has** (no history for that path in this repo, so the
+link was wrong when written). Retarget to
+`/contents/BrighterInboxSupport.md#inbox-configuration` — that heading exists
+(`BrighterInboxSupport.md:67`), it preserves the "Inbox Configuration" link text,
+and it matches the sibling `### Outbox` entry's pattern of deep-linking into the
+support page. Unrelated to this feature; fixed opportunistically.
+
+---
+
+### 10. `contents/V10MigrationGuide.md` — UPDATE  [P2-19]
+
+| Location | Change |
+| :--- | :--- |
+| Breaking-changes section | Short entry: `IRequestContext` gains a required `InstrumentationOptions` member. Source-breaking for anyone implementing the interface directly; the shipped `RequestContext` already has it, so normal call sites are unaffected. One-line fix snippet — Example 11. |
+
+Lowest priority in the spec. Drop if effort is constrained; it affects only
+custom `IRequestContext` implementors.
+
+## SUMMARY.md Changes
+
+**Before** (lines 81–82):
+
+```markdown
+ * [Inbox Support](/contents/BrighterInboxSupport.md)
+ * [MSSQL Outbox](/contents/MSSQLOutbox.md)
+```
+
+**After:**
+
+```markdown
+ * [Inbox Support](/contents/BrighterInboxSupport.md)
+ * [Replay On Seen](/contents/ReplayOnSeen.md)
+ * [MSSQL Outbox](/contents/MSSQLOutbox.md)
+```
+
+Single insertion, one line, unnested — consistent with every other page in the
+**Outbox and Inbox** section except the Distributed Lock provider group, where
+nesting signals "one of N implementations".
+
+## Code Examples Plan
+
+| # | Example | Source | Complete or abbreviated | Goes in |
+| :-- | :--- | :--- | :--- | :--- |
+| 1 | Handler with `[UseInbox(..., onceOnlyAction: OnceOnlyAction.Replay, contextKey: ...)]` | `Core.Tests/OnceOnly/TestDoubles/ProcessAndForwardHandler.cs:55` | Complete (handler + attribute) | ReplayOnSeen |
+| 2 | `[UseInboxAsync(...)]` variant | Adapted from Example 1 + `BrighterInboxSupport.md:58` | Complete | ReplayOnSeen |
+| 3 | Global config: `AddConsumers(options => options.InboxConfiguration = new InboxConfiguration(inbox: …, actionOnExists: OnceOnlyAction.Replay))` | Shape from `BrighterBasicConfiguration.md:905`; params verified against `InboxConfiguration.cs:70` | Abbreviated (`// ...` around it) | ReplayOnSeen |
+| 4 | ❌ `Post(evt)` vs ✅ `Post(evt, Context)` | `release_notes.md:315–330`, real form at `ProcessAndForwardHandler.cs:65` (`Context as RequestContext`) | Complete pair | ReplayOnSeen |
+| 5 | Two-step cascade: `ProcessPayment` (already seen, Replay) → `ShipOrder` (never ran) | Written from scratch, modelled on `ProcessAndForwardHandler` | Complete, both handlers | ReplayOnSeen |
+| 6 | Sweeper registration `.UseOutboxSweeper(...)` | `BrighterOutboxSupport.md:253` | Abbreviated | ReplayOnSeen |
+| 7 | Validation Before/After — Replay configured against a non-tracking Outbox | Messages from ADR 0057 validation rule | Complete pair | PipelineValidation |
+| 8 | New DynamoDB table incl. the Causation GSI via `DynamoDbTableFactory.GenerateCreateTableRequest<MessageItem>(...)` | `DynamoDbTableFactory.cs:60`; GSI attribute at `MessageItem.cs:49` | Abbreviated | DynamoOutbox |
+| 9 | `UpdateTable` adding the Causation GSI to an existing table | Written from scratch against the AWS SDK; index name from `DynamoDbConfiguration.cs:71` | Complete | DynamoOutbox |
+| 10 | Flow diagram, duplicate → replay → sweep | ADR 0057 "Architecture Overview", trimmed | Fenced text, not code | ReplayOnSeen |
+| 11 | `public InstrumentationOptions InstrumentationOptions { get; set; } = InstrumentationOptions.All;` | `release_notes.md:338` | Snippet | V10MigrationGuide |
+| 12 | *(P2)* Skeleton `IAmACausationTrackingOutbox` implementation | `IAmACausationTrackingOutbox.cs` | Abbreviated | ReplayOnSeen |
+
+**Verification rule:** examples 5 and 9 are the only ones written from scratch and
+so carry the most risk. Both must be checked against the real APIs as they are
+written — spec 007 shipped two example defects that a QA pass caught late.
+
+Examples 1, 2, 4 use `MyCommand`/`MyEvent` in the test source; rename to the
+Order/Payment/Shipping domain used throughout this page, per the "realistic
+examples" standard.
+
+## Style Notes
+
+**Terminology decisions:**
+
+- **Causation Id** — spaced and capitalised as the concept; `CausationId` when
+  naming the property or a non-PostgreSQL column. In cross-store prose use "the
+  causation column" — PostgreSQL's is lowercase `causationid` by design.
+- **Replay** as the action; `OnceOnlyAction.Replay` when naming the enum member.
+  The page title is "Replay On Seen" but the running prose says "replay" — avoid
+  turning the page title into a pseudo-term.
+- **Cascade** — used descriptively for the step-by-step advance. Not introduced as
+  a formal term and not added to the Glossary; there is no matching type or API.
+- Avoid "idempotent" as a description of what this achieves. The page's argument
+  is that the Inbox is *not* idempotency, which is precisely why Replay exists.
+- **Sweeper**, **Inbox**, **Outbox**, **Dispatcher** per the Glossary.
+
+**Deviations from standard patterns:**
+
+1. **"You Must Thread Your RequestContext" gets its own H2** rather than living
+   under Common Pitfalls. It is a *prerequisite*, not a pitfall — get it wrong and
+   the feature does nothing, with no error anywhere. It sits immediately after
+   configuration so it cannot be skipped.
+2. **No "Sample Code" section.** No sample in `Brighter/samples/` uses Replay
+   (open question 2 in the requirements). Rather than an empty heading, the
+   worked example cites the end-to-end test as the reference implementation.
+3. **Store support is a matrix, not per-store pages.** Only DynamoDB needs
+   store-specific instructions, and those go on the existing `DynamoOutbox.md`
+   rather than a new page.
+4. **`BoxProvisioning.md` changes are corrections to another spec's pages**
+   (spec 005). Called out so the reviewer can split them off if preferred; the
+   recommendation is to keep them here, since they are wrong today and this is the
+   change that makes them wrong.
+
+## Resolved at Design Review (2026-08-02)
+
+1. **`BrighterBasicConfiguration.md` is in scope** — added as section 4. Its
+   `ActionOnExists` bullet presents a closed list of two actions and is now wrong.
+2. **The broken Glossary link is fixed here** — retargeted to
+   `/contents/BrighterInboxSupport.md#inbox-configuration` (section 9). The old
+   target never existed in this repo.
+3. **All P2 content is kept and the page may exceed 400 lines** — target raised to
+   450–520. If it lands materially past 500, split out the custom-store notes
+   [P2-18] rather than cutting anything a *user* reads.
+4. **The design-rationale material is a real section again** — "Why It Works This
+   Way" [P2-20], rather than being dissolved into other sections as the first
+   draft had it.
+5. **`PipelineValidation.md` insertion point made precise** — end of Common
+   Mistakes, before `## Further Reading` (line 323), not after line 302.
+
+**Known-unverified link:** `BrighterBasicConfiguration.md#inbox` targets a heading
+written as `#### **Inbox**` (bold inside the heading), so the generated anchor may
+not be literally `#inbox`. Three existing pages already use this exact link
+(`BrighterInboxSupport.md:69`, `DynamoInbox.md:4`, `MongoDBInbox.md:4`); follow the
+established convention rather than inventing a variant. If it is broken it is
+broken repo-wide and is a separate fix.
+
+---
+
+**Next step:** run `/spec:tasks` to build the writing task list.

--- a/spec/008-replay_on_seen/requirements.md
+++ b/spec/008-replay_on_seen/requirements.md
@@ -1,0 +1,337 @@
+# Requirements: Spec 008 — Replay On Seen
+
+**Created:** 2026-08-01
+**Status:** Approved 2026-08-01
+
+## Topic Overview
+
+Brighter's [Inbox](/contents/BrighterInboxSupport.md) de-duplicates incoming requests. Until now, when the Inbox saw a request it had already handled it could only *throw* (`OnceOnlyAction.Throw`) or *warn and skip* (`OnceOnlyAction.Warn`).
+In both cases the messages the handler originally produced stay put — so there is no way to nudge a stalled workflow forward by replaying it from the beginning, with handlers that have already processed a message, re-sending the messages they in turn raised, thus triggering the next step. Eventually the flow reaches an unvisited handler, which runs as normal.
+
+**Replay on seen** adds a third option, `OnceOnlyAction.Replay`. When the Inbox detects a duplicate, Brighter looks up the **Causation Id** recorded against that Inbox entry, finds the Outbox messages stamped with the same Causation Id, and
+clears their dispatched state. The Outbox Sweeper then re-dispatches those *same* messages. The handler itself is **not** re-run — only its direct effects (the outgoing messages) are replayed.
+
+This matters because the Inbox alone does not give you true idempotency. Skipping a duplicate protects the handler's side effects, but it also swallows the outgoing messages that downstream steps depend on. Replay closes that hole: re-send the
+original command and the workflow picks up from wherever it stalled.
+
+The feature is **opt-in**, and it has real prerequisites — a causation-tracking Inbox *and* Outbox, a migrated store schema, a running Sweeper, and handlers that thread their `RequestContext` through `Post`/`DepositPost`. Miss the last one and replay is a **silent no-op**. Documentation needs to make each prerequisite unmissable.
+
+## Current State
+
+**What exists today:**
+
+| Page | Relevance | Gap |
+| :--- | :--- | :--- |
+| `contents/BrighterInboxSupport.md` (129 lines) | The home of `OnceOnly` / `OnceOnlyAction` | Documents only `Warn` and `Throw`. The behaviour table at lines 41–45 is now incomplete. No mention of Causation Id or Replay. |
+| `contents/BrighterOutboxSupport.md` (510 lines) | Outbox and Sweeper behaviour | No mention that dispatched state can be cleared by an external trigger, or of the `CausationId` column. |
+| `contents/PipelineValidation.md` (331 lines) | Startup validation rules and "Common Mistakes and Fixes" | The new `ReplayRequiresCausationTracking` rule is undocumented; its five distinct findings have no fix guidance. |
+| `contents/BoxProvisioning.md` | Per-backend migration-version matrix (lines 93–96) | **Stale.** Matrix says Outbox `V1..V7` and Inbox `V1..V2` (PostgreSQL Inbox "V1 only"). The shipped code is Outbox **V8**, Inbox **V3**, PostgreSQL Inbox **V2** — all from the `CausationId` migration. Lines 101, 108, 116 carry the same stale claims. |
+| `contents/BoxProvisioningUpgrade.md` | Upgrade narrative, uses V7 as "current" throughout (lines 15, 63, 79, 130) | Stale example versions; no mention that the `CausationId` migration is the one you must run before Replay works. |
+| `contents/Glossary.md` (577 lines) | Defines Inbox, Outbox, Sweeper, Migration Chain, etc. | No **Causation Id** or **Replay** entry. |
+| `contents/V10MigrationGuide.md` | Breaking changes | Does not carry the `IRequestContext.InstrumentationOptions` source-breaking change. |
+
+**Net:** the feature is entirely undocumented, and two existing pages now state
+migration-version facts that the shipped code contradicts.
+
+## Target State
+
+A reader should be able to:
+
+1. Understand what a Causation Id is and how it differs from Correlation Id  
+2. Decide whether Replay fits their problem (and recognise when it does not — it is not saga orchestration).
+3. Turn it on: attribute or global `InboxConfiguration`, migrate the store, confirm the Sweeper is running, thread `Context` through their `Post` calls.
+4. Look up whether their chosen Inbox/Outbox pair supports causation tracking.
+5. Diagnose a replay that did nothing, using the startup validation findings, the log messages, and the trace events.
+6. Find the migration version their store needs, and what happens if they upgrade Brighter without running it.
+
+Note that Job Id / Workflow Id exist but are reserved for future use and don't need discussion in this documentation.
+
+## Target Audience
+
+- **Primary — intermediate.** Users already running an Inbox and an Outbox with a Sweeper, who hit a stalled multi-step workflow. They know the patterns; they need the mechanics and the prerequisites.
+- **Secondary — advanced.** Users writing a custom Inbox/Outbox who need to implement `IAmACausationTrackingInbox` / `IAmACausationTrackingOutbox`, and   users debugging a silent no-op.
+- **Not the audience — beginners.** Someone who has not yet met the Inbox or Outbox should be sent to those pages first. The new page links back rather than re-explaining them.
+
+## Source Material
+
+**Design and rationale:**
+
+- `../Brighter/docs/adr/0057-replay-outbox-on-inbox-duplicate.md` (661 lines) —  the authoritative design. Covers Causation Id semantics, the role interfaces, the write-path gate, schema evolution, pipeline validation, observability, the   key-components table, consequences, and alternatives considered.
+- `../Brighter/specs/0027-replay-matching-outbox-events-when-inbox-has-already-seen/`  — `requirements.md` (problem statement, acceptance criteria, out-of-scope), `tasks.md`, and the four `review-*.md` documents. 
+- GitHub issue BrighterCommand/Brighter#2541.
+
+**Release notes:**
+
+- `../Brighter/release_notes.md:304–338` — the user-facing summary, the **"thread your `RequestContext` through `Post`/`DepositPost`"** requirement with  ❌/✅ code samples, and the `IRequestContext.InstrumentationOptions` source-breaking change.
+
+**Source code:**
+
+- `../Brighter/src/Paramore.Brighter/Inbox/OnceOnlyAction.cs` — the enum, with the `Replay` member's XML doc.
+- `../Brighter/src/Paramore.Brighter/Inbox/IAmACausationTrackingInbox.cs`
+- `../Brighter/src/Paramore.Brighter/IAmACausationTrackingOutbox.cs`
+- `../Brighter/src/Paramore.Brighter/RequestContextBagNames.cs:143` — `CausationId = "Brighter-CausationId"`.
+- `../Brighter/src/Paramore.Brighter/Inbox/Handlers/UseInboxHandler.cs` and the async variant — the Replay branch and the `CustomContextDisablesReplay` warning.
+- `../Brighter/src/Paramore.Brighter/InMemoryInbox.cs`, `InMemoryOutbox.cs` — the reference implementations.
+- `../Brighter/src/Paramore.Brighter/RelationalDatabaseInbox.cs`,
+  `RelationDatabaseOutbox.cs`, `IRelationalDatabaseInboxCausationQueries.cs`, `IRelationalDatabaseOutboxCausationQueries.cs` — how the relational stores get causation support via their per-backend `*Queries` class.
+- `../Brighter/src/Paramore.Brighter.Outbox.DynamoDB{,.V4}/DynamoDbOutbox.cs` and `DynamoDbConfiguration.cs` — the `Causation` GSI
+  (`CausationIndexName`, default `"Causation"`) and the `DescribeTable` probe.
+- `../Brighter/src/Paramore.Brighter.BoxProvisioning.*/[Ms|My]Sql*MigrationCatalog.cs`, `PostgreSql*`, `Sqlite*` — confirm **Outbox V8** (`s_v8AddedColumns =  ["CausationId"]` plus the new replay index) and **Inbox V3** (PostgreSQL Inbox
+  **V2**).
+- `../Brighter/src/Paramore.Brighter/Extensions/.../ServiceCollectionExtensions.cs`
+  — the extra `IAmACausationTrackingOutbox` DI registration.
+
+**Tests (use as verified examples):**
+
+- `../Brighter/tests/Paramore.Brighter.Core.Tests/OnceOnly/When_a_seen_message_is_replayed_end_to_end.cs`
+  — a full end-to-end scenario: command → handler → downstream event → duplicate
+  command → replay. The best single reference for the "how it hangs together"
+  walkthrough.
+- `../Brighter/tests/Paramore.Brighter.Core.Tests/OnceOnly/TestDoubles/ProcessAndForwardHandler.cs:55,65`
+  — the canonical handler shape:
+  `[UseInbox(1, onceOnly: true, onceOnlyAction: OnceOnlyAction.Replay, contextKey: typeof(ProcessAndForwardHandler))]`
+  and `_commandProcessor.Post(outgoing, Context as RequestContext);`.
+- `../Brighter/tests/Paramore.Brighter.Base.Test` — the causation-tracking base
+  tests, useful for confirming per-store behaviour claims.
+
+**Existing Docs specs to align with:**
+
+- `spec/003-pipeline-validation-at-startup` — the validation page this feature
+  extends.
+- `spec/005-database_migration` — the BoxProvisioning pages whose version matrix
+  this feature invalidates.
+
+## Scope
+
+### P0 — Must have
+
+1. **What Replay is and the problem it solves.** The stalled-workflow scenario: handler completed, downstream consumer never processed, re-sending the message currently achieves nothing. Contrast with `Throw` and `Warn`. Make the **cascade** explicit — you re-send the original message at the front of the flow, each already-seen handler skips its work but re-raises the messages it produced, and the flow walks forward step by step until it reaches the handler that never ran, which executes normally.
+2. **Causation Id defined.** One handler invocation's outgoing messages share one Causation Id. Default value is the request's `Id`. Explicitly distinguish from `CorrelationId` (request-reply). Note it travels in `RequestContext.Bag` under `RequestContextBagNames.CausationId`.
+3. **The end-to-end flow.** Duplicate detected → `GetCausationId` from the Inbox → `ReplayCausation` on the Outbox clears `DispatchedAt` → the Sweeper picks the messages up on its next run → handler never re-runs. Include the ADR's architecture diagram (or an equivalent) as a fenced text block.
+4. **Enabling it.** Both routes, with working code:
+   - Per handler:
+     `[UseInbox(step: 1, contextKey: typeof(MyHandler), onceOnly: true, onceOnlyAction: OnceOnlyAction.Replay)]`
+     and the `UseInboxAsync` equivalent.
+   - Globally: `InboxConfiguration.ActionOnExists = OnceOnlyAction.Replay`, wired
+     via `AddBrighter(...).UseExternalInbox(...)` — cross-link
+     `BrighterBasicConfiguration.md#inbox`.
+5. **The `RequestContext` threading requirement.** Its own clearly-signposted
+   section with the ❌/✅ pair from the release notes. State plainly that
+   `Post(evt)` without a context produces a `null` `CausationId` and a **silent
+   no-op** at replay time; `Post(evt, Context)` is required. Applies to
+   `PostAsync`, `DepositPost`, `DepositPostAsync`.
+6. **Prerequisites checklist.** Inbox implements `IAmACausationTrackingInbox`;
+   Outbox implements `IAmACausationTrackingOutbox`; store schema migrated so
+   `SupportsCausationTracking()` returns `true`; handlers thread `Context`
+   through their `Post`/`DepositPost` calls (see item 5).
+7. **An Outbox Sweeper must be running.** Immediate send is not a replay path —
+   replay works only by clearing dispatched state and letting the Sweeper resend.
+   Register it with `.UseOutboxSweeper(...)` from
+   `Paramore.Brighter.Outbox.Hosting` (which hosts `TimedOutboxSweeper`; the
+   lower-level type is `OutboxSweeper`). This applies whichever Outbox you use,
+   **including the implicit one**: if you configure no explicit Outbox, Brighter
+   creates an `InMemoryOutbox` for you (`CreateDefaultOutbox` in
+   `ServiceCollectionExtensions.cs`), and it does support Replay
+   (`InMemoryOutbox` implements `IAmACausationTrackingOutbox`) — but without a
+   Sweeper nothing re-sends. There is no in-memory-specific sweeper type.
+8. **Replay must be configured on every already-seen step.** The cascade is the
+   point of the feature, and it only propagates if each handler the flow passes
+   back through is itself set to `OnceOnlyAction.Replay`. A downstream handler
+   configured with `Throw` or `Warn` receives the replayed message, recognises
+   the duplicate, and **stops the cascade there** — the flow never reaches the
+   step that failed. State this explicitly with the consequence.
+9. **Update the `OnceOnlyAction` table in `BrighterInboxSupport.md`.** Add the `Replay` row to the behaviour table and to the bullet list at lines 32–38, and  link out to the new page.
+10. **Correct the stale BoxProvisioning version matrix.** `BoxProvisioning.md`
+   lines 93–96 → Outbox `V1..V8`, Inbox `V1..V3`, PostgreSQL Inbox `V1..V2`;
+   fix the supporting prose at lines 101, 108, 116 (the "PostgreSQL Inbox is
+   V1-only" claim is no longer true) and the V7-as-current examples in
+   `BoxProvisioningUpgrade.md` (lines 15, 63, 79, 130).
+
+### P1 — Should have
+
+11. **Store support matrix.** A table of Brighter-maintained stores × causation
+   tracking, with the migration each needs:
+   - Relational (MsSql, MySql, PostgreSql, Sqlite): supported; needs Outbox V8 /
+     Inbox V3 (PostgreSQL Inbox V2) via BoxProvisioning.
+   - Spanner: supported via its provisioner; live column probe.
+   - DynamoDB / DynamoDB.V4: Inbox supported unconditionally; **Outbox requires
+     the `Causation` GSI** (`DynamoDbConfiguration.CausationIndexName`, default
+     `"Causation"`) — call this out, it is the one NoSQL store with a real
+     prerequisite, and the only store where you must provision infrastructure
+     yourself. See the dedicated deliverable below.
+   - **How to create the DynamoDB `Causation` GSI.** BoxProvisioning does not
+     cover DynamoDB, so this is the user's job and must be documented rather than
+     assumed:
+     - *New tables* get it for free — `MessageItem.CausationId` carries
+       `[DynamoDBGlobalSecondaryIndexHashKey(indexName: "Causation")]`
+       (`MessageItem.cs:49`), so
+       `DynamoDbTableFactory.GenerateCreateTableRequest<MessageItem>()` emits the
+       GSI along with the existing `Outstanding` / `Delivered` indexes.
+     - *Existing tables* need an explicit `UpdateTable` with a
+       `GlobalSecondaryIndexUpdates` create — show it, and note that AWS
+       backfills a new GSI asynchronously, so `SupportsCausationTracking()` (a
+       live `DescribeTable` probe) keeps reporting false until the index is
+       `ACTIVE`.
+     - State the consequence of skipping it: startup validation reports the
+       Outbox as not supporting causation tracking, and Replay never fires.
+   - Firestore, MongoDb: supported, schemaless, no migration.
+   - In-memory: supported (development only).
+12. **Startup validation.** Document the `ReplayRequiresCausationTracking` rule
+    and all five findings — Inbox missing the interface (Error), Inbox
+    `SupportsCausationTracking()` false (Warning), no Outbox configured (Warning,
+    terminal step), Outbox missing the interface (Error), Outbox
+    `SupportsCausationTracking()` false (Warning) — each with the fix. Add a
+    "Common Mistakes and Fixes" entry in `PipelineValidation.md`.
+13. **Upgrade-without-migrating behaviour.** The write-path gate: relational
+    stores probe once per store instance for the `CausationId` column and fall
+    back to the old INSERT when it is absent, so deposits keep working
+    byte-for-byte. Consequence to state explicitly: **the memo is not
+    invalidated**, so provisioning that runs after a store instance was
+    constructed needs a process restart.
+14. **Observability.** The four `UseInboxHandler` span events (`Add`,
+    `Duplicate Throw`, `Duplicate Warn`, `Duplicate Replay`), the
+    `paramore.brighter.causation_id` tag on the Replay event, and the
+    `CustomContextDisablesReplay` warning log. Note that the Sweeper's re-dispatch
+    is its own trace with no parent link back to the replay — say why (the sweep
+    is asynchronous and may cover many replays).
+15. **Glossary entries.** **Causation Id** and **Replay (Inbox)**, cross-linked to
+    Inbox, Outbox, Sweeper, and Migration Chain.
+16. **Gotchas / limitations.** Each stated with its consequence:
+    - Historical rows have a `null` `CausationId` — no backfill, so entries
+      written before the migration can never be replayed.
+    - The default Causation Id is the request `Id`, so if the same message id is
+      handled by several `[UseInbox]` handlers, a replay resends **all** their
+      messages. Intended; note the escape hatch (set your own Causation Id in the
+      Bag before the Inbox handler runs). Note also that `UseInbox` is normally
+      applied to Commands (single handler), not Events.
+    - Sweeper race: a message may be dispatched twice. Downstream de-duplication
+      handles it.
+    - A custom `IAmARequestContextFactory` returning a non-`RequestContext`
+      `IRequestContext` degrades Replay to a no-op (with the one-time warning).
+    - No Outbox (terminal step) → safe no-op, validation warns.
+
+### P2 — Nice to have
+
+17. **Worked end-to-end walkthrough** derived from
+    `When_a_seen_message_is_replayed_end_to_end.cs`: command handled, downstream
+    event deposited, same command re-posted, event re-sent.
+18. **Implementing causation tracking in a custom store** — the two role
+    interfaces, what `SupportsCausationTracking()` must honestly report, and why
+    it is a runtime check rather than a static capability.
+19. **`IRequestContext.InstrumentationOptions` source-breaking change** noted in
+    `V10MigrationGuide.md` for anyone implementing `IRequestContext` directly.
+20. **Design-rationale sidebar** — why not `CorrelationId`, and why not
+    re-execute the handler (from the ADR's Alternatives Considered).
+
+## Out of Scope
+
+- **Saga / workflow orchestration.** Replay *does* cascade across steps — that is
+  the point of the feature (see P0 items 1 and 8) — but it is not orchestration:
+  there is no coordinator, no compensation, and no ordering guarantee. It is
+  re-delivery of already-recorded messages, and each step advances only because
+  its own Inbox is configured to replay. Draw that line once and move on; there
+  is no orchestration page to link to yet.
+- **Immediate-send replay.** Sweeper-only. Do not document a non-existent path.
+- **Re-executing handler logic.** Explicitly not what this does.
+- **Data backfill** for pre-migration rows.
+- **Rewriting the Inbox or Outbox pages** beyond the additions listed above.
+- **Per-backend BoxProvisioning mechanics** — owned by the existing
+  `BoxProvisioning*.md` pages; this spec only corrects their version facts and
+  links to them.
+- **Darker.** Queries have no Inbox/Outbox; nothing to say.
+
+## Documentation Deliverables
+
+**New file:**
+
+| File | Purpose |
+| :--- | :--- |
+| `contents/ReplayOnSeen.md` | The main page. Concept (Causation Id, the problem), **the cascade** — how replay walks a stalled flow forward step by step, and why every already-seen step needs `OnceOnlyAction.Replay` for it to propagate — how it works, enabling it, the `RequestContext` threading requirement, prerequisites, store support matrix, validation findings, observability, gotchas, further reading. Target 300–400 lines. |
+
+**Updated files:**
+
+| File | Change |
+| :--- | :--- |
+| `contents/BrighterInboxSupport.md` | Add `Replay` to the `OnceOnlyAction` bullet list and the behaviour table; a short paragraph pointing at `ReplayOnSeen.md`. |
+| `contents/BrighterOutboxSupport.md` | Note in the Sweeper section that replay clears dispatched state so the Sweeper re-sends; link to `ReplayOnSeen.md`. |
+| `contents/BrighterBasicConfiguration.md` | *(added at design review, 2026-08-02)* Line 884 presents `ActionOnExists` as a closed list of `Throw` and `Warn`; add `Replay` as the third option. |
+| `contents/PipelineValidation.md` | Add the `ReplayRequiresCausationTracking` rule to "Handler Pipeline Checks" and a "Common Mistakes and Fixes" entry. |
+| `contents/BoxProvisioning.md` | Correct the per-backend version matrix (Outbox V8, Inbox V3, PostgreSQL Inbox V2) and the prose that depends on it; mention the new `CausationId` replay index on the Outbox. |
+| `contents/BoxProvisioningUpgrade.md` | Refresh the V7-as-current examples; add a line on the `CausationId` migration being the prerequisite for Replay. |
+| `contents/DynamoOutbox.md` | Add a section on the `Causation` GSI — how a new table gets it from `DynamoDbTableFactory`, and the `UpdateTable` call that adds it to an existing table. The page has no table-provisioning content today, so this is new material, not an amendment. Note the async backfill and link to `ReplayOnSeen.md`. |
+| `contents/Glossary.md` | Add **Causation Id** and **Replay (Inbox)**. |
+| `contents/V10MigrationGuide.md` | Note `IRequestContext.InstrumentationOptions` (P2). |
+| `SUMMARY.md` | Add the new page. |
+
+## SUMMARY.md Changes
+
+Place the new page in the **Outbox and Inbox** section, immediately after
+`Inbox Support` — it is Inbox-triggered behaviour and reads best straight after
+the Inbox page, before the long run of per-store pages:
+
+```markdown
+ * [Inbox Support](/contents/BrighterInboxSupport.md)
+ * [Replay On Seen](/contents/ReplayOnSeen.md)
+ * [MSSQL Outbox](/contents/MSSQLOutbox.md)
+```
+
+Rejected alternative: nesting it under `Inbox Support`. Nothing else in that
+section nests except the Distributed Lock provider pages, where nesting signals
+"one of N implementations" — the wrong signal here.
+
+## Constraints
+
+**Terminology** (follow `contents/Glossary.md` and `BasicConcepts.md`):
+
+- **Causation Id** — capitalised as a defined term on first use, then `CausationId`
+  when naming the column/property.
+- **Replay** — the `OnceOnlyAction`. Write `OnceOnlyAction.Replay` when naming the
+  enum member.
+- **Dispatcher**, not "ServiceActivator".
+- **Sweeper**, **Outbox**, **Inbox** — as already defined in the Glossary.
+- Do not call this "idempotency". The page should say plainly that the Inbox does
+  *not* make you idempotent, which is the reason Replay exists.
+
+**Style:**
+
+- Second person, active voice, present tense (per `CLAUDE.md`).
+- V10 patterns only. Configuration enters through `AddBrighter()`.
+- Every C# example verified against Brighter source or the tests listed above —
+  the previous spec (007) found two example defects at QA, so verify names and
+  registration shapes as they are written, not afterwards.
+- Prefer the real shapes from `ProcessAndForwardHandler.cs` over invented ones.
+
+**Cross-linking:**
+
+- `ReplayOnSeen.md` links to: `BrighterInboxSupport.md`,
+  `BrighterOutboxSupport.md`, `OutboxPattern.md`, `BoxProvisioning.md`,
+  `BoxProvisioningUpgrade.md`, `PipelineValidation.md`, `Telemetry.md`,
+  `Glossary.md`, and the relevant per-store pages (`DynamoOutbox.md` for the GSI).
+- Each updated page links *back* to `ReplayOnSeen.md`.
+- Reference the ADR for design rationale rather than restating it at length:
+  `Brighter/docs/adr/0057-replay-outbox-on-inbox-duplicate.md`.
+
+**Accuracy constraints:**
+
+- Migration version claims must be re-verified against the `*MigrationCatalog.cs`
+  sources at writing time, not taken from this document.
+- **Column casing differs by backend.** PostgreSQL emits lowercase `causationid`
+  (deliberately — ADR 0057 §1, and its migration description reads
+  `"Add causationid column"`); MsSql, MySql, and Sqlite use `CausationId`. Never
+  assert a single casing across all stores; where the column is named in prose,
+  either use the backend's own spelling or name it generically ("the causation
+  column").
+- The store support matrix must be checked store by store — the DynamoDB Outbox
+  GSI requirement is the one asymmetry and is easy to flatten by mistake.
+
+## Open Questions
+
+1. Should the P2 walkthrough be inline in `ReplayOnSeen.md` or a separate page?
+   Recommendation: inline, kept short — a separate page risks duplicating the
+   concept material.
+2. Is there a sample in `../Brighter/samples/` that uses Replay? None found in
+   this pass; if one lands, link it from "Sample Code".
+
+---
+
+**Next step:** run `/spec:review` when you are ready to approve these requirements.

--- a/spec/008-replay_on_seen/tasks.md
+++ b/spec/008-replay_on_seen/tasks.md
@@ -1,0 +1,405 @@
+# Tasks: Replay On Seen (Spec 008)
+
+**Created:** 2026-08-02
+**Status:** Draft — awaiting review
+**Traceability:** Implements `design.md` (approved 2026-08-02), which traces to
+`requirements.md` (approved 2026-08-01). Scope items are cited as **[P0-n]**,
+**[P1-n]**, **[P2-n]**.
+
+## Overview
+
+**Total tasks: 33**, across 4 phases.
+
+| Phase | Goal | Tasks |
+|-------|------|-------|
+| 1. Research & Verification | Lock down every API name, version number, and store capability before a word is written | 5 |
+| 2. Core Documentation (P0) | Write the P0 half of `ReplayOnSeen.md`, then the P0 edits to five existing pages | 10 |
+| 3. Supporting Documentation (P1/P2) | Finish `ReplayOnSeen.md`, then the P1/P2 edits to four existing pages | 12 |
+| 4. Polish & Review | SUMMARY.md, length, example verification, link check, style, final QA | 6 |
+
+**Priority mapping (from requirements):**
+
+- **P0:** `ReplayOnSeen.md` §problem→prerequisites; `BrighterInboxSupport.md`,
+  `BrighterOutboxSupport.md`, `BrighterBasicConfiguration.md`, `BoxProvisioning.md`,
+  `BoxProvisioningUpgrade.md`.
+- **P1:** `ReplayOnSeen.md` §store support→limitations; `PipelineValidation.md`,
+  `DynamoOutbox.md`, `Glossary.md`.
+- **P2:** `ReplayOnSeen.md` §worked example, rationale, custom stores;
+  `V10MigrationGuide.md`.
+
+**Source-of-truth note:** every C# example and every version number must be verified
+against the Brighter source (read only — **never modify** `../Brighter`). Spec 007
+shipped two example defects that QA caught late; examples 5 and 9 here are written
+from scratch and carry the same risk, so they are verified as they are written
+(Task 4.3 is a second pass, not the first).
+
+---
+
+## Phase 1 — Research & Verification
+
+> Goal: no example ships a guessed symbol and no table ships a stale version.
+> Must complete before Phase 2. Tasks 1.1–1.5 are mutually independent.
+
+- [x] **Task 1.1:** Verify the configuration surface — enum, attributes, `InboxConfiguration`
+  - Input: `../Brighter/src/Paramore.Brighter/Inbox/OnceOnlyAction.cs`,
+    `Inbox/Attributes/UseInboxAttribute.cs` and the async variant,
+    `Inbox/InboxConfiguration.cs:70`,
+    `../Brighter/tests/Paramore.Brighter.Core.Tests/OnceOnly/TestDoubles/ProcessAndForwardHandler.cs:55`
+  - Output: a confirmed-names note in the spec directory (`verification-notes.md`) —
+    exact `[UseInbox]` / `[UseInboxAsync]` parameter names and order, the
+    `InboxConfiguration` constructor parameter list, and the `Replay` member's XML doc
+  - Notes: Confirm `ActionOnExists` is constructor-set, not a settable property
+    (design §1 "Turning It On" asserts this). Feeds Examples 1, 2, 3.
+
+- [x] **Task 1.2:** Verify the runtime mechanics — role interfaces, handler branch, telemetry
+  - Input: `../Brighter/src/Paramore.Brighter/Inbox/IAmACausationTrackingInbox.cs`,
+    `IAmACausationTrackingOutbox.cs`, `Inbox/Handlers/UseInboxHandler.cs` + async variant,
+    `RequestContextBagNames.cs:143`,
+    `../Brighter/docs/adr/0057-replay-outbox-on-inbox-duplicate.md`
+  - Output: appended to `verification-notes.md` — the interface method signatures
+    (`GetCausationId`, `ReplayCausation`, `SupportsCausationTracking`), the exact span
+    event names, the `paramore.brighter.causation_id` tag string, and the
+    `CustomContextDisablesReplay` warning text
+  - Notes: Confirm the bag key literal is `"Brighter-CausationId"` and that the default
+    Causation Id is the request's `Id`. Feeds §Causation Id, §Observability, Example 12.
+
+- [x] **Task 1.3:** Verify migration versions and column casing
+  - Input: `../Brighter/src/Paramore.Brighter.BoxProvisioning.*/` —
+    `MsSql*MigrationCatalog.cs`, `MySql*`, `PostgreSql*`, `Sqlite*` (Outbox and Inbox)
+  - Output: appended to `verification-notes.md` — a per-backend version table (Outbox
+    max version, Inbox max version, the causation migration's `Description`), plus
+    confirmation that the Outbox V8 migration creates an **index** as well as a column
+  - Notes: **Do not copy the numbers from `design.md`** — the requirements' accuracy
+    constraint says re-verify at writing time. Record PostgreSQL's lowercase
+    `causationid` vs `CausationId` elsewhere. Gates Tasks 2.9 and 2.10.
+
+- [x] **Task 1.4:** Verify store-by-store causation support
+  - Input: `InMemoryInbox.cs`, `InMemoryOutbox.cs`, `RelationalDatabaseInbox.cs`,
+    `RelationDatabaseOutbox.cs`, `IRelationalDatabase{Inbox,Outbox}CausationQueries.cs`,
+    `Paramore.Brighter.{Inbox,Outbox}.DynamoDB{,.V4}/`
+    (`DynamoDbOutbox.cs`, `DynamoDbConfiguration.cs:71`, `MessageItem.cs:49`),
+    plus the Spanner, MongoDb, and Firestore Inbox/Outbox projects
+  - Output: appended to `verification-notes.md` — which stores implement each role
+    interface, what `SupportsCausationTracking()` probes on each, and the DynamoDB
+    `CausationIndexName` default
+  - Notes: The DynamoDB Outbox GSI is the one asymmetry and is easy to flatten by
+    mistake — confirm the Inbox needs nothing while the Outbox needs the index. Also
+    confirm `DynamoDbTableFactory.GenerateCreateTableRequest<MessageItem>` emits the
+    GSI (`DynamoDbTableFactory.cs:60`). Gates Tasks 3.1 and 3.10.
+
+- [x] **Task 1.5:** Verify the validation findings and read the end-to-end test
+  - Input: `../Brighter/src/Paramore.Brighter/Validation/HandlerPipelineValidationRules.cs:137`
+    (the `ReplayRequiresCausationTracking` rule) and `Validation/PipelineValidator.cs:119`
+    (where it is invoked), ADR 0057 §validation,
+    `../Brighter/tests/Paramore.Brighter.Core.Tests/OnceOnly/When_a_seen_message_is_replayed_end_to_end.cs`
+  - Output: appended to `verification-notes.md` — the five findings with their exact
+    message text and severity, and a step-by-step trace of the end-to-end test
+    (what each store holds after each step)
+  - Notes: Gates Tasks 3.2, 3.6, and 3.9. Confirm there is still no sample in
+    `../Brighter/samples/` that uses Replay (requirements open question 2); if one has
+    landed, note it — it changes design deviation 2.
+
+---
+
+## Phase 2 — Core Documentation (P0)
+
+> Goal: the P0 spine. Tasks 2.1–2.5 build `ReplayOnSeen.md` top-down and are
+> **sequential** (each appends to the file in reading order). Tasks 2.6–2.10 edit
+> existing pages, are mutually independent, and can run in parallel with each other
+> once 2.1 exists as a link target.
+
+- [x] **Task 2.1:** Write `ReplayOnSeen.md` — intro, the problem, and the cascade  [P0-1, P0-8]
+  - Input: `design.md` §1 (sections "The Problem" and "How Replay Walks the Flow
+    Forward"); `requirements.md` P0-1 and P0-8; ADR 0057 problem statement
+  - Output: `ReplayOnSeen.md` from the H1 to the end of `## How Replay Walks the Flow
+    Forward` — 3-sentence intro, the Order → Payment → Shipping stall, why the Inbox
+    alone is not idempotency, the cascade stated plainly, and the callout that **every**
+    already-seen step needs `OnceOnlyAction.Replay`
+  - Notes: Do not use "idempotent" to describe what Replay achieves — the argument is
+    that the Inbox is *not* idempotency. State explicitly that the handler is not
+    re-executed and that the *same* stored messages are re-dispatched. Link
+    `BrighterInboxSupport.md` and `BrighterOutboxSupport.md` in the intro.
+
+- [x] **Task 2.2:** Write `ReplayOnSeen.md` — Causation Id and the duplicate walkthrough  [P0-2, P0-3]
+  - Input: Task 1.2 notes; ADR 0057 "Architecture Overview" diagram; `design.md` §1
+  - Output: `## Causation Id` (definition, default, how it travels in
+    `RequestContext.Bag`, one sentence distinguishing Correlation Id, stored in both
+    boxes) and `### What Happens on a Duplicate` (Example 10 — the flow diagram as a
+    fenced text block — plus the numbered walkthrough matching it)
+  - Notes: Trim the ADR diagram; it is fenced text, not code. End the walkthrough on the
+    latency consequence: replay happens on the Sweeper's next interval, not immediately.
+    Depends on 2.1.
+
+- [x] **Task 2.3:** Write `ReplayOnSeen.md` — Turning It On  [P0-4]
+  - Input: Task 1.1 notes; `ProcessAndForwardHandler.cs:55`;
+    `BrighterBasicConfiguration.md:905` for the registration shape
+  - Output: `## Turning It On` with `### On a Handler` (Example 1 — complete handler with
+    `[UseInbox(..., onceOnlyAction: OnceOnlyAction.Replay, contextKey: ...)]`; Example 2 —
+    the `[UseInboxAsync]` variant) and `### Globally` (Example 3 — `AddConsumers` with
+    `InboxConfiguration(..., actionOnExists: OnceOnlyAction.Replay)`, abbreviated)
+  - Notes: Rename the test's `MyCommand`/`MyEvent` to the Order/Payment/Shipping domain
+    used across the page. Note `ActionOnExists` is constructor-set. Link
+    `BrighterBasicConfiguration.md#inbox` (established convention — see design's
+    known-unverified-link note) and the homogeneous-pipeline anchor from Example 2.
+    Depends on 2.2.
+
+- [x] **Task 2.4:** Write `ReplayOnSeen.md` — You Must Thread Your RequestContext  [P0-5]
+  - Input: `../Brighter/release_notes.md:315–330`; `ProcessAndForwardHandler.cs:65`
+    (`Context as RequestContext`)
+  - Output: `## You Must Thread Your RequestContext` — warning callout, the why (the
+    causation id lives in the pipeline's `RequestContext.Bag`; a fresh context loses it
+    and stores a null `CausationId`), Example 4 as an ❌/✅ pair, the list of affected
+    methods (`Post`, `PostAsync`, `DepositPost`, `DepositPostAsync`), and the symptom
+  - Notes: This is its own H2, not a pitfall — design deviation 1. It must sit
+    immediately after configuration. Say "silent no-op" plainly: no log, no error,
+    nothing resent. Depends on 2.3.
+
+- [x] **Task 2.5:** Write `ReplayOnSeen.md` — Before You Enable It  [P0-6, P0-7]
+  - Input: `design.md` §1 checklist; `BrighterOutboxSupport.md:182`
+    (`### You always need a Sweeper`); `BrighterOutboxSupport.md:253` for Example 6
+  - Output: `## Before You Enable It` — the six-row checklist table (requirement | how to
+    satisfy | what happens if you don't) and the Sweeper sub-point with Example 6
+    (`.UseOutboxSweeper(...)`, abbreviated)
+  - Notes: **Link** to "You always need a Sweeper" rather than restating it — that
+    section already covers the in-memory Outbox and the RabbitMQ/Kafka async-confirmation
+    case. State that replay has no immediate-send path, and that the implicit
+    `InMemoryOutbox` supports Replay but still needs a Sweeper. Depends on 2.4.
+
+- [x] **Task 2.6:** Update `contents/BrighterInboxSupport.md`  [P0-9]
+  - Input: `design.md` §2; current lines 32–47
+  - Output: a third `Replay` sub-bullet in the `OnceOnlyAction` list, one new row in the
+    behaviour table (`true` / `Replay`), and a two-sentence paragraph after the table
+    naming the prerequisites and linking `ReplayOnSeen.md`
+  - Notes: Do not expand the page further — the Inbox page stays about the Inbox. The
+    prerequisite sentence exists so nobody enables Replay from this page alone.
+
+- [x] **Task 2.7:** Update `contents/BrighterOutboxSupport.md`  [P0-7]
+  - Input: `design.md` §3; current lines 182 and 432
+  - Output: a short paragraph appended to `### You always need a Sweeper` (replay clears
+    `DispatchedAt` so the Sweeper resends; it is the only replay path) and one sentence
+    at the end of `### Consumer: Using Inbox for Deduplication`
+  - Notes: Weave into the existing prose, don't rewrite it. Both additions link
+    `ReplayOnSeen.md`.
+
+- [x] **Task 2.8:** Update `contents/BrighterBasicConfiguration.md`
+  - Input: `design.md` §4; current **line 886** (the design says 884 — the file has since
+    shifted by two lines; verified at tasks review 2026-08-02)
+  - Output: the `ActionOnExists` bullet extended with `OnceOnlyAction.Replay` as a third
+    option, one clause, linking `ReplayOnSeen.md`
+  - Notes: One sentence. The bullet currently presents a closed list of two ("The default,
+    **OnceOnlyAction.Throw** … The alternative is **OnceOnlyAction.Warn**") and is now
+    factually wrong. Added at design review 2026-08-02.
+
+- [x] **Task 2.9:** Correct the version matrix in `contents/BoxProvisioning.md`  [P0-10]
+  - Input: **Task 1.3 notes** (not `design.md`'s numbers); current lines 93–96, 101,
+    108, 116
+  - Output: corrected per-backend matrix rows; corrected version prose at 101 (append the
+    causation migration); rewritten asymmetry row at 108; corrected V1-only explanation at
+    116 (keep the historical reason PostgreSQL skipped the `ContextKey` migration, correct
+    the conclusion — the chain is one shorter, not absent); a note that the Outbox
+    causation migration is the first to create an index rather than only columns
+  - Notes: These are factual corrections to spec 005's pages, not additions. Verify every
+    number against the catalog sources. Depends on 1.3.
+
+- [x] **Task 2.10:** Refresh the examples in `contents/BoxProvisioningUpgrade.md`  [P0-10]
+  - Input: Task 1.3 notes; current lines 15, 53, 63, 79, 130
+  - Output: version numbers refreshed at 15, 63, 79, 130 (including a consistently
+    regenerated sample log block at 63), plus a new bullet under `## What to verify after
+    upgrade` on confirming the causation column landed, linking `ReplayOnSeen.md`
+  - Notes: Regenerate the log block wholesale rather than hand-patching individual lines —
+    check every version number in it. Depends on 1.3.
+
+---
+
+## Phase 3 — Supporting Documentation (P1 / P2)
+
+> Goal: finish the page and hook up the remaining entry points. Tasks 3.1–3.8 continue
+> `ReplayOnSeen.md` in reading order and are sequential; 3.9–3.12 are mutually
+> independent page edits.
+
+- [x] **Task 3.1:** Write `ReplayOnSeen.md` — Store Support  [P1-11]
+  - Input: Task 1.4 notes; Task 1.3 notes for the migration versions
+  - Output: `## Store Support` — a matrix table (store | Inbox | Outbox | what you must do
+    first) covering relational, Spanner, MongoDb, Firestore, DynamoDB (+.V4), and
+    in-memory, with the column-casing note
+  - Notes: Never assert a single column casing across stores. DynamoDB's Outbox row links
+    to `DynamoOutbox.md`; relational rows link to `BoxProvisioning.md`. Depends on 2.5,
+    1.3, 1.4.
+
+- [x] **Task 3.2:** Write `ReplayOnSeen.md` — When Replay Does Not Fire  [P1-12, P1-16]
+  - Input: Task 1.5 notes (the five findings verbatim)
+  - Output: `## When Replay Does Not Fire` — the startup-findings table (finding |
+    severity | cause | fix, five rows) followed by the five runtime silences that produce
+    no startup error at all
+  - Notes: This is the diagnostic section — target-state item 5 depends on it. Link
+    `PipelineValidation.md`. Depends on 3.1, 1.5.
+
+- [x] **Task 3.3:** Write `ReplayOnSeen.md` — Upgrading Without Migrating  [P1-13]
+  - Input: ADR 0057 §write-path gate; `RelationDatabaseOutbox.cs`
+  - Output: `## Upgrading Without Migrating` — the probe-and-fall-back behaviour, and the
+    consequence that the memoized probe result is never invalidated, so provisioning that
+    runs after a store instance was built needs a process restart
+  - Notes: Link `BoxProvisioningUpgrade.md`. Depends on 3.2.
+
+- [x] **Task 3.4:** Write `ReplayOnSeen.md` — Observability  [P1-14]
+  - Input: Task 1.2 notes (event names, tag string, warning text)
+  - Output: `## Observability` — the span-events table (path | event name | tags), the
+    `paramore.brighter.causation_id` tag, the `CustomContextDisablesReplay` warning, and
+    why the re-dispatch is a separate trace with no parent link
+  - Notes: Link `Telemetry.md`. Depends on 3.3.
+
+- [x] **Task 3.5:** Write `ReplayOnSeen.md` — Limitations  [P1-16]
+  - Input: `requirements.md` P1-16 and the Out of Scope section; ADR 0057 §consequences
+  - Output: `## Limitations` — not saga orchestration (no coordinator, no compensation,
+    no ordering); the shared-Causation-Id case with its escape hatch; the Sweeper race;
+    historical rows that can never be replayed
+  - Notes: Draw the orchestration line once and move on — there is no orchestration page
+    to link to. Note `UseInbox` is normally applied to Commands. Depends on 3.4.
+
+- [x] **Task 3.6:** Write `ReplayOnSeen.md` — A Worked Example  [P2-17]
+  - Input: Task 1.5's trace of `When_a_seen_message_is_replayed_end_to_end.cs`
+  - Output: `## A Worked Example` — Example 5 (both handlers: `ProcessPayment`, already
+    seen and set to Replay; `ShipOrder`, never ran) followed by numbered steps noting what
+    each store holds at each point
+  - Notes: **Example 5 is written from scratch** — model it on `ProcessAndForwardHandler`
+    and verify every symbol as you write. Cite the test as the reference implementation;
+    there is no sample app (unless Task 1.5 found one). Depends on 3.5.
+
+- [x] **Task 3.7:** Write `ReplayOnSeen.md` — Why It Works This Way  [P2-20]
+  - Input: ADR 0057 §Alternatives Considered
+  - Output: `## Why It Works This Way` — three short paragraphs: why not re-execute the
+    handler, why not reuse `CorrelationId`, why the Sweeper rather than an immediate send
+  - Notes: Reference the ADR rather than restating it at length. Depends on 3.6.
+
+- [x] **Task 3.8:** Write `ReplayOnSeen.md` — custom stores and Further Reading  [P2-18]
+  - Input: Task 1.2 notes (interface signatures); `IAmACausationTrackingOutbox.cs`
+  - Output: `## Implementing Causation Tracking in Your Own Store` (the two role
+    interfaces, what each method must do, why `SupportsCausationTracking()` must report
+    the **live** state, Example 12 — an abbreviated skeleton) and `## Further Reading`
+  - Notes: Signpost this section as being for people *writing* a store, not using one.
+    Further Reading covers Inbox Support, Outbox Support, Outbox Pattern, Box
+    Provisioning, Upgrading Existing Deployments, Pipeline Validation, DynamoDb Outbox,
+    Telemetry, Glossary, and ADR 0057. Depends on 3.7. Completes the page.
+
+- [x] **Task 3.9:** Update `contents/PipelineValidation.md`  [P1-12]
+  - Input: Task 1.5 notes; `design.md` §5; current lines ~38, ~44, and 323
+  - Output: one new row in the `### Handler Pipeline Checks (AddBrighter)` rule table; two
+    of the five messages added verbatim to the example-error block (one Error, one
+    Warning); a new `### Replay Without Causation Tracking` section in the established
+    Before/After shape (Example 7), placed at the **end of `## Common Mistakes and Fixes`,
+    immediately before `## Further Reading`**
+  - Notes: Keep the page's existing summary-table density — the five findings enumerated
+    in full belong on `ReplayOnSeen.md`. Depends on 1.5.
+
+- [x] **Task 3.10:** Add the Causation GSI section to `contents/DynamoOutbox.md`  [P1-11]
+  - Input: Task 1.4 notes; `DynamoDbTableFactory.cs:60`; `MessageItem.cs:49`;
+    `DynamoDbConfiguration.cs:71`
+  - Output: a new `## Replay Support: The Causation Index` **appended at the end of the
+    file** (the page is exactly 89 lines and ends inside the handler code fence, so this
+    is an append, not a mid-file insertion) — Example 8 (new table, GSI for free from
+    `DynamoDbTableFactory`,
+    abbreviated) and Example 9 (`UpdateTable` with `GlobalSecondaryIndexUpdates` for an
+    existing table, complete), the async-backfill note, the consequence of skipping it,
+    and a link to `ReplayOnSeen.md`
+  - Notes: **Example 9 is written from scratch** against the AWS SDK — verify the request
+    shape as you write. State the default index name (`"Causation"`) and that it is
+    configurable. The page has no provisioning content today, so this is new material.
+    Depends on 1.4.
+
+- [x] **Task 3.11:** Add Glossary entries  [P1-15]
+  - Input: `design.md` §9; `Glossary.md` `### Inbox` at **line 174** (design says ~178)
+  - Output: `### Causation Id` and `### Replay (Inbox)` entries in `## Patterns`
+    immediately after `### Inbox`, each following the existing `Term` / definition /
+    `See:` shape
+  - Notes: **The broken-link half of this task is already done.** Design §9 calls for
+    retargeting the `### Inbox` entry away from the non-existent
+    `/contents/InboxConfiguration.md`, but the working tree already points it at
+    `/contents/BrighterInboxSupport.md#inbox-configuration` — fixed by an uncommitted
+    link sweep on this branch, confirmed at tasks review 2026-08-02. Verify it is still
+    correct and make no change. This task is now additive only.
+
+- [x] **Task 3.12:** Note `IRequestContext.InstrumentationOptions` in `contents/V10MigrationGuide.md`  [P2-19]
+  - Input: `../Brighter/release_notes.md:338`
+  - Output: a short breaking-changes entry — source-breaking for direct `IRequestContext`
+    implementors only, with Example 11 as the one-line fix
+  - Notes: Lowest priority in the spec. If effort is constrained this is the one to drop;
+    say so in the final QA note if dropped.
+
+---
+
+## Phase 4 — Polish & Review
+
+> Goal: navigation, accuracy, and the QA checklist. Runs after Phases 2 and 3.
+> Order matters: 4.1 before 4.4; 4.2 before 4.5.
+
+- [ ] **Task 4.1:** Update `SUMMARY.md`
+  - Input: `design.md` §SUMMARY.md Changes; current lines 81–82
+  - Output: `* [Replay On Seen](/contents/ReplayOnSeen.md)` inserted between
+    `Inbox Support` and `MSSQL Outbox` in the **Outbox and Inbox** section, unnested
+  - Notes: Single line, no nesting — nesting in that section signals "one of N
+    implementations", the wrong signal here.
+
+- [ ] **Task 4.2:** Check `ReplayOnSeen.md` length and decide on the split
+  - Input: the finished page; `design.md` §1 target (450–520 lines)
+  - Output: either confirmation the page is within target, or the custom-store section
+    [P2-18] extracted to its own page with `SUMMARY.md` and the Further Reading links
+    updated
+  - Notes: Split **only** if the page lands materially past 500 lines, and split the
+    custom-store notes — never cut reader-facing material. That section is the clean seam
+    because it targets a different audience. Depends on 3.8.
+
+- [ ] **Task 4.3:** Verify every code example against the source
+  - Input: all 12 examples; the Phase 1 `verification-notes.md`
+  - Output: confirmation each example compiles against the V10 API; fixes for any drift
+  - Notes: Concentrate on Examples **5** (the two-step cascade) and **9** (the DynamoDB
+    `UpdateTable`) — the two written from scratch. Also re-check Example 3's
+    `InboxConfiguration` parameter names and Example 4's `Context as RequestContext` form.
+    This is the second pass; examples were verified at writing time.
+
+- [ ] **Task 4.4:** Verify all internal links resolve
+  - Input: all new and edited pages, `SUMMARY.md`
+  - Output: `python3 tools/linkcheck.py` exits zero; fixes for anything it reports
+  - Notes: Includes the back-links into `ReplayOnSeen.md` from all eight edited pages and
+    `BrighterOutboxSupport.md#you-always-need-a-sweeper`. The repo was clean at tasks
+    review (106 files, zero broken links), so **anything this check reports is yours**.
+    `BrighterBasicConfiguration.md#inbox` was confirmed resolving at tasks review — the
+    design's "known-unverified link" concern is settled; seven pages use it. Depends on 4.1.
+
+- [ ] **Task 4.5:** Terminology and style pass
+  - Input: all deliverables; `contents/Glossary.md`, `BasicConcepts.md`,
+    `design.md` §Style Notes
+  - Output: consistent **Causation Id** / `CausationId`, **Replay** / `OnceOnlyAction.Replay`,
+    **Sweeper**, **Inbox**, **Outbox**, **Dispatcher**; second person, active voice,
+    present tense throughout
+  - Notes: No "ServiceActivator". No "idempotent" as a description of what Replay
+    achieves. "Cascade" stays descriptive — it is not introduced as a formal term and does
+    not go in the Glossary. Confirm the page title "Replay On Seen" has not leaked into
+    the running prose as a pseudo-term. Depends on 4.2.
+
+- [ ] **Task 4.6:** Final read-through against the QA checklist
+  - Input: `CLAUDE.md` Quality Assurance Checklist; all deliverables
+  - Output: the `README.md` Status Checklist ticked (Writing complete, Documentation
+    reviewed) with a short closing note beneath it confirming the code, content,
+    structure, and accuracy checks pass — and naming anything deliberately dropped
+  - Notes: Update the existing Status Checklist rather than adding a new section. Mark the
+    spec ready to close after this task.
+
+---
+
+## Dependency Summary
+
+- **Phase 1** (1.1–1.5) gates all writing. The five tasks are mutually independent and
+  all append to a shared `verification-notes.md`.
+- **`ReplayOnSeen.md` is written strictly top-down**: 2.1 → 2.2 → 2.3 → 2.4 → 2.5 →
+  3.1 → 3.2 → 3.3 → 3.4 → 3.5 → 3.6 → 3.7 → 3.8. Each task appends the next section.
+- **Existing-page edits** (2.6–2.10, 3.9–3.12) are mutually independent and can run in
+  parallel with the page-writing chain once Task 2.1 has created the link target.
+- **Specific data dependencies:** 1.3 → 2.9, 2.10, 3.1. 1.4 → 3.1, 3.10.
+  1.5 → 3.2, 3.6, 3.9. 1.2 → 2.2, 3.4, 3.8. 1.1 → 2.3.
+- **Phase 4** runs last: 4.1 before 4.4 (SUMMARY link must exist before the check);
+  4.2 before 4.5 (settle the file layout before the style pass); 4.6 closes.
+
+---
+
+**Next step:** Run `/spec:review` to approve these tasks, then `/spec:implement` to
+start writing.

--- a/spec/008-replay_on_seen/tasks.md
+++ b/spec/008-replay_on_seen/tasks.md
@@ -332,14 +332,21 @@ from scratch and carry the same risk, so they are verified as they are written
 > Goal: navigation, accuracy, and the QA checklist. Runs after Phases 2 and 3.
 > Order matters: 4.1 before 4.4; 4.2 before 4.5.
 
-- [ ] **Task 4.1:** Update `SUMMARY.md`
+- [x] **Task 4.1:** Update `SUMMARY.md`
   - Input: `design.md` §SUMMARY.md Changes; current lines 81–82
   - Output: `* [Replay On Seen](/contents/ReplayOnSeen.md)` inserted between
     `Inbox Support` and `MSSQL Outbox` in the **Outbox and Inbox** section, unnested
   - Notes: Single line, no nesting — nesting in that section signals "one of N
     implementations", the wrong signal here.
 
-- [ ] **Task 4.2:** Check `ReplayOnSeen.md` length and decide on the split
+- [x] **Task 4.2:** Check `ReplayOnSeen.md` length and decide on the split
+  - **Decision (2026-08-03):** split executed. Page was 1,154 lines against a 450–520
+    target — the design estimate was wrong by 2.2×, not an overrun. Custom-store notes
+    [P2-18] extracted to `contents/CausationTrackingStores.md` (149 lines) on the audience
+    seam; `ReplayOnSeen.md` is now 1,032 lines. The split is justified by audience, **not**
+    by length: it removes 11% and cannot reach the target. 1,032 is within repo norms
+    (`QueryPatterns.md` 1,289, `CQRSWithBrighterAndDarker.md` 1,142,
+    `BrighterBasicConfiguration.md` 1,068). No reader-facing material was cut.
   - Input: the finished page; `design.md` §1 target (450–520 lines)
   - Output: either confirmation the page is within target, or the custom-store section
     [P2-18] extracted to its own page with `SUMMARY.md` and the Further Reading links
@@ -348,7 +355,17 @@ from scratch and carry the same risk, so they are verified as they are written
     custom-store notes — never cut reader-facing material. That section is the clean seam
     because it targets a different audience. Depends on 3.8.
 
-- [ ] **Task 4.3:** Verify every code example against the source
+- [x] **Task 4.3:** Verify every code example against the source
+  - **Result (2026-08-03):** all 12 examples verified against V10 source; 3 defects found
+    and fixed. (1) `ReplayOnSeen.md` quoted the two "does not implement" validation errors
+    naming `'InMemoryInbox'` and `'MySqlOutbox'` — both *do* implement the role interfaces
+    (`InMemoryInbox.cs:115`; `RelationDatabaseOutbox.cs:24`), so neither message can occur
+    as printed, and it contradicted the Store Support table on the same page. Renamed to
+    `'MyCustomInbox'`/`'MyCustomOutbox'` and added a note that these two Errors can only
+    name a hand-written store. (2) `DynamoOutbox.md` presented `CausationIndexName` as
+    freely settable; `DynamoDbConfiguration.cs:36-40` says "Leave this at the default" —
+    reframed to lead with that. (3) Examples 5 and 9, the two written from scratch, were
+    **correct** — the risk flagged at design did not materialise.
   - Input: all 12 examples; the Phase 1 `verification-notes.md`
   - Output: confirmation each example compiles against the V10 API; fixes for any drift
   - Notes: Concentrate on Examples **5** (the two-step cascade) and **9** (the DynamoDB
@@ -356,7 +373,20 @@ from scratch and carry the same risk, so they are verified as they are written
     `InboxConfiguration` parameter names and Example 4's `Context as RequestContext` form.
     This is the second pass; examples were verified at writing time.
 
-- [ ] **Task 4.4:** Verify all internal links resolve
+- [x] **Task 4.4:** Verify all internal links resolve
+  - **Result (2026-08-03):** `python3 tools/linkcheck.py` exits 0 — 108 files, zero broken
+    links. Checked beyond the tool, since it verifies only that links present resolve:
+    all eight edited pages carry a back-link into `ReplayOnSeen.md`;
+    `BrighterOutboxSupport.md#you-always-need-a-sweeper` resolves (target at
+    `BrighterOutboxSupport.md:182`); `BrighterBasicConfiguration.md#inbox` resolves from
+    the `#### **Inbox**` heading and is used by 9 pages; the external ADR URL (which the
+    tool skips) names the right one of the **four** files sharing number 0057, and that
+    file is on `origin/master`. Both new pages are in `SUMMARY.md`.
+  - **Out of scope, for the record:** the repo has 10 pre-existing orphans not in
+    `SUMMARY.md` (`ClaimCheck.md`, `Compression.md`, `EFCoreOutbox.md`,
+    `ImplementingAHandler.md`, `MongoDBInbox.md`, `S3LuggageStore.md`,
+    `AzureBlobConfiguration.md`, `Requests, Commands and Events.md`, `VersionBegin.md`,
+    `VersionEnd.md`). None introduced by this spec. linkcheck cannot detect orphans.
   - Input: all new and edited pages, `SUMMARY.md`
   - Output: `python3 tools/linkcheck.py` exits zero; fixes for anything it reports
   - Notes: Includes the back-links into `ReplayOnSeen.md` from all eight edited pages and
@@ -365,7 +395,25 @@ from scratch and carry the same risk, so they are verified as they are written
     `BrighterBasicConfiguration.md#inbox` was confirmed resolving at tasks review — the
     design's "known-unverified link" concern is settled; seven pages use it. Depends on 4.1.
 
-- [ ] **Task 4.5:** Terminology and style pass
+- [x] **Task 4.5:** Terminology and style pass
+  - **Result (2026-08-03):** 5 fixes. (1-2) `PipelineValidation.md:335,367` used lowercase
+    "causation ids"/"causation id" in our own prose — capitalised per design §Style Notes.
+    (3-4) The duplicate-flow diagram in `ReplayOnSeen.md` used lowercase inside the ASCII
+    box — capitalised; replacement is the same character width, so box alignment holds.
+    (5) `BrighterInboxSupport.md:53` said "Service Activator" as a concept, banned by
+    CLAUDE.md — now "Dispatcher", and its "will result" changed to present tense. That
+    line was **pre-existing** (commit 213def1), not written by this spec; corrected as it
+    sits directly under our new paragraph.
+  - **Deliberately left alone:** lowercase "causation id" at `ReplayOnSeen.md:559,613` —
+    both are verbatim quoted output (`HandlerPipelineValidationRules.cs`,
+    `UseInboxHandler.cs:264`) and must match the source exactly. Remaining
+    "ServiceActivator" hits across the deliverables are real assembly/type/method names
+    (`ServiceActivatorHostedService`, `AddServiceActivator`) or Glossary entries defining
+    the term — all legitimate.
+  - **Verified clean:** no "idempotent" anywhere in the new pages; "cascade" never
+    capitalised and not in the Glossary; "Replay On Seen" appears only as the H1 and as
+    link text, never as a pseudo-term in prose; no first-person; all six "will" usages are
+    genuine future reference, not present-tense violations.
   - Input: all deliverables; `contents/Glossary.md`, `BasicConcepts.md`,
     `design.md` §Style Notes
   - Output: consistent **Causation Id** / `CausationId`, **Replay** / `OnceOnlyAction.Replay`,
@@ -376,7 +424,15 @@ from scratch and carry the same risk, so they are verified as they are written
     not go in the Glossary. Confirm the page title "Replay On Seen" has not leaked into
     the running prose as a pseudo-term. Depends on 4.2.
 
-- [ ] **Task 4.6:** Final read-through against the QA checklist
+- [x] **Task 4.6:** Final read-through against the QA checklist
+  - **Result (2026-08-03):** QA checklist passes; `README.md` Status Checklist updated
+    with the closing note. One fix: the intro of `CausationTrackingStores.md` bolded
+    **Causation Id** without defining it — a reader landing on that page directly (it has
+    its own `SUMMARY.md` entry since 4.2) got no definition. Added a one-clause definition
+    and deep-linked the term to `ReplayOnSeen.md#causation-id`. Verified the referenced
+    test `When_a_seen_message_is_replayed_end_to_end.cs` exists; all 20 requirements
+    P0-1..P2-20 map to completed tasks; nothing dropped, including the P2-19 item the
+    spec pre-authorised cutting.
   - Input: `CLAUDE.md` Quality Assurance Checklist; all deliverables
   - Output: the `README.md` Status Checklist ticked (Writing complete, Documentation
     reviewed) with a short closing note beneath it confirming the code, content,

--- a/spec/008-replay_on_seen/verification-notes.md
+++ b/spec/008-replay_on_seen/verification-notes.md
@@ -1,0 +1,579 @@
+# Verification Notes — Spec 008 (Replay On Seen)
+
+Source of truth for every symbol, signature, and version number used in this spec's
+documentation. Verified against the Brighter working tree (read only). Each section is
+produced by one Phase 1 task; do not write an example that is not backed by an entry here.
+
+---
+
+## Task 1.1 — Configuration surface (verified 2026-08-02)
+
+Feeds Examples 1, 2, 3 (Task 2.3) and the `ActionOnExists` edit (Task 2.8).
+
+### `OnceOnlyAction`
+
+`../Brighter/src/Paramore.Brighter/Inbox/OnceOnlyAction.cs`
+
+Namespace: `Paramore.Brighter.Inbox`. Three members, in declaration order:
+
+| Member | Line | XML doc (verbatim) |
+|--------|------|--------------------|
+| `Throw` | 35 | "Throw OnceOnlyException when OnceOnly is true" |
+| `Warn` | 39 | "Log a WARN message when OnceOnly is true" |
+| `Replay` | 45 | "When OnceOnly is true and a duplicate is detected, replay the outbox messages produced during the original handling (by clearing their dispatched state so the sweeper resends them) instead of re-running the handler. Requires causation-tracking inbox and outbox support." |
+
+`Throw` is the enum's default (value 0), which matches the `onceOnlyAction` /
+`actionOnExists` parameter defaults below.
+
+The `Replay` doc comment is the tightest one-sentence statement of the feature in the
+source, and it independently confirms three claims the page makes: the handler is **not**
+re-run, the mechanism is **clearing dispatched state** so the **Sweeper** resends, and
+both an inbox **and** an outbox must support causation tracking.
+
+### `[UseInbox]` — `UseInboxAttribute`
+
+`../Brighter/src/Paramore.Brighter/Inbox/Attributes/UseInboxAttribute.cs`
+
+Namespace: `Paramore.Brighter.Inbox.Attributes` (the enum is in
+`Paramore.Brighter.Inbox`, so an example that names `OnceOnlyAction.Replay` needs **both**
+usings).
+
+Two constructors:
+
+```csharp
+// line 49 — string contextKey
+public UseInboxAttribute(
+    int step,
+    string? contextKey = null,
+    bool onceOnly = false,
+    HandlerTiming timing = HandlerTiming.Before,
+    OnceOnlyAction onceOnlyAction = OnceOnlyAction.Throw)
+
+// line 65 — Type contextKey, delegates to the above via contextKey.FullName
+public UseInboxAttribute(
+    int step,
+    Type contextKey,
+    bool onceOnly = false,
+    HandlerTiming timing = HandlerTiming.Before,
+    OnceOnlyAction onceOnlyAction = OnceOnlyAction.Throw)
+```
+
+Properties: `ContextKey` (get-only, line 37), `OnceOnly` (get-only, line 38),
+`OnceOnlyAction` (**`get; set;`** — line 39).
+
+### `[UseInboxAsync]` — `UseInboxAsyncAttribute`
+
+`../Brighter/src/Paramore.Brighter/Inbox/Attributes/UseInboxAsyncAttribute.cs`
+
+```csharp
+// line 51 — string contextKey
+public UseInboxAsyncAttribute(
+    int step,
+    bool onceOnly = false,
+    string? contextKey = null,
+    HandlerTiming timing = HandlerTiming.Before,
+    OnceOnlyAction onceOnlyAction = OnceOnlyAction.Throw)
+
+// line 67 — Type contextKey
+public UseInboxAsyncAttribute(
+    int step,
+    Type contextKey,
+    bool onceOnly = false,
+    HandlerTiming timing = HandlerTiming.Before,
+    OnceOnlyAction onceOnlyAction = OnceOnlyAction.Throw)
+```
+
+Properties: `OnceOnly`, `ContextKey`, `OnceOnlyAction` — **all three get-only** (lines
+39–41), unlike the sync attribute.
+
+> **⚠ Parameter order differs between the two attributes.** In the string-`contextKey`
+> constructors the sync attribute is `(step, contextKey, onceOnly, …)` and the async
+> attribute is `(step, onceOnly, contextKey, …)` — positions 2 and 3 are swapped. The
+> `Type`-`contextKey` overloads happen to agree. **Examples 1 and 2 must use named
+> arguments** for everything after `step`; a positional example copied from one attribute
+> to the other compiles differently or not at all. This is the single highest-risk detail
+> in Task 2.3.
+
+`GetHandlerType()` returns `UseInboxHandler<>` (sync) and `UseInboxHandlerAsync<>`
+(async) — the handlers Task 1.2 traces.
+
+### Reference usage — the end-to-end test
+
+`../Brighter/tests/Paramore.Brighter.Core.Tests/OnceOnly/TestDoubles/ProcessAndForwardHandler.cs:55`
+
+```csharp
+[UseInbox(1, onceOnly: true, onceOnlyAction: OnceOnlyAction.Replay, contextKey: typeof(ProcessAndForwardHandler))]
+public override MyCommand Handle(MyCommand command)
+```
+
+All arguments after `step` are named, and `contextKey: typeof(…)` selects the `Type`
+overload. Example 1 follows this form exactly, renaming `MyCommand` to the page's
+Order/Payment/Shipping domain. Note the handler's own class type is the `contextKey` —
+the convention the attribute's XML doc describes ("the name of the handler").
+
+Two further details from the same file, useful to Tasks 2.4 and 3.6:
+
+- Line 65: `_commandProcessor.Post(outgoing, Context as RequestContext);` — the
+  `RequestHandler<T>.Context` property is `IRequestContext`, so threading it into `Post`
+  requires the `as RequestContext` cast. This is the exact form Example 4's ✅ branch uses.
+- The class doc comment states that on a duplicate the pipeline short-circuits **before**
+  the handler runs, so nothing is forwarded again — the replay is driven by the outbox.
+
+### `InboxConfiguration` (global configuration)
+
+`../Brighter/src/Paramore.Brighter/InboxConfiguration.cs` — namespace
+`Paramore.Brighter` (not `.Inbox`).
+
+```csharp
+// line 71
+public InboxConfiguration(
+    IAmAnInbox? inbox = null,
+    InboxScope scope = InboxScope.All,
+    bool onceOnly = true,
+    OnceOnlyAction actionOnExists = OnceOnlyAction.Throw,
+    Func<Type, string>? context = null)
+```
+
+Properties: `ActionOnExists` (line 47), `OnceOnly` (52), `Inbox` (57), `Scope` (62) —
+**all get-only**; `Context` (69) is `get; set;`.
+
+- **Design §1's assertion is confirmed:** `ActionOnExists` is constructor-set and has no
+  setter. You cannot flip an existing configuration to Replay; you construct a new
+  `InboxConfiguration`.
+- Note the parameter is named `actionOnExists` here but `onceOnlyAction` on the
+  attributes — same enum, two names. The page should not use them interchangeably in prose.
+- Defaults worth stating: `onceOnly` defaults to `true` here but `false` on the
+  attributes; `inbox` defaults to `new InMemoryInbox(TimeProvider.System)` (line 78).
+  That default matters for Task 2.5 — the implicit in-memory Inbox is what you get if you
+  set `actionOnExists` without naming an `inbox`.
+- `InboxScope` is `[Flags]` with `Commands = 1`, `Events = 2`, `All = 3` (lines 30–36).
+
+### Registration shape for Example 3
+
+`ConsumersOptions.InboxConfiguration` is `{ get; set; }` and defaults to `new()` —
+`../Brighter/src/Paramore.Brighter.ServiceActivator.Extensions.DependencyInjection/ConsumersOptions.cs:20`.
+So the `AddConsumers(options => options.InboxConfiguration = new InboxConfiguration(…))`
+shape in design.md is correct.
+
+`contents/BrighterBasicConfiguration.md` (around line 903) already shows this shape with
+`inbox:`, `scope:`, `onceOnly:`, `actionOnExists:` named arguments — Example 3 should
+match its layout so the two pages read as one convention. (That existing block is missing
+a comma after the `inbox:` argument and trails off in `...`; it is illustrative rather
+than compiling. Example 3 is abbreviated too, but must not reproduce the missing comma.)
+
+---
+
+## Task 1.2 — Runtime mechanics (verified 2026-08-02)
+
+Feeds §Causation Id (Task 2.2), §Observability (Task 3.4), Example 12 (Task 3.8).
+
+### ⚠ Citing the ADR
+
+**Four different ADRs in `../Brighter/docs/adr/` are numbered 0057.** The one this spec
+depends on is `0057-replay-outbox-on-inbox-duplicate.md` ("57. Replay Outbox Messages on
+Inbox Duplicate Detection", accepted 2026-04-16). Every reference in the docs must cite
+the **filename**, not the bare number, or a reader following it lands on box schema
+versioning, in-memory box expiry, or span-based performance instead.
+
+### The context bag key
+
+`../Brighter/src/Paramore.Brighter/RequestContextBagNames.cs:143`
+
+```csharp
+public const string CausationId = "Brighter-CausationId";
+```
+
+Confirmed literal. The XML doc states it is "distinct from the correlation id
+(request-reply), the `JobId`, and the `WorkflowId`" and that "it defaults to the handled
+request's id on first handling" — both claims the page makes, sourced here rather than
+only from the ADR.
+
+### `IAmACausationTrackingInbox`
+
+`../Brighter/src/Paramore.Brighter/Inbox/IAmACausationTrackingInbox.cs:39` — namespace
+`Paramore.Brighter` (**not** `Paramore.Brighter.Inbox`, despite living in the `Inbox`
+folder).
+
+```csharp
+bool SupportsCausationTracking();
+Task<bool> SupportsCausationTrackingAsync(CancellationToken cancellationToken = default);
+string? GetCausationId(string id, string contextKey, RequestContext? requestContext, int timeoutInMilliseconds = -1);
+Task<string?> GetCausationIdAsync(string id, string contextKey, RequestContext? requestContext, int timeoutInMilliseconds = -1, CancellationToken cancellationToken = default);
+```
+
+### `IAmACausationTrackingOutbox`
+
+`../Brighter/src/Paramore.Brighter/IAmACausationTrackingOutbox.cs:41` — namespace
+`Paramore.Brighter`.
+
+```csharp
+bool SupportsCausationTracking();
+Task<bool> SupportsCausationTrackingAsync(CancellationToken cancellationToken = default);
+bool ReplayCausation(string causationId, RequestContext? requestContext, Dictionary<string, object>? args = null);
+Task<bool> ReplayCausationAsync(string causationId, RequestContext? requestContext, Dictionary<string, object>? args = null, CancellationToken cancellationToken = default);
+```
+
+> **⚠ The ADR is out of date here.** ADR 0057 §"New Role Interfaces" (lines 109–114)
+> declares `void ReplayCausation` / `Task ReplayCausationAsync`. **The shipped code returns
+> `bool` / `Task<bool>`** — `true` if the replay was performed, `false` if it was a no-op
+> because the live schema lacks causation tracking ("callers use this to avoid reporting a
+> successful replay when nothing was actually resent"). Example 12 must use the shipped
+> `bool` signature. Do not copy the ADR's code block.
+
+The return value's meaning is the page's material for the "inbox migrated, outbox not"
+mixed state — the store returns `false` rather than throwing.
+
+### The handler branch
+
+`../Brighter/src/Paramore.Brighter/Inbox/Handlers/UseInboxHandler.cs` (async variant
+mirrors it at `UseInboxHandlerAsync.cs`).
+
+Sequence on every request (`Handle`, line 88):
+
+1. Throw `ArgumentException("ContextKey must be set before Handling")` if `_contextKey`
+   is null (line 90).
+2. `ResolveRequestContext()` (line 93) — see below.
+3. **Stamp the causation id if absent** (lines 95–96):
+   `if (!requestContext.Bag.ContainsKey(RequestContextBagNames.CausationId)) requestContext.Bag[…] = request.Id.Value;`
+   Confirms the default is the request's own `Id`, and that a caller who sets the key
+   first wins (the escape hatch Task 3.5 documents).
+4. Capture `Context?.Span` **once** into a local (line 99) before any branch. The async
+   handler must do this before the first `await` because `RequestContext.Span` is
+   thread-affine; the sync handler does it for parity.
+5. If `_onceOnly` and `_inbox.Exists<T>(…)`, switch on the action (lines 109–126).
+
+The Replay branch (line 121):
+
+```csharp
+case OnceOnlyAction.Replay:
+    Log.CommandHasAlreadyBeenSeenReplayingOutbox(s_logger, request.Id.Value);
+    var (causationId, replayed) = ReplayCausation(request, requestContext);
+    WriteReplayEvent(span, request, causationId, replayed);
+    return request;
+```
+
+`ReplayCausation` (line 178) returns `(null, false)` — nothing replayed — in three cases:
+
+- the inbox is not an `IAmACausationTrackingInbox`, **or** the injected outbox is `null`
+  (line 180);
+- `GetCausationId` returns `null`, i.e. the stored row predates the migration or was
+  written before causation tracking was on (line 184);
+- otherwise it returns whatever `_outbox.ReplayCausation(causationId, requestContext)`
+  returns (line 187) — `false` when the outbox schema does not support tracking.
+
+These three are exactly the "runtime silences" Task 3.2 lists. Note the handler
+**returns the request either way** — a failed replay is indistinguishable from a
+successful one to the caller.
+
+The outbox is injected as an optional constructor parameter
+(`UseInboxHandler(IAmAnInboxSync inbox, IAmACausationTrackingOutbox? outbox = null)`,
+line 67), so a terminal step with no outbox degrades to a plain skip.
+
+### `ResolveRequestContext` and the custom-context warning
+
+Lines 151–164. If `Context is RequestContext` it is returned; otherwise the handler falls
+back to `new RequestContext { Span = Activity.Current }` — a throwaway whose Bag never
+reaches the outbox `Add`. Before falling back, and only when `_onceOnlyAction is
+OnceOnlyAction.Replay`, it logs **once process-wide** (guarded by
+`Interlocked.CompareExchange` on a static `int`):
+
+`CustomContextDisablesReplay`, `LogLevel.Warning`, message text verbatim
+(`UseInboxHandler.cs:264`, identical at `UseInboxHandlerAsync.cs:282`):
+
+> A custom IRequestContext (not a RequestContext) was supplied; the causation id cannot
+> flow to downstream handlers, so OnceOnlyAction.Replay will be a no-op
+
+"Once" is best-effort — the source comment notes a benign race may log it a couple of
+extra times under concurrent first hits. Do not tell readers to expect exactly one line.
+
+### Span events
+
+Written by `WriteReplayEvent` (line 202) and `WriteInboxEvent` (line 234). Both are
+no-ops unless `span is not null`, `Context is not null`, **and**
+`Context.InstrumentationOptions.HasFlag(InstrumentationOptions.Brighter)`.
+
+| Path | Event name | Tags |
+|------|-----------|------|
+| First handling (stored) | `UseInboxHandler Add` | `paramore.brighter.request.id` |
+| Duplicate + Throw | `UseInboxHandler Duplicate Throw` | request id |
+| Duplicate + Warn | `UseInboxHandler Duplicate Warn` | request id |
+| Duplicate + Replay, messages resent | `UseInboxHandler Duplicate Replay` | request id, `paramore.brighter.causation_id` |
+| Duplicate + Replay, nothing resent | `UseInboxHandler Duplicate Replay Skipped` | request id, `paramore.brighter.causation_id` (null) |
+
+- The tag constant is `BrighterSemanticConventions.CausationId =
+  "paramore.brighter.causation_id"` (`Observability/BrighterSemanticConventions.cs:54`).
+  Confirmed verbatim.
+- **The event names are identical in the async handler** — both emit the
+  `"UseInboxHandler …"` prefix; there is no `"UseInboxHandlerAsync …"` variant. Verified
+  at `UseInboxHandlerAsync.cs:121, 126, 147, 236–237`.
+- > **⚠ The ADR is out of date here too.** Its Observability table (line 535) lists only
+  > four events and omits `UseInboxHandler Duplicate Replay Skipped`, which shipped. The
+  > "Skipped" name is chosen when `causationId is null || !replayed` (line 217) — so
+  > operators can tell a real replay from a silent no-op. Task 3.4's table must have five
+  > rows, not the ADR's four.
+- No new spans are created; events attach to the existing pipeline span. The ADR
+  (§"No new spans", line 544) confirms the re-dispatch has **no parent-child link** to the
+  replay trigger, because the Sweeper creates its own Activity in `SweepAsync` and may
+  pick up messages from several replays at once. That is the sentence Task 3.4 needs.
+
+### Log messages (all from the `Log` nested class, `UseInboxHandler.cs:247`)
+
+| Level | Message template |
+|-------|------------------|
+| Debug | `Checking if command {Id} has already been seen` |
+| Debug | `Command {Id} has already been seen` |
+| Warning | `Command {Id} has already been seen` (the `Warn` action) |
+| Debug | `Command {Id} has already been seen; replaying its outbox messages` |
+| Debug | `Writing command {Id} to the Inbox` |
+| Warning | `CustomContextDisablesReplay` (text above) |
+
+Note the replay log is **Debug**, not Information — worth saying plainly in Task 3.2, since
+an operator at default log levels sees nothing when a replay happens.
+
+---
+
+## Task 1.3 — Migration versions and column casing (verified 2026-08-02)
+
+Re-derived from the catalog sources, **not** from `design.md`. Gates Tasks 2.9, 2.10, 3.1.
+
+### Outbox — all four catalog backends are at **V8**
+
+| Backend | Max version | V8 `Description` | Column added | Type |
+|---------|-------------|------------------|--------------|------|
+| MsSql | 8 | `Add CausationId column and replay index` | `CausationId` | `NVARCHAR(255)` |
+| MySql | 8 | `Add CausationId column and replay index` | `CausationId` | `VARCHAR(255)` |
+| PostgreSql | 8 | `Add causationid column and replay index` | `causationid` | `character varying(255)` |
+| Sqlite | 8 | `Add CausationId column and replay index` | `CausationId` | `TEXT` |
+
+Sources: `MsSqlOutboxMigrationCatalog.cs:191`, `MySqlOutboxMigrationCatalog.cs:202`,
+`PostgreSqlOutboxMigrationCatalog.cs:203`, `SqliteOutboxMigrationCatalog.cs:168`.
+
+### Inbox — **not uniform**
+
+| Backend | Max version | Description | Column added | Type |
+|---------|-------------|-------------|--------------|------|
+| MsSql | 3 | `Add CausationId column` | `CausationId` | `NVARCHAR(256)` |
+| MySql | 3 | `Add CausationId column` | `CausationId` | `VARCHAR(256)` |
+| Sqlite | 3 | `Add CausationId column` | `CausationId` | `TEXT` |
+| **PostgreSql** | **2** | `Add causationid column` | `causationid` | `character varying(256)` |
+
+Sources: `MsSqlInboxMigrationCatalog.cs:138`, `MySqlInboxMigrationCatalog.cs:150`,
+`SqliteInboxMigrationCatalog.cs:119`, `PostgreSqlInboxMigrationCatalog.cs:132`.
+
+PostgreSQL's inbox is one version behind because its **V1 already created the
+`contextkey` column**, so it never needed the separate `ContextKey` migration the other
+three have as their V2 (`PostgreSqlInboxMigrationCatalog.cs:41–49`). The chain is one
+step shorter — **not absent**. That is the correction Task 2.9 must make at
+`BoxProvisioning.md:116`: keep the historical reason, fix the conclusion.
+
+### Column casing
+
+**Never assert one casing across backends.** PostgreSQL uses all-lowercase unquoted
+identifiers (`causationid`); MsSql, MySql, Sqlite and Spanner use `CausationId`. The
+outbox column is **255** and the inbox column **256** on the sized backends — a real
+asymmetry, so do not "tidy" one to match the other.
+
+### The index — new in V8, outbox only
+
+The outbox V8 migration creates **a column and an index**; the inbox migrations create a
+column only. This is the first migration in any catalog to create an index — none of the
+outbox catalogs indexed any column before V8 (stated in the source comments at
+`MsSqlOutboxMigrationCatalog.cs:223`, `SqliteOutboxMigrationCatalog.cs:198`). Index names
+differ per backend:
+
+| Backend | Index name | Mechanism |
+|---------|-----------|-----------|
+| MsSql | `idx_<table>_CausationId` | `IF NOT EXISTS (… sys.indexes …)` then `EXEC('CREATE INDEX …')` |
+| MySql | `idx_CausationId` (bare — MySQL scopes index names to the table) | `information_schema.statistics` probe driving a prepared statement |
+| PostgreSql | `idx_<table>_causationid` | native `CREATE INDEX IF NOT EXISTS` |
+| Sqlite | `idx_<table>_CausationId` | native `CREATE INDEX IF NOT EXISTS` |
+
+### Spanner
+
+`SpannerBoxMigrationRunner.cs:138–139`:
+
+```csharp
+public static readonly int VLatestOutbox = 8;
+public static readonly int VLatestInbox = 3;
+```
+
+Both bumped in step with the relational catalogs, as ADR 0057 requires. `VLatestInbox = 3`
+matches MsSql/MySql/Sqlite, not PostgreSql's 2.
+
+---
+
+## Task 1.4 — Store-by-store causation support (verified 2026-08-02)
+
+Gates Tasks 3.1 and 3.10.
+
+### Who implements the role interfaces
+
+Exhaustive grep for `IAmACausationTracking` across `src` (excluding `bin`/`obj`) returns
+implementations in: `InMemoryInbox`, `InMemoryOutbox`, `RelationalDatabaseInbox`,
+`RelationDatabaseOutbox`, `DynamoDbInbox` (+`.V4`), `DynamoDbOutbox` (+`.V4`),
+`FirestoreInbox`/`FirestoreOutbox`, `MongoDbInbox`/`MongoDbOutbox`.
+
+**Every Brighter-maintained inbox and outbox implements its role interface.** There is no
+store you must replace — only schemas you may have to migrate. The relational and Spanner
+stores inherit the implementation from the two abstract base classes:
+
+- `MsSqlInbox`, `MySqlInbox`, `PostgreSqlInbox`, `SqliteInbox`, `SpannerInboxAsync` all
+  derive from `RelationalDatabaseInbox` (`RelationalDatabaseInbox.cs:41`).
+- `MsSqlOutbox`, `MySqlOutbox`, `PostgreSqlOutbox`, `SqliteOutbox`, `SpannerOutbox` all
+  derive from `RelationDatabaseOutbox` (`RelationDatabaseOutbox.cs:17`).
+
+So Spanner is covered by the same base-class probe as the catalog backends, despite having
+no migration catalog of its own.
+
+### What `SupportsCausationTracking()` actually probes
+
+| Store | Inbox probe | Outbox probe |
+|-------|-------------|--------------|
+| In-memory | `=> true` (`InMemoryInbox.cs:361`) | `=> true` (`InMemoryOutbox.cs:709`) |
+| Relational + Spanner | live `CausationId` column-existence query, memoized per store instance (`RelationalDatabaseInbox.cs:278`) | same, `RelationDatabaseOutbox.cs:1009` |
+| MongoDb | `=> true` (`MongoDbInbox.cs:259`) | `=> true` (`MongoDbOutbox.cs:853`) |
+| Firestore | `=> true` (`FirestoreInbox.cs:498`) | `=> true` (`FirestoreOutbox.cs:856`) |
+| DynamoDB / .V4 | `=> true` (`DynamoDbInbox.cs:257`) | **live `DescribeTable` check for the GSI** (`DynamoDbOutbox.cs:573`; `.V4` at the same member) |
+
+**The DynamoDB outbox is the single asymmetry**, exactly as design.md predicted. Confirmed
+in both directions:
+
+- The DynamoDB **inbox** returns `true` unconditionally — it needs nothing. `GetCausationId`
+  queries the table's own primary keys, so no new index.
+- The DynamoDB **outbox** probes `DescribeTableAsync` and checks
+  `GlobalSecondaryIndexes.Any(gsi => gsi.IndexName == _configuration.CausationIndexName)`
+  (`DynamoDbOutbox.cs:588–596`), memoized in a `bool? _causationIndexExists` field.
+
+### DynamoDB specifics for Task 3.10
+
+- **Default index name:** `CausationIndexName = "Causation"`, set in the
+  `DynamoDbConfiguration` constructor — `Outbox.DynamoDB.V4/DynamoDbConfiguration.cs:71`
+  and `Outbox.DynamoDB/DynamoDbConfiguration.cs:78`. It is a `{ get; set; }` property
+  (line 35 / 42), so it is configurable.
+- **⚠ But the attribute hard-codes it.** `MessageItem.CausationId` is decorated
+  `[DynamoDBGlobalSecondaryIndexHashKey(indexName: "Causation")]` (`MessageItem.cs:49`) —
+  a compile-time literal, not the configuration value. So `DynamoDbTableFactory` always
+  generates a GSI named `Causation`; changing `CausationIndexName` without also creating
+  a matching index by hand makes the probe report "absent". Task 3.10 should say the
+  property exists but that the default is what the table factory produces.
+- **The GSI comes for free on a new table.**
+  `DynamoDbTableFactory.GenerateCreateTableRequest<T>` calls
+  `GetGlobalSecondaryIndices<T>(docType)` and adds the results to the request
+  (`DynamoDb.V4/DynamoDbTableFactory.cs:80`), and that reflects over the
+  `[DynamoDBGlobalSecondaryIndexHashKey]` attributes. Passing `MessageItem` therefore
+  emits the `Causation` GSI with no extra code — Example 8's whole point.
+- **GSI shape for Example 9:** hash key `CausationId` (string), no range key.
+  `ReplayCausationAsync` issues a `QueryRequest` with `IndexName =
+  _configuration.CausationIndexName`, `KeyConditionExpression = "CausationId = :causationId"`,
+  and `ProjectionExpression = "MessageId"` (`DynamoDbOutbox.cs` V4:636–648). Since
+  `MessageId` is the base table's hash key, a `KEYS_ONLY` projection satisfies the query.
+- **`ReplayCausationAsync` degrades, it does not throw**: it returns `false` early when
+  the probe says the GSI is absent, precisely so a duplicate does not unwind the pipeline
+  with a DynamoDB `ValidationException` on a pre-feature table (V4:620–625).
+- Writing the `CausationId` attribute to a table with no GSI is a harmless sparse-index
+  no-op, so **normal deposits are unaffected** by skipping the index. Only replay needs it.
+- The update loop restores the outstanding marker with
+  `UpdateExpression = "SET OutstandingCreatedTime = CreatedTime REMOVE DeliveryTime, DeliveredAt"`,
+  and swallows `ConditionalCheckFailedException` because **the GSI is eventually
+  consistent** — it can list a `MessageId` whose base item has since been swept or
+  TTL-deleted. Worth one sentence in Task 3.10's async-backfill note: a newly created GSI
+  backfills asynchronously, so replay is incomplete until the backfill finishes.
+
+---
+
+## Task 1.5 — Validation findings and the end-to-end test (verified 2026-08-02)
+
+Gates Tasks 3.2, 3.6, 3.9.
+
+### ⚠ There are SIX findings, not five
+
+`tasks.md` (written from `design.md`) says "the five findings". The shipped rule
+`HandlerPipelineValidationRules.ReplayRequiresCausationTracking(inbox, outbox)`
+(`Validation/HandlerPipelineValidationRules.cs:137`) produces **six** distinct findings —
+the five the ADR sketched, plus a probe-failure Warning that was added when the probe was
+wrapped in `SupportsCausationTrackingSafely` (line 219). Task 3.2's table needs six rows.
+Task 3.9's wording ("two of the five messages") should be read as "two of the six".
+
+The rule fires only when a pipeline configures Replay — `OnceOnlyActionOf(step.Attribute)
+== OnceOnlyAction.Replay` across `BeforeSteps.Concat(AfterSteps)` (line 141). Non-Replay
+pipelines yield nothing. `source` is `$"Handler '{d.HandlerType.Name}'"`.
+
+| # | Severity | Condition | Message (verbatim, after the source prefix) |
+|---|----------|-----------|---------------------------------------------|
+| 1 | **Error** | inbox is not `IAmACausationTrackingInbox` | `OnceOnlyAction.Replay requires a causation-tracking inbox, but the configured inbox '<Type>' does not implement IAmACausationTrackingInbox — Replay cannot find the causation id of the original handling` |
+| 2 | Warning | inbox probe returns `false` | `OnceOnlyAction.Replay requires causation tracking, but the inbox store schema does not support it — migrate the inbox schema to add the CausationId column for Replay to work` |
+| 3 | Warning | no outbox configured | `OnceOnlyAction.Replay has no outbox to replay — on a duplicate the handler is skipped and no messages are resent (Replay is a graceful terminal step without an outbox)` |
+| 4 | **Error** | outbox is not `IAmACausationTrackingOutbox` | `OnceOnlyAction.Replay requires a causation-tracking outbox, but the configured outbox '<Type>' does not implement IAmACausationTrackingOutbox — Replay cannot reset the dispatched state of the original messages` |
+| 5 | Warning | outbox probe returns `false` | `OnceOnlyAction.Replay requires causation tracking, but the outbox store schema does not support it — migrate the outbox schema to add the CausationId column for Replay to work` |
+| 6 | Warning | probe **throws** | `OnceOnlyAction.Replay could not verify causation-tracking support on the <inbox\|outbox> store — the schema capability probe failed (<ExceptionType>: <message>). Ensure the store is reachable and its schema is migrated before relying on Replay` |
+
+In the inbox `'<Type>'` slot, a null inbox renders as `(none)`
+(`inbox?.GetType().Name ?? "(none)"`).
+
+Notes that matter for the page:
+
+- Findings 1 and 4 are the only **Errors**. Everything else is a Warning — including
+  "schema not migrated", which means a mis-provisioned store does not fail startup.
+- Finding 6 exists because the probe hits a live store: an unreachable database or a
+  missing permission would otherwise crash host startup from inside validation. A throwing
+  probe is treated as "capability unknown", and the rule then suppresses finding 2/5 for
+  that store (`SupportsCausationTrackingSafely` returns `null`).
+- Findings 3 and 4 both `return findings` early — no outbox-schema finding follows them.
+- Wiring: `PipelineValidator.ValidateHandlerPipelines()` adds the rule to the standard
+  handler-pipeline spec list (`Validation/PipelineValidator.cs:116`), alongside
+  `HandlerTypeVisibility`, `BackstopAttributeOrdering`, and `AttributeAsyncConsistency`.
+  No separate code path.
+
+### Confirmed: still no sample uses Replay
+
+`grep -rl "OnceOnlyAction.Replay" samples/ --include='*.cs'`, excluding `bin`/`obj`,
+returns **nothing** (the apparent hits are copies of `Paramore.Brighter.xml` under
+`bin/`). Requirements open question 2 stands and **design deviation 2 is unchanged**:
+the reference implementation to cite is the test, not a sample app.
+
+### The end-to-end test
+
+`../Brighter/tests/Paramore.Brighter.Core.Tests/OnceOnly/When_a_seen_message_is_replayed_end_to_end.cs`
+— class `EndToEndReplayOnSeenTests`, test method
+`When_a_seen_message_is_replayed_end_to_end_through_the_internal_bus` (line 158).
+
+Setup: `InternalBus` as transport; `InMemoryInbox` and `InMemoryOutbox` (both with a
+`FakeTimeProvider`); a real `Reactor` pump on a `Performer` background thread; a
+`ProcessAndForwardHandler` registered for `MyCommand`. The container registers
+`IAmACausationTrackingOutbox` **explicitly** as the same `InMemoryOutbox` instance
+(line 129) — the DI detail ADR 0057 §"DI Registration" describes.
+
+Trace, with store state at each step:
+
+| # | Action | Inbox | Outbox | Bus (`MyEvent` topic) |
+|---|--------|-------|--------|----------------------|
+| 1 | `Post(command, new RequestContext())` — first time | empty | empty | empty |
+| 2 | Pump delivers; `UseInboxHandler` stamps `Bag[CausationId] = command.Id`, sees no duplicate, runs the handler | — | — | — |
+| 3 | Handler `Post`s `MyEvent`, **threading `Context as RequestContext`** | — | 1 message, `CausationId = command.Id`, dispatched immediately | 1 message |
+| 4 | Handler returns; `UseInboxHandler` writes the inbox entry | 1 entry, `CausationId = command.Id` | unchanged | 1 |
+| 5 | Assertions: `GetCausationId(command.Id, contextKey, …) == command.Id.Value`; `ReceivedCount == 1` | | | |
+| 6 | `Post(command, …)` — **the same command again** | | | |
+| 7 | `Exists` returns true → Replay branch → `GetCausationId` → `outbox.ReplayCausation` clears the dispatched state | unchanged | message flips back to **outstanding** | still 1 |
+| 8 | Assertion: `ReceivedCount` is **still 1** — the handler did not re-run | | | |
+| 9 | `ClearOutbox([outgoingMessageId], …)` re-dispatches | unchanged | dispatched again | **2** messages, both with the *same* message id |
+
+The final assertion (`Assert.All(afterReplay, m => Assert.Equal(outgoingMessageId.Value, m.Id.Value))`)
+is the proof that the *same* stored message is resent, not a newly generated one — the
+claim Task 2.1 makes in prose.
+
+Two honesty constraints on Task 3.6:
+
+1. **The test does not run a Sweeper.** Line 187 comments "Re-dispatch the replayed message
+   to the bus with the same primitive Post uses (no background sweeper needed)" and calls
+   `ClearOutbox` directly. Replay's effect in the test is "the message became outstanding
+   again"; the Sweeper is what would do step 9 in production. Do not write the trace as if
+   a Sweeper ran.
+2. **The test is one step, not a cascade.** It has a single handler forwarding a single
+   event. Example 5's two-step Order → Payment → Shipping cascade (`ProcessPayment` already
+   seen, `ShipOrder` never ran) is **not** traced from this test — the test verifies the
+   mechanism for one step. Write Example 5 as an extrapolation and cite the test for the
+   mechanism, not for the cascade.
+
+Also useful (a race the test documents at lines 208–219): the handler signals from
+*inside* the pipeline, but `UseInboxHandler` writes the inbox entry *after* the inner
+handler returns. So "the handler ran" and "the inbox entry exists" are different moments.

--- a/tools/linkcheck.py
+++ b/tools/linkcheck.py
@@ -1,10 +1,21 @@
 #!/usr/bin/env python3
 """Check internal markdown links across the documentation.
 
-Reports two kinds of breakage:
+Reports four kinds of breakage:
 
   MISSING FILE    the link target file does not exist
   MISSING ANCHOR  the file exists, but no heading in it slugifies to the anchor
+  WRONG CASE      the target exists only under different capitalisation
+  ORPHAN          a published page nothing in SUMMARY.md links to
+
+WRONG CASE matters because macOS and Windows resolve paths case-insensitively
+while GitBook and GitHub do not. A link that works on the machine that wrote it
+404s once published, and a plain os.path.isfile() check cannot see it.
+
+ORPHAN catches the opposite failure: the link resolves, but no reader can reach
+the page, because it never made it into the table of contents. Anchors and file
+existence say nothing about reachability, so this is checked separately by
+walking SUMMARY.md. Pages listed in NON_CONTENT below are exempt.
 
 Anchors are slugified with GitHub's rules, which GitBook follows: inline
 markdown is stripped, the text is lowercased, punctuation is dropped, and each
@@ -14,6 +25,9 @@ space becomes a hyphen. Note that runs of spaces are *not* collapsed, so
 Usage:
     python3 tools/linkcheck.py            # check the whole repo
     python3 tools/linkcheck.py contents/Glossary.md   # check specific files
+
+Orphans are only reported on a whole-repo run: the check needs every page in
+view to know what is missing, so passing explicit paths skips it.
 
 Exit code is 1 when anything is broken, 0 when clean, so it can gate CI.
 """
@@ -30,6 +44,12 @@ SKIP_DIRS = {'.git', '.github', '.claude', '.repomix', 'spec', 'node_modules'}
 
 # Files whose links are deliberate placeholders, not real targets.
 SKIP_FILES = {'CLAUDE.md', 'PROMPT.md'}
+
+# Pages that are not reader-facing content, so are exempt from the orphan check.
+# VersionBegin/VersionEnd are GitBook version markers, not documentation.
+NON_CONTENT = {'VersionBegin.md', 'VersionEnd.md'}
+
+TOC = 'SUMMARY.md'
 
 LINK_RE = re.compile(r'\[([^\]]*)\]\(([^)]+)\)')
 HEADING_RE = re.compile(r'^(#{1,6})\s+(.*?)\s*#*$', re.M)
@@ -73,8 +93,53 @@ def md_files():
                 yield os.path.join(dirpath, fn)
 
 
+def real_paths():
+    """Map lowercased repo-relative path -> its true on-disk spelling."""
+    out = {}
+    for p in md_files():
+        rel = os.path.relpath(p, ROOT)
+        out[rel.lower()] = rel
+    return out
+
+
+def linked_from_toc():
+    """Repo-relative paths that SUMMARY.md links to, in its own spelling."""
+    toc = os.path.join(ROOT, TOC)
+    if not os.path.isfile(toc):
+        return None
+    with open(toc, encoding='utf-8') as fh:
+        body = fh.read()
+    out = set()
+    for _, raw in LINK_RE.findall(body):
+        target = unquote(raw.strip()).split('#')[0]
+        if not target.endswith('.md'):
+            continue
+        out.add(os.path.normpath(target.lstrip('/')))
+    return out
+
+
+def orphans():
+    """Published pages that SUMMARY.md never links to."""
+    listed = linked_from_toc()
+    if listed is None:
+        return []
+    listed = {p.lower() for p in listed}
+    out = []
+    for p in md_files():
+        rel = os.path.relpath(p, ROOT)
+        # Only pages under contents/ are navigable; SUMMARY.md itself is the TOC.
+        if os.path.dirname(rel) != 'contents':
+            continue
+        if os.path.basename(rel) in NON_CONTENT:
+            continue
+        if rel.lower() not in listed:
+            out.append(rel)
+    return sorted(out)
+
+
 def check(paths):
     anchor_cache = {}
+    on_disk = real_paths()
     problems = []
     for src in paths:
         with open(src, encoding='utf-8') as fh:
@@ -101,6 +166,14 @@ def check(paths):
                 if not os.path.isfile(path):
                     problems.append(('MISSING FILE', rel_src, lineno, raw, label))
                     continue
+                # isfile() is case-insensitive on macOS/Windows, so a link that
+                # resolves here can still 404 on GitBook. Compare spellings.
+                rel_target = os.path.relpath(path, ROOT)
+                actual = on_disk.get(rel_target.lower())
+                if actual and actual != rel_target:
+                    problems.append(
+                        ('WRONG CASE', rel_src, lineno, raw, f'file is {actual}'))
+                    continue
                 if anchor:
                     if path not in anchor_cache:
                         anchor_cache[path] = anchors_for(path)
@@ -111,6 +184,7 @@ def check(paths):
 
 
 def main(argv):
+    whole_repo = not argv
     if argv:
         paths = [os.path.abspath(p) for p in argv]
         missing = [p for p in paths if not os.path.isfile(p)]
@@ -121,18 +195,29 @@ def main(argv):
         paths = list(md_files())
 
     problems = check(paths)
-    if not problems:
+    # Reachability needs every page in view, so only check it on a full run.
+    stranded = orphans() if whole_repo else []
+
+    if not problems and not stranded:
         print(f"No broken internal links ({len(paths)} files checked).")
         return 0
 
-    for kind in ('MISSING FILE', 'MISSING ANCHOR'):
+    for kind in ('MISSING FILE', 'WRONG CASE', 'MISSING ANCHOR'):
         rows = [p for p in problems if p[0] == kind]
         if not rows:
             continue
         print(f"\n===== {kind} ({len(rows)}) =====")
         for _, src, lineno, target, label in rows:
             print(f"{src}:{lineno}  [{label}]({target})")
-    print(f"\n{len(problems)} broken link(s) across {len(paths)} files.")
+
+    if stranded:
+        print(f"\n===== ORPHAN ({len(stranded)}) =====")
+        print(f"published, but nothing in {TOC} links to them:")
+        for rel in stranded:
+            print(f"  {rel}")
+
+    total = len(problems) + len(stranded)
+    print(f"\n{total} problem(s) across {len(paths)} files.")
     return 1
 
 

--- a/tools/linkcheck.py
+++ b/tools/linkcheck.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+"""Check internal markdown links across the documentation.
+
+Reports two kinds of breakage:
+
+  MISSING FILE    the link target file does not exist
+  MISSING ANCHOR  the file exists, but no heading in it slugifies to the anchor
+
+Anchors are slugified with GitHub's rules, which GitBook follows: inline
+markdown is stripped, the text is lowercased, punctuation is dropped, and each
+space becomes a hyphen. Note that runs of spaces are *not* collapsed, so
+"Handlers & Pipelines" becomes "handlers--pipelines" with two hyphens.
+
+Usage:
+    python3 tools/linkcheck.py            # check the whole repo
+    python3 tools/linkcheck.py contents/Glossary.md   # check specific files
+
+Exit code is 1 when anything is broken, 0 when clean, so it can gate CI.
+"""
+import os
+import re
+import sys
+from collections import defaultdict
+from urllib.parse import unquote
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+# Directories that hold no published documentation.
+SKIP_DIRS = {'.git', '.github', '.claude', '.repomix', 'spec', 'node_modules'}
+
+# Files whose links are deliberate placeholders, not real targets.
+SKIP_FILES = {'CLAUDE.md', 'PROMPT.md'}
+
+LINK_RE = re.compile(r'\[([^\]]*)\]\(([^)]+)\)')
+HEADING_RE = re.compile(r'^(#{1,6})\s+(.*?)\s*#*$', re.M)
+
+
+def slug(text):
+    """Convert heading text to its GitHub/GitBook anchor."""
+    text = re.sub(r'`([^`]*)`', r'\1', text)
+    text = re.sub(r'\*\*([^*]*)\*\*', r'\1', text)
+    text = re.sub(r'\*([^*]*)\*', r'\1', text)
+    text = re.sub(r'__([^_]*)__', r'\1', text)
+    text = re.sub(r'\[([^\]]*)\]\([^)]*\)', r'\1', text)
+    text = text.strip().lower()
+    text = re.sub(r'[^\w\s-]', '', text)
+    # GitHub replaces each space individually; it does not collapse runs
+    return text.replace(' ', '-')
+
+
+def anchors_for(path):
+    """All anchors a file offers, including GitHub's -1/-2 duplicate suffixes."""
+    try:
+        with open(path, encoding='utf-8') as fh:
+            body = fh.read()
+    except OSError:
+        return set()
+    seen = defaultdict(int)
+    out = set()
+    for _, text in HEADING_RE.findall(body):
+        s = slug(text)
+        n = seen[s]
+        seen[s] += 1
+        out.add(s if n == 0 else f"{s}-{n}")
+    return out
+
+
+def md_files():
+    for dirpath, dirnames, filenames in os.walk(ROOT):
+        dirnames[:] = [d for d in dirnames if d not in SKIP_DIRS]
+        for fn in sorted(filenames):
+            if fn.endswith('.md') and fn not in SKIP_FILES:
+                yield os.path.join(dirpath, fn)
+
+
+def check(paths):
+    anchor_cache = {}
+    problems = []
+    for src in paths:
+        with open(src, encoding='utf-8') as fh:
+            content = fh.read()
+        rel_src = os.path.relpath(src, ROOT)
+        for lineno, line in enumerate(content.splitlines(), 1):
+            for label, raw in LINK_RE.findall(line):
+                target = unquote(raw.strip())
+                if target.startswith(('http://', 'https://', 'mailto:')):
+                    continue
+                if target.startswith('#'):
+                    path, anchor = src, target[1:]
+                else:
+                    path, _, anchor = target.partition('#')
+                    if not path:
+                        continue
+                    if path.startswith('/'):
+                        path = os.path.join(ROOT, path.lstrip('/'))
+                    else:
+                        path = os.path.normpath(
+                            os.path.join(os.path.dirname(src), path))
+                if not path.endswith('.md'):
+                    continue
+                if not os.path.isfile(path):
+                    problems.append(('MISSING FILE', rel_src, lineno, raw, label))
+                    continue
+                if anchor:
+                    if path not in anchor_cache:
+                        anchor_cache[path] = anchors_for(path)
+                    if anchor.lower() not in anchor_cache[path]:
+                        problems.append(
+                            ('MISSING ANCHOR', rel_src, lineno, raw, label))
+    return problems
+
+
+def main(argv):
+    if argv:
+        paths = [os.path.abspath(p) for p in argv]
+        missing = [p for p in paths if not os.path.isfile(p)]
+        if missing:
+            print("no such file: " + ", ".join(missing), file=sys.stderr)
+            return 2
+    else:
+        paths = list(md_files())
+
+    problems = check(paths)
+    if not problems:
+        print(f"No broken internal links ({len(paths)} files checked).")
+        return 0
+
+    for kind in ('MISSING FILE', 'MISSING ANCHOR'):
+        rows = [p for p in problems if p[0] == kind]
+        if not rows:
+            continue
+        print(f"\n===== {kind} ({len(rows)}) =====")
+        for _, src, lineno, target, label in rows:
+            print(f"{src}:{lineno}  [{label}]({target})")
+    print(f"\n{len(problems)} broken link(s) across {len(paths)} files.")
+    return 1
+
+
+if __name__ == '__main__':
+    sys.exit(main(sys.argv[1:]))


### PR DESCRIPTION
Documents `OnceOnlyAction.Replay` (spec 008), and adds a link checker that
found and fixed a backlog of broken and unreachable pages along the way.

## Replay On Seen

New `contents/ReplayOnSeen.md` covers the stalled-workflow problem Replay
solves, how the Causation Id links an Inbox entry to the Outbox messages
produced while handling it, turning replay on per-handler and globally, the
`RequestContext` threading requirement, store support, startup validation,
observability and limitations. Notes for people implementing causation
tracking in a store they wrote themselves are split into
`contents/CausationTrackingStores.md` — a different audience, not a length
split.

Supporting updates: cross-links from `BrighterInboxSupport.md`,
`BrighterOutboxSupport.md` and `BrighterBasicConfiguration.md`; the startup
rule in `PipelineValidation.md`; a Causation index section in
`DynamoOutbox.md`; Causation Id and Replay (Inbox) in `Glossary.md`; and
`IRequestContext.InstrumentationOptions` in `V10MigrationGuide.md`
(source-breaking in 10.7.0 for direct implementors).

All 12 code examples were verified against Brighter source. Two defects that
found:

- The two "does not implement" validation errors were quoted naming
  `InMemoryInbox` and `MySqlOutbox`. Both implement the causation role
  interfaces, so neither message could occur as printed — and it contradicted
  the Store Support table on the same page.
- `DynamoOutbox.md` presented `CausationIndexName` as freely settable. It is
  also an attribute argument on `MessageItem` and so must be a compile-time
  constant; renaming it points the probe at a GSI the table model never
  declares, and replay silently finds nothing.

## Link checking

`tools/linkcheck.py` walks every published page and reports four faults:
MISSING FILE, MISSING ANCHOR, WRONG CASE (resolves on macOS and Windows,
404s on GitBook) and ORPHAN (a page `SUMMARY.md` never links to). It exits
non-zero so it can gate CI. Each check was verified by injecting the fault
and confirming the failure, not just by observing a green run.

It found 22 broken links across 18 pages — renamed-section anchors, links to
pages that never existed in this repo, and same-page anchors for sections
that live elsewhere — one case-mismatched nav link (`MongoDbInbox.md` vs the
real `MongoDBInbox.md`), and six pages that existed but were unreachable from
the table of contents, now placed: `ImplementingAHandler.md`,
`ClaimCheck.md` (with `S3LuggageStore.md` under it), `Compression.md`,
`EFCoreOutbox.md` and `AzureBlobConfiguration.md`.

`CLAUDE.md` documents the tool and ties the orphan check to the existing
"never create orphaned files" rule; `/spec:review` runs it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012tcdwxVb8NmKaX2S6fvyFg
