### PR TITLE
spec 010 D0 cleanup: probe key removed, both mechanisms measured

### DIFF
--- a/.gitbook.yaml
+++ b/.gitbook.yaml
@@ -10,13 +10,8 @@ redirects:
   # carried them until 2026-08-05, which is why GitBook never read the structure
   # block at all. Verify this file by byte inspection, not by eye.
 
-  # The real redirect for the section renamed in #77. Belt-and-braces: D0 step 1
-  # showed GitBook already issues an automatic 307 for this path unaided.
+  # The real redirect for the section renamed in #77. Kept as belt-and-braces: D0
+  # measured GitBook issuing an automatic 307 for this path unaided, so this entry
+  # is a safety net rather than the mechanism. D0's probe key confirmed that keys in
+  # this block ARE read and honoured; it was removed once measured (PR #79).
   command-processors-and-dispatchers/commandscommanddispatcherandprocessor: contents/CommandsCommandDispatcherandProcessor.md
-
-  # D0 probe, and the only discriminating half of this change. This path has never
-  # existed and returns 404 today, so no automatic redirect can mask the result.
-  # If it resolves after publish, .gitbook.yaml redirects are read on this site and
-  # the site plan permits them. If it still 404s, they are not, and spec 010's D2
-  # is dead. REMOVE THIS KEY once the measurement is recorded.
-  d0-probe-gitbook-yaml-redirects: contents/CommandsCommandDispatcherandProcessor.md


### PR DESCRIPTION
Closes out D0. The probe key promised for removal in #78 comes out here.

## Both halves answered

| Question | Answer |
|---|---|
| Does GitBook auto-redirect a Git-synced `SUMMARY.md` rename? | **Yes** — 307 within 25s of #77, with no redirects block in the repo |
| Are `.gitbook.yaml` redirects read on this site, and does the plan permit them? | **Yes** — the probe key began redirecting after #78; a control key absent from the block kept 404ing |

The control is what makes the second a measurement rather than a hope.

## Fingerprint

Cached responses all report `200`, so status alone proves nothing. The discriminators:

| Path class | `location:` header | Body |
|---|---|---|
| probe key **in** the block | **1** | 192,328 |
| key **not** in the block | 0 | 189,517 (404 shell) |
| renamed-away path (automatic) | **1** | 192,373 |
| real page | 0 | **584,460** |

## The finding worth more than either

**The redirect value is a repository path, and GitBook resolves it to wherever that page currently publishes.** The probe pointed at `contents/CommandsCommandDispatcherandProcessor.md` and landed on `commands-processors-and-dispatchers/…` — the *post*-rename URL. So a redirect entry does not go stale when its page moves again, which matters for a spec that will move some pages more than once.

## What stays

The real redirect for #77's rename, as a safety net. **Nothing yet establishes that automatic redirects persist over time** — they may be tied to revision history, and one session cannot test that.

Re-verified after the edit: zero bytes outside printable ASCII, parses as YAML, `structure:` intact, target exists, no leading slashes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012tcdwxVb8NmKaX2S6fvyFg