### PR TITLE
DO NOT MERGE: probe that pagelint --changed fires on pull_request

### DIFF
--- a/contents/AWSSQSConfiguration.md
+++ b/contents/AWSSQSConfiguration.md
@@ -31,7 +31,7 @@ public void ConfigureServices(IServiceCollection services)
 {
     if (!new CredentialProfileStoreChain().TryGetAWSCredentials("default", out var credentials)
 	{
-        throw InvalidOperationException("Missing AWS Credentials");
+        throw InvalidOperationException("Missing AWS credentials");
     }
 
     services.AddBrighter(...)


### PR DESCRIPTION
Throwaway probe for spec 011 Task 5.2. Expected to go **red**.

Task 5.2 exists because a `--changed` step that finds no changed ranges passes vacuously — the worst outcome, since the strict code rules would then never fire and the build would stay green while enforcing nothing.

This PR changes one character inside the C# block at `contents/AWSSQSConfiguration.md:29`, which has no `using` directives. Expected:

- `python3 tools/pagelint.py` (repo-wide) — **green**, 0 errors / 840 warnings
- `python3 tools/pagelint.py --changed origin/$BASE_REF` — **red**, 1 error on that block alone

Will be closed and the branch deleted as soon as the run is observed. Do not merge.