### PR TITLE
Confirm the banner renders as a callout (spec 011, Task 3.5)

### DIFF
--- a/spec/011-authoring_conventions/tasks.md
+++ b/spec/011-authoring_conventions/tasks.md
@@ -256,10 +256,51 @@ Goal: a human page-type verdict for every page, then one mechanical 105-file com
   - Output: 105 files under `contents/` each gaining one banner line and one blank line below the H1; `apply_banners.py` deleted
   - Notes: **Its own commit**, carrying nothing else — a 105-file diff is reviewable only if it is genuinely mechanical, and the linter rather than the reviewer verifies uniformity. Verify: rules 1 and 2 report **zero**; `linkcheck.py` still clean (banners carrying prerequisite links add link targets to check).
 
-- [ ] **Task 3.5:** Rendered-preview sanity check
+- [x] **Task 3.5:** Rendered-preview sanity check
   - Input: the published GitBook site after the sweep reaches a published branch
   - Output: Confirmation that the banner renders as a callout below the title, and a note in this file if it does not
   - Notes: The one leftover from requirements Q1. Not a blocker — a blockquote is ordinary Markdown and nothing about it is version-specific — but worth doing once on the first page that ships, since it is now on all 105.
+
+### Task 3.5 as executed (2026-08-05)
+
+**The banner renders as intended, checked against the published site rather than a
+preview** — PR #74 merged first, so `master` was already live. 12 pages sampled across
+the corpus, including **all five that carry a Prerequisites segment**. Every one:
+
+```text
+page                                    h1    blockquote  prereq  applies
+rabbitmqdurability                      True  True        True    Brighter V10
+rabbitmqmigratetoquorumqueues           True  True        True    Brighter V10
+rabbitmqconnectionstability             True  True        True    Brighter V10
+commandprocessorconfigurationreference  True  True        True    Brighter V10
+dispatcherconfigurationreference        True  True        True    Brighter V10
+glossary                                True  True        False   Brighter V10 and Darker V4
+basicconcepts                           True  True        False   Brighter V10 and Darker V4
+whybrighter                             True  True        False   Brighter V10 and Darker V4
+showmethecode                           True  True        False   Brighter V10 and Darker V4
+kafkaconfiguration                      True  True        False   Brighter V10
+v10migrationguide                       True  True        False   Brighter V10
+faq                                     True  True        False   Brighter V10
+```
+
+GitBook emits `<h1>` … `</header>`, then the banner as the first element of the content
+body: `<blockquote class="… border-l-2 pl-6 py-3 border-tint …">`. So it is a real
+blockquote with a left border and padding — a callout below the title, which is what
+this task asked. Inside it, `**Reference**` becomes `<strong>`, the ` · ` separators
+survive as U+00B7, and the Prerequisites link is a real `<a href>`:
+`/paramore-brighter-documentation/guaranteed-at-least-once/rabbitmqconfiguration`,
+fetched and confirmed **200**.
+
+**The obvious check would have proved nothing.** Reading the page through a
+Markdown-converting fetcher returns `> **Explanation** · Applies to …` — which is
+exactly what a *correctly rendered blockquote* converts back to, and equally what a
+literal, unrendered banner would look like. The two are indistinguishable after
+conversion, and the concern behind requirements Q1 was precisely that GitBook might emit
+the banner literally. **The check had to be run against raw HTML** for the `<blockquote>`
+element, and was.
+
+Also settled: the corpus publishes **111 URLs** (`sitemap-pages.xml`) — 110 pages plus
+the index — so all five split pages are live and none is orphaned in the published tree.
 
 **Verified by:** rules 1 and 2 at zero; `linkcheck.py` clean; every verdict human-reviewed
 (AC3).


### PR DESCRIPTION
Closes the last leftover from Spec 011's requirements Q1: does the page banner actually
render as a callout below the title, or does GitBook emit it literally?

It needed a published branch, and #74 supplied one by merging — so this was checked
against the **live site** rather than a preview revision. Documentation only; no page
under `contents/` is touched.

## What was checked

GitBook emits `<h1>` … `</header>`, then the banner as the first element of the content
body:

```html
<blockquote class="… border-l-2 pl-6 py-3 border-tint …">
  <strong>Explanation</strong> · Applies to <strong>Brighter V10</strong> ·
  Prerequisites: <a href="…/guaranteed-at-least-once/rabbitmqconfiguration">RabbitMQ Configuration</a>
```

A real blockquote with a left border and padding — a callout below the title, which is
what the convention asks for. `**Reference**` becomes `<strong>`, the ` · ` separators
survive as U+00B7, and the Prerequisites link is a genuine anchor (fetched: **200**).

12 pages sampled across the corpus, **including all five that carry a Prerequisites
segment**. That half of the banner grammar had never appeared in a rendered page until
the Phase 6 splits created pages using it, so this is the first time it has been
checkable at all.

## The check that would have proved nothing

The first attempt read the page through a Markdown-converting fetcher, which returned:

```text
> **Explanation** · Applies to **Brighter V10** · Prerequisites: [RabbitMQ Configuration](…)
```

That is exactly what a **correctly rendered blockquote** converts back to — and equally
what an **unrendered literal banner** would look like. The two are indistinguishable
after conversion, and GitBook rendering such things literally is precisely the concern
behind Q1. The check had to be run against raw HTML for the `<blockquote>` element, and
was.

## Also settled

The published site is **111 URLs** (`sitemap-pages.xml`) — 110 pages plus the index — so
all five pages created by the Phase 6 splits are live, and none is orphaned in the
published tree.

## Verification

```
python3 tools/linkcheck.py     # No broken internal links (112 files checked)
python3 tools/pagelint.py      # 0 errors, 836 warnings across 110 pages
```

Spec 011 is now **40 of 43 tasks**. Remaining: the language-tag backfill, `--fix` for
`pagelint.py`, and the acceptance pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012tcdwxVb8NmKaX2S6fvyFg
