### PR TITLE
fix: scheduling overloads take the time first, not a named at:/delay: argument

### DIFF
--- a/contents/BrighterSchedulerSupport.md
+++ b/contents/BrighterSchedulerSupport.md
@@ -49,16 +49,17 @@ public interface IAmACommandProcessor
 Specifies the **absolute time** when the message should be delivered:
 
 ```csharp
+// ...
 // Schedule for specific date and time
 var schedulerId = await commandProcessor.SendAsync(
-    new ProcessOrderCommand { OrderId = orderId },
-    at: new DateTimeOffset(2025, 1, 15, 14, 30, 0, TimeSpan.Zero)
+    new DateTimeOffset(2025, 1, 15, 14, 30, 0, TimeSpan.Zero),
+    new ProcessOrderCommand { OrderId = orderId }
 );
 
 // Schedule for 1 hour from now
 var schedulerId = await commandProcessor.SendAsync(
-    new SendReminderCommand { UserId = userId },
-    at: DateTimeOffset.UtcNow.AddHours(1)
+    DateTimeOffset.UtcNow.AddHours(1),
+    new SendReminderCommand { UserId = userId }
 );
 ```
 
@@ -67,16 +68,17 @@ var schedulerId = await commandProcessor.SendAsync(
 Specifies a **relative delay** from the current time:
 
 ```csharp
+// ...
 // Schedule for 30 minutes from now
 var schedulerId = await commandProcessor.SendAsync(
-    new ProcessPaymentCommand { TransactionId = txId },
-    delay: TimeSpan.FromMinutes(30)
+    TimeSpan.FromMinutes(30),
+    new ProcessPaymentCommand { TransactionId = txId }
 );
 
 // Schedule for 5 seconds from now (useful for retry)
 var schedulerId = commandProcessor.Send(
-    new RetryOperationCommand { AttemptNumber = 2 },
-    delay: TimeSpan.FromSeconds(5)
+    TimeSpan.FromSeconds(5),
+    new RetryOperationCommand { AttemptNumber = 2 }
 );
 ```
 
@@ -89,10 +91,11 @@ All scheduling methods return a `string` representing the **scheduler ID**. This
 - **Track** scheduled messages in your application
 
 ```csharp
+// ...
 // Save the scheduler ID for later use
 string schedulerId = await commandProcessor.SendAsync(
-    new CancelableOperationCommand { OperationId = opId },
-    delay: TimeSpan.FromMinutes(30)
+    TimeSpan.FromMinutes(30),
+    new CancelableOperationCommand { OperationId = opId }
 );
 
 // Later, cancel the scheduled message if needed

--- a/contents/PostgreSQLMessageBroker.md
+++ b/contents/PostgreSQLMessageBroker.md
@@ -372,6 +372,7 @@ var configuration = new RelationalDatabaseConfiguration(
 PostgreSQL message broker supports message scheduling using the visibility timeout:
 
 ```csharp
+// ...
 // Schedule message for future delivery
 var delayedEvent = new OrderReminderEvent
 {
@@ -380,8 +381,8 @@ var delayedEvent = new OrderReminderEvent
 };
 
 await _commandProcessor.PublishAsync(
-    delayedEvent,
-    delay: TimeSpan.FromHours(24)  // Deliver in 24 hours
+    TimeSpan.FromHours(24),        // Deliver in 24 hours
+    delayedEvent
 );
 ```
 

--- a/contents/SchedulingAMessage.md
+++ b/contents/SchedulingAMessage.md
@@ -24,8 +24,8 @@ public class OrderService
         // Schedule order processing for tomorrow at 9 AM
         var processTime = DateTime.UtcNow.Date.AddDays(1).AddHours(9);
         var schedulerId = await _commandProcessor.SendAsync(
-            new ProcessOrderCommand { OrderId = order.Id },
-            at: new DateTimeOffset(processTime)
+            new DateTimeOffset(processTime),
+            new ProcessOrderCommand { OrderId = order.Id }
         );
 
         // Store scheduler ID for potential cancellation
@@ -54,8 +54,8 @@ public class RegistrationService
 
         // Schedule reminder email for 24 hours later
         await _commandProcessor.SendAsync(
-            new SendReminderEmailCommand { UserId = user.Id },
-            delay: TimeSpan.FromHours(24)
+            TimeSpan.FromHours(24),
+            new SendReminderEmailCommand { UserId = user.Id }
         );
     }
 }
@@ -75,12 +75,12 @@ public class NotificationService
     {
         // Schedule notification to be sent via external bus
         var schedulerId = await _commandProcessor.PostAsync(
+            request.Delay,
             new NotificationEvent
             {
                 UserId = request.UserId,
                 Message = request.Message
-            },
-            delay: request.Delay
+            }
         );
 
         // Return scheduler ID for tracking
@@ -137,8 +137,8 @@ public class RetryService
 
         // Schedule retry
         await _commandProcessor.SendAsync(
-            command with { AttemptNumber = attemptNumber + 1 },
-            delay: delay
+            delay,
+            command with { AttemptNumber = attemptNumber + 1 }
         );
     }
 }


### PR DESCRIPTION
**Ten calls across three pages did not compile.** `IAmACommandProcessor` declares every scheduling overload with the time as the **first** parameter:

```csharp
string       Send<TRequest>(DateTimeOffset at, TRequest command, ...)       // IAmACommandProcessor.cs:61
string       Send<TRequest>(TimeSpan delay, TRequest command, ...)          // :73
Task<string> SendAsync<TRequest>(DateTimeOffset at, TRequest command, ...)  // :98
Task<string> SendAsync<TRequest>(TimeSpan delay, TRequest command, ...)     // :111
string       Publish<TRequest>(DateTimeOffset at, TRequest @event, ...)     // :131
Task<string> PublishAsync<TRequest>(TimeSpan delay, TRequest @event, ...)   // :190
Task<string> PostAsync<TRequest>(TimeSpan delay, TRequest request, ...)     // :282
```

There is **no overload taking the request first with a named `at:`/`delay:` argument**. The plain `SendAsync(TRequest command, ...)` returns `Task`, not `Task<string>` — so the docs also assigned a scheduler ID from a call that returns nothing.

## What changed

| Page | Calls |
|---|---:|
| `contents/SchedulingAMessage.md` | 4 — `SendAsync` ×3, `PostAsync` ×1 |
| `contents/BrighterSchedulerSupport.md` | 5 — `SendAsync` ×4, `Send` ×1 |
| `contents/PostgreSQLMessageBroker.md` | 1 — `PublishAsync` |

Before and after:

```csharp
// before — does not compile
var schedulerId = await _commandProcessor.SendAsync(
    new ProcessOrderCommand { OrderId = order.Id },
    at: new DateTimeOffset(processTime)
);

// after
var schedulerId = await _commandProcessor.SendAsync(
    new DateTimeOffset(processTime),
    new ProcessOrderCommand { OrderId = order.Id }
);
```

## Why it is a separate PR

Found during spec 010 Phase 5 while checking the signature for an unrelated reason, and recorded there. `SchedulingAMessage.md` was created in Phase 4 by moving the text verbatim from `BrighterSchedulerSupport.md`, so standing obligation 1 — *move the text, do not improve it* — was honoured, and **the defect is older than both phases**. The sweep therefore covers the whole class rather than only the page 010 created, which is why it does not belong inside a phase PR.

Editing the blocks made them overlap the diff, so `pagelint --changed` turned four of them strict and reported them as errors. They carry fictional user types (`ProcessOrderCommand` and friends) whose namespaces cannot be determined, so the omission is **marked `// ...` rather than guessed at**, per Appendix C's *do not backfill `using` directives you have not checked*.

## Gates

| | |
|---|---|
| `linkcheck.py` | clean, 122 files |
| `pagelint.py` | 0 errors, 791 warnings, 120 pages |
| `urlmap.py --check-shape` | 0 — 120 pages, deepest 4, widest 10 |
| `urlmap.py --check-redirects` | 0 — 77 entries |
| `pagelint.py --changed origin/master` | 0 errors |

No page is added, removed or renamed; **no URL moves**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012tcdwxVb8NmKaX2S6fvyFg