### PR TITLE
probe: does a four-segment URL publish on this site?

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -75,6 +75,7 @@
  * [Azure Service Bus Configuration](/contents/AzureServiceBusConfiguration.md)
  * [Azure Blob Archive Provider](/contents/AzureBlobArchiveProvider.md)
    * [Azure Archive Provider Configuration](/contents/AzureBlobConfiguration.md)
+     * [URL Depth Probe](/contents/UrlDepthProbe.md)
  * [Brighter Control API](/contents/BrighterControlAPI.md)
 
 ## Outbox and Inbox

--- a/contents/UrlDepthProbe.md
+++ b/contents/UrlDepthProbe.md
@@ -1,0 +1,34 @@
+# URL Depth Probe
+
+> **Reference** · Applies to **Brighter V10**
+
+This page is a temporary measurement for Spec 010 and will be removed within minutes of
+being published. It exists to establish, against the live site rather than by inference,
+whether a page nested three levels deep in `SUMMARY.md` publishes at a four-segment URL.
+
+## URL Depth Probe Method
+
+Spec 010's shape rule **S3** caps a published path at three segments, on the stated grounds
+that three is the deepest the live site is *known* to work at and four had never been
+tested. That is an evidence boundary rather than a platform limit, and it was costing
+navigation quality in two places, so it is being measured instead of assumed.
+
+This page is nested under *Azure Archive Provider Configuration*, which itself publishes at
+three segments. The predicted path is therefore:
+
+```text
+guaranteed-at-least-once/azureblobarchiveprovider/azureblobconfiguration/urldepthprobe
+```
+
+A page that has never existed at any path is used deliberately, so that no automatic
+redirect can mask the result — the same reasoning that made Spec 010's D0 experiment a
+measurement rather than a hope. No existing page moves, so no real URL churns and no
+redirect is cached against content a reader might want.
+
+The result is read from `sitemap-pages.xml` and from the response fingerprint, never from
+the status code: every cached response on this site reports `200`, and the reliable tell is
+that no genuine page response carries a `location:` header.
+
+## Further Reading
+
+- [Basic Concepts](/contents/BasicConcepts.md)


### PR DESCRIPTION
Temporary measurement for Spec 010. **To be reverted immediately after the result is recorded.**

Spec 010's shape rule **S3** caps a published path at three segments, on the stated grounds that three is the deepest the live site is *known* to work at and four is unverified. That is an evidence boundary, not a platform limit — and it is now costing navigation quality in two places:

- `MigratingToPollyV8.md` cannot nest under its own source, because `PolicyRetryAndCircuitBreaker.md` already publishes at three.
- `AzureBlobConfiguration.md` cannot sit under `AzureBlobArchiveProvider.md` under a new `OutboxArchiver.md`.

**GitBook's own documentation publishes 30 pages at four segments below its site root** (e.g. `create-content/content-structure/page/tags` — section plus two ancestor pages plus page), so the platform supports the shape. This measures *our* site.

## Method

A brand-new page at a path that has **never existed**, so no automatic redirect can mask the result — D0's reasoning. No existing page moves, so no real URL churns and no redirect caches against content a reader wants.

Predicted path:

```text
guaranteed-at-least-once/azureblobarchiveprovider/azureblobconfiguration/urldepthprobe
```

Read from `sitemap-pages.xml` and the response fingerprint, never the status code — every cached response on this site reports `200`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012tcdwxVb8NmKaX2S6fvyFg