### PR TITLE
spec 010 D0 step 1: rename a section, deliberately without a redirect

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -136,7 +136,7 @@
  * [V10 Migration Guide](/contents/V10MigrationGuide.md)
  * [Nullable Reference Types](/contents/NullableReferenceTypes.md)
 
-## Command, Processors and Dispatchers
+## Commands, Processors and Dispatchers
 
  * [Command, Processor and Dispatcher Patterns](/contents/CommandsCommandDispatcherandProcessor.md) 
 


### PR DESCRIPTION
Step 1 of two. **This PR intentionally ships a URL change with no redirect**, and step 2 adds the redirect immediately after.

## Why it has to be two PRs

Spec 010 rests on GitBook redirects working for pages that move section. GitBook resolves a URL in three steps — **automatic redirects first**, then `.gitbook.yaml` section-level redirects *only if the URL did not resolve*, then site-level redirects. It creates an automatic **HTTP 307** "whenever pages are moved or renamed", and it is **not established whether a Git-synced `SUMMARY.md` reorganisation counts as a move**.

If it does, a rename shipped alongside its redirect would work whether or not the redirect block was ever read — green and vacuous would be indistinguishable. That is exactly the failure mode `.gitbook.yaml` has already exhibited once in this repo, when two U+200B zero-width spaces meant GitBook never read the `structure:` block at all and nothing looked broken.

So this step observes what GitBook does **unaided**.

## What changes

One heading. The comma was misplaced — the section is *Commands, Processors and Dispatchers*; the page beneath it is *Command, Processor and Dispatcher Patterns*. The fix is independently right, which is why this section was chosen as the test subject.

One URL moves, of 110:

```
command-processors-and-dispatchers/commandscommanddispatcherandprocessor
  -> commands-processors-and-dispatchers/commandscommanddispatcherandprocessor
```

## Measured before publishing

| URL | Status |
|---|---|
| old path | **200** |
| new path | **404** |

Controls established on the live site first: real pages 200, every miss 404 with **no** redirect. So a 307 after this merges can only have come from GitBook.

## Interpreting the result

| Step 1 result | Meaning |
|---|---|
| old path **404** | GitBook does *not* auto-redirect Git-synced structural changes. D2/D3 are load-bearing, and step 2 must fix it. |
| old path **307** | It does. `.gitbook.yaml` redirects are belt-and-braces, and no single-request check could ever have told us. |

## Risk

Scoped deliberately: one low-traffic page in a one-page section, exposed only until step 2 merges. **No internal link is affected** — all 763 are of the form `/contents/Page.md`, and the file has not moved on disk.

`linkcheck.py` clean (112 files); `pagelint.py` 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012tcdwxVb8NmKaX2S6fvyFg