### PR TITLE
spec: 010 — Task 10.1 closed, 10.3 ruled, AC9 narrowed

### DIFF
--- a/spec/010-information_architecture/design.md
+++ b/spec/010-information_architecture/design.md
@@ -750,6 +750,24 @@ parsed `​structure:` happily. **Type the block; never paste it.**
 
 ### 9.2 D6 — `tools/llmstxt.py`, and Q9
 
+> **Superseded in its mechanism 2026-08-12, and vindicated in its rule.** `tools/llmstxt.py`
+> is **not built**: GitBook owns `/llms.txt`, generates it from the published tree, and we
+> cannot override it — measured in `tasks.md` §3, ruled at Task 10.3. **The summary now
+> travels as `description:` front matter on the page**, which GitBook reads and emits into
+> that canonical index as `- [Title](url): description`. Proven on the live site the same
+> day: one page's entry gained exactly **105 bytes** — its 103-character description plus
+> `": "` — and nothing else in the file moved.
+>
+> **Everything below about *the sentence* stands, and matters more now than when it was
+> written.** There is no generator to fail the build, so the extraction rule becomes Task
+> 10.4's check and the front matter it feeds. The paragraph's central claim — that a
+> hand-written parallel table drifts and a sentence living in the page cannot — is exactly
+> why the front-matter route is the same design by another mechanism.
+>
+> **One amendment the section asked for is now moot.** It proposed `llms.txt` emit published
+> URLs rather than repository paths, and called it the maintainer's call. The platform emits
+> published URLs already; there is no file of ours for the question to apply to.
+
 `CLAUDE.md` fixes the format as `- [Title](path): Type — one sentence.` The type comes
 from the banner. **The sentence comes from the page's own opening sentence**, and the
 generator refuses to invent one:
@@ -918,7 +936,7 @@ Three corrections, all recorded in requirements §8 and §2.1:
 | AC6 | No section of one page; none unnavigable | **S1/S2/S3** in §4, enforced by `--check-shape` |
 | AC7 | Per split, no information loss, mechanically | D5 per split. Partial completion is a valid end state |
 | AC8 | All 16 `keep` rows honoured | §7 touches none of them; §7.7 changes no verdict |
-| AC9 | `llms.txt` generated, not hand-written | §9.2 — extracted from the page, and the build fails when it cannot be |
+| AC9 | A summary per page, set at source, reaching the canonical `/llms.txt` | §9.2 **as re-scoped** — `description:` front matter carrying the page's own opening sentence, and the build fails when that sentence cannot be extracted. **Narrowed 2026-08-12**, requirements §12 |
 
 ---
 

--- a/spec/010-information_architecture/requirements.md
+++ b/spec/010-information_architecture/requirements.md
@@ -486,7 +486,37 @@ rather than a list here. Two placement rules bind it:
 | **AC6** | No section holds one page; no section is unnavigable without a middle layer | review against the final tree — **threshold still open, Q8** |
 | **AC7** | **Per split:** every split that lands proves no information loss for that split, mechanically. **Partial completion of the 26 is a valid end state** — the spec is accepted on the splits it landed, not blocked on the ones it did not | D5, per split |
 | **AC8** | Every `worklist.md` `keep` verdict is honoured — 16 rows across 15 pages | review |
-| **AC9** | `llms.txt` covers every page with type and one-line summary, generated not hand-written | D6 |
+| **AC9** | Every page carries a one-line summary that reaches the canonical `/llms.txt`, set at source and never hand-maintained in a parallel file. **Narrowed 2026-08-12** — see below | D6, as re-scoped |
+
+> **AC9 narrowed 2026-08-12, at Task 10.3's ruling.** It read *"`llms.txt` covers every page
+> with type and one-line summary, generated not hand-written"*, and that was written before
+> anyone measured what the platform ships. **GitBook owns `/llms.txt`, generates it from the
+> published tree, and we cannot override it** — so a criterion phrased as *we generate a file*
+> was asking for the wrong artefact. What is left of the intent survives intact: every page
+> gets a summary, it is derived from the page rather than authored in parallel, and it reaches
+> a retrieval client.
+>
+> **Two clauses changed and one was dropped, deliberately:**
+>
+> - *"generated not hand-written"* becomes **"set at source"**. The point of that clause was
+>   that a parallel table drifts from the pages within a release. Front matter on the page
+>   cannot drift from the page, which satisfies the intent by a route the criterion did not
+>   anticipate.
+> - *"`llms.txt` covers every page"* becomes **"reaches the canonical `/llms.txt`"** — measured
+>   2026-08-12: our space contributes **143** of the index's 202 entries, one per page under
+>   `contents/` plus `README`, automatically.
+> - **"with type" is dropped.** The platform's line format is `- [Title](url): description`
+>   and has no type field. It could be smuggled into the description as a `Reference — ` prefix
+>   and **should not be**: the same string is the page's `<meta name="description">`,
+>   `og:description` and `twitter:description`, so the prefix would degrade every search
+>   snippet and social card to carry information a retrieval client already has — the `.md`
+>   variant leads with the H1 and then the banner, which states the type in full. **Measured,
+>   not assumed:** `…/azureblobconfiguration.md` opens `# Azure Archive Provider Configuration`
+>   then `> **Reference** · Applies to **Brighter V10**`.
+>
+> `CLAUDE.md`'s § llms.txt documents the four-part format `- [Title](path): Type — one
+> sentence.` That section now describes a file this spec does not build; **amending it is
+> Phase 11's**, and it should record the platform's format rather than an aspiration.
 
 ---
 

--- a/spec/010-information_architecture/tasks.md
+++ b/spec/010-information_architecture/tasks.md
@@ -2445,6 +2445,45 @@ is not a safe default at 142 pages.
 
 **Only then** narrow AC9, and only then sweep the remaining 141 pages and the 59 on `v9`.
 
+### Task 10.1 closed — the index measured after merge, 2026-08-12
+
+PR #96 merged as `c521d6b`. **The deploy was confirmed by the control before the index was
+read** — the live `.md` variant carried the corrected paragraph — and only then:
+
+```text
+- [Azure Archive Provider Configuration](https://…/azureblobconfiguration.md): The Azure
+  Archive Provider writes messages swept from your Outbox into an Azure Blob Storage container.
+```
+
+**The whole file moved by 105 bytes — the description's 103 characters plus `": "` — and that
+one line is the only diff.** 32,792 → 32,897, entries carrying a description **0 → 1** of 143.
+
+**So the format is the platform's, and `CLAUDE.md`'s minus the type.** GitBook emits
+`- [Title](url): description`. There is no type field, the type could only be smuggled in as a
+`Reference — ` prefix, and it **should not be**: that same string is the page's
+`<meta name="description">`, `og:description` and `twitter:description`, so the prefix would
+degrade every search snippet and social card to repeat something the `.md` variant already
+states one line below the H1. **AC9 is narrowed accordingly** — requirements §12 carries the
+three clause changes and why, design §14 the row, design §9.2 the supersession note.
+
+**`tools/llmstxt.py` is not built.** D6's mechanism is superseded and its rule is not: the
+extraction discipline moves into Task 10.4's check, which now has something to feed.
+
+**What Phase 10 has left, in order:**
+
+1. **Task 10.4** — implement the opening-sentence rule and fix the **15** pages still failing
+   it (16 before `AzureBlobConfiguration.md`). It must rule on *source or rendered* for the
+   200-character limit; the answer is rendered.
+2. **The sweep** — `description:` plus `layout.description.visible: false` on the remaining
+   141 pages, derived mechanically from each page's opening sentence with markdown stripped,
+   **every value quoted**.
+3. **Task 10.2's fix** — the 59 pages on `v9`, whose descriptions carry the version marker
+   their bodies lack. A separate PR: a different branch, a different space, no banners, and
+   nothing `pagelint.py` can see.
+
+- [x] **Task 10.1** — the mechanism established and measured end to end
+- [x] **Task 10.3** — ruled *fix it at source*; AC9 narrowed in all three documents
+
 ---
 
 ## Phase 11 — Close (PR 11)


### PR DESCRIPTION
Spec documents only — no file under `contents/`, nothing published changes.

## The index, measured after #96 deployed

The deploy was confirmed by the control **before** the index was read — the live `.md` carried the corrected paragraph — and only then:

```
- [Azure Archive Provider Configuration](…/azureblobconfiguration.md): The Azure Archive
  Provider writes messages swept from your Outbox into an Azure Blob Storage container.
```

**The file moved by exactly 105 bytes** — the description's 103 characters plus `": "` — and **that one line is the only diff**. 32,792 → 32,897; entries carrying a description **0 → 1** of 143. Task 10.1 closes.

## The format is the platform's, and it is `CLAUDE.md`'s minus the type

GitBook emits `- [Title](url): description`. There is no type field. It could only be smuggled in as a `Reference — ` prefix and **should not be**: that same string is the page's `<meta name="description">`, `og:description` and `twitter:description`, so the prefix would degrade every search snippet and social card to repeat what the `.md` variant already states one line below the H1 — measured, not assumed.

## AC9, narrowed in three places

- **requirements §12** — the row, plus the three clause changes and why: *"generated not hand-written"* → **"set at source"** (front matter on the page cannot drift from the page, which is what that clause was protecting); *"`llms.txt` covers every page"* → **"reaches the canonical `/llms.txt`"**; and **"with type" dropped**.
- **design §14** — the row.
- **design §9.2** — superseded in its mechanism, vindicated in its rule. **`tools/llmstxt.py` is not built.** The extraction discipline moves into Task 10.4's check, which now has something to feed. Its proposed "published URLs, not repository paths" amendment is moot — the platform emits published URLs and there is no file of ours for the question to apply to.

`CLAUDE.md` § llms.txt now documents a file this spec does not build. **Amending it is Phase 11's**, flagged there.

## What Phase 10 has left

1. **Task 10.4** — implement the rule, fix the **15** pages still failing it, and rule *source or rendered* for the 200-character limit (the answer is rendered).
2. **The sweep** — 141 pages, `description:` + `layout.description.visible: false`, every value quoted.
3. **Task 10.2's fix** — the 59 pages on `v9`, in a separate PR.

## Gates

linkcheck **144 files**; pagelint **0 errors / 791 warnings / 142 pages**. Unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012tcdwxVb8NmKaX2S6fvyFg