### PR TITLE
spec: 010 — the description sweep, 142 of 142

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -418,11 +418,19 @@ Version markers are the one convention with no rule, and deliberately so: whethe
 code blocks differ *by version* is a judgement about meaning, and a regex that guessed
 at it would fire on every before/after pair in the repo. It is checked in review.
 
-**`--fix` repairs two of these and refuses the rest.** It retargets a banner whose
+**`--fix` repairs three of these and refuses the rest.** It retargets a banner whose
 *Applies to* is stale against `APPLIES_TO` — which is what makes a version bump one
-edit to that tuple plus one command — and tags an untagged fence ```` ```text ````
-when nothing in the block looks like code. It rewrites only the version segment, so
+edit to that tuple plus one command — tags an untagged fence ```` ```text ```` when
+nothing in the block looks like code, and writes a page's `description:` front matter
+from its own opening sentence. It rewrites only the version segment, so
 the page type and any Prerequisites are out of its reach by construction.
+
+The description repair is what swept all 142 pages, and it refuses in two cases rather
+than guessing. It refuses when the sentence it would copy **fails rule 7**, so `--fix`
+cannot manufacture a description the linter then rejects — nor, worse, one it accepts.
+And it refuses when **the H1 is not on line 1**: GitBook reads front matter only at the
+very first byte of a file, so a block written under a leading blank line is not front
+matter at all, and the page simply has no description with nothing to say so.
 
 It **never decides a page type.** That is a judgement about what a page is *for*, it
 cannot be recovered from the text, and a wrong one is invisible: a page mislabelled

--- a/contents/AWSSQSConfiguration.md
+++ b/contents/AWSSQSConfiguration.md
@@ -1,3 +1,10 @@
+---
+description: "SNS and SQS are proprietary message-oriented-middleware available on the AWS platform."
+layout:
+  description:
+    visible: false
+---
+
 # AWS SQS Configuration
 
 > **Reference** · Applies to **Brighter V10**

--- a/contents/AWSSQSMigrateToV10.md
+++ b/contents/AWSSQSMigrateToV10.md
@@ -1,3 +1,10 @@
+---
+description: "Brighter provides support for both version 3 and version 4 of the AWS SDK for .NET through separate NuGet packages."
+layout:
+  description:
+    visible: false
+---
+
 # Migrating AWS SQS to V10
 
 > **How-to** · Applies to **Brighter V10** · Prerequisites: [AWS SQS Configuration](/contents/AWSSQSConfiguration.md)

--- a/contents/AggregationQueryPatterns.md
+++ b/contents/AggregationQueryPatterns.md
@@ -1,3 +1,10 @@
+---
+description: "How to return whole collections, counts, and summary statistics from a query handler."
+layout:
+  description:
+    visible: false
+---
+
 # Collection and Aggregation Query Patterns
 
 > **How-to** · Applies to **Darker V4** · Prerequisites: [Query Patterns](/contents/QueryPatterns.md)

--- a/contents/AgreementDispatcher.md
+++ b/contents/AgreementDispatcher.md
@@ -1,3 +1,10 @@
+---
+description: "The Agreement Dispatcher is a pattern for routing requests to handlers dynamically based on the request's content or context, rather than using a fixed type-to-handler mapping."
+layout:
+  description:
+    visible: false
+---
+
 # Agreement Dispatcher
 
 > **How-to** · Applies to **Brighter V10**

--- a/contents/AgreementDispatcherRouting.md
+++ b/contents/AgreementDispatcherRouting.md
@@ -1,3 +1,10 @@
+---
+description: "Why you would route a request by its content rather than its type, what that buys you, and what it costs."
+layout:
+  description:
+    visible: false
+---
+
 # Agreement Dispatcher Routing
 
 > **Explanation** · Applies to **Brighter V10** · Prerequisites: [Agreement Dispatcher](/contents/AgreementDispatcher.md)

--- a/contents/AnalyzerSupport.md
+++ b/contents/AnalyzerSupport.md
@@ -1,3 +1,10 @@
+---
+description: "Brighter provides Roslyn analyzers that detect common configuration and message-mapping mistakes while you write and build your application."
+layout:
+  description:
+    visible: false
+---
+
 # Analyzer Support
 
 > **Reference** · Applies to **Brighter V10**

--- a/contents/AsyncAPISupport.md
+++ b/contents/AsyncAPISupport.md
@@ -1,3 +1,10 @@
+---
+description: "Brighter can automatically generate AsyncAPI 3.0 documents from your service's runtime configuration."
+layout:
+  description:
+    visible: false
+---
+
 # AsyncAPI Document Generation
 
 > **How-to** · Applies to **Brighter V10**

--- a/contents/AsyncDispatchARequest.md
+++ b/contents/AsyncDispatchARequest.md
@@ -1,3 +1,10 @@
+---
+description: "Once you have implemented your async Request Handler, you will want to dispatch Commands and Events to it through the Command Processor's asynchronous methods."
+layout:
+  description:
+    visible: false
+---
+
 # Dispatching Requests Asynchronously
 
 > **How-to** · Applies to **Brighter V10**

--- a/contents/AwsScheduler.md
+++ b/contents/AwsScheduler.md
@@ -1,3 +1,10 @@
+---
+description: "AWS EventBridge Scheduler is a fully managed, serverless service on AWS that allows you to create, run, and manage scheduled tasks at scale."
+layout:
+  description:
+    visible: false
+---
+
 # AWS Scheduler
 
 > **Reference** · Applies to **Brighter V10**

--- a/contents/AzureBlobArchiveProvider.md
+++ b/contents/AzureBlobArchiveProvider.md
@@ -1,3 +1,10 @@
+---
+description: "The Azure Blob Archive Provider is a provider for Outbox Archiver."
+layout:
+  description:
+    visible: false
+---
+
 # Azure Blob Archive Provider
 
 > **Reference** · Applies to **Brighter V10**

--- a/contents/AzureBlobDistributedLock.md
+++ b/contents/AzureBlobDistributedLock.md
@@ -1,3 +1,10 @@
+---
+description: "The Azure Blob locking provider implements Brighter's distributed lock using blob leases in Azure Blob Storage, so a single Outbox Sweeper and Archiver run when you scale out."
+layout:
+  description:
+    visible: false
+---
+
 # Azure Blob Distributed Lock
 
 > **Reference** · Applies to **Brighter V10**

--- a/contents/AzureScheduler.md
+++ b/contents/AzureScheduler.md
@@ -1,3 +1,10 @@
+---
+description: "Azure Service Bus includes native support for scheduled message delivery using the ScheduledEnqueueTimeUtc property."
+layout:
+  description:
+    visible: false
+---
+
 # Azure Service Bus Scheduler
 
 > **Reference** · Applies to **Brighter V10**

--- a/contents/AzureServiceBusConfiguration.md
+++ b/contents/AzureServiceBusConfiguration.md
@@ -1,3 +1,10 @@
+---
+description: "Azure Service Bus (ASB) is a fully managed enterprise message broker and is well documented Brighter handles the details of sending to or receiving from ASB."
+layout:
+  description:
+    visible: false
+---
+
 # Azure Service Bus Configuration
 
 > **Reference** · Applies to **Brighter V10**

--- a/contents/BasicConcepts.md
+++ b/contents/BasicConcepts.md
@@ -1,3 +1,10 @@
+---
+description: "A command is an instruction to carry out work."
+layout:
+  description:
+    visible: false
+---
+
 # Basic Concepts
 
 > **Reference** · Applies to **Brighter V10 and Darker V4**

--- a/contents/BoxProvisioning.md
+++ b/contents/BoxProvisioning.md
@@ -1,3 +1,10 @@
+---
+description: "BoxProvisioning is the Brighter library that creates and migrates your Outbox and Inbox tables at application startup."
+layout:
+  description:
+    visible: false
+---
+
 # Box Provisioning
 
 > **Explanation** · Applies to **Brighter V10**

--- a/contents/BoxProvisioningConfiguration.md
+++ b/contents/BoxProvisioningConfiguration.md
@@ -1,3 +1,10 @@
+---
+description: "This page is the how-to companion to Box Provisioning."
+layout:
+  description:
+    visible: false
+---
+
 # Configuring Box Provisioning
 
 > **How-to** · Applies to **Brighter V10**

--- a/contents/BoxProvisioningUpgrade.md
+++ b/contents/BoxProvisioningUpgrade.md
@@ -1,3 +1,10 @@
+---
+description: "This page is for operators of a pre-existing Brighter deployment who are adopting Database Provisioning for the first time."
+layout:
+  description:
+    visible: false
+---
+
 # Upgrading Existing Deployments
 
 > **How-to** · Applies to **Brighter V10**

--- a/contents/BrighterBasicConfiguration.md
+++ b/contents/BrighterBasicConfiguration.md
@@ -1,3 +1,10 @@
+---
+description: "Configuration is the most labor-intensive part of using Brighter."
+layout:
+  description:
+    visible: false
+---
+
 # Basic Configuration
 
 > **How-to** · Applies to **Brighter V10**

--- a/contents/BrighterControlAPI.md
+++ b/contents/BrighterControlAPI.md
@@ -1,8 +1,15 @@
+---
+description: "The Brighter Control API allows direct management of a Dispatcher node."
+layout:
+  description:
+    visible: false
+---
+
 # **Brighter Control API**
 
 > **Reference** · Applies to **Brighter V10**
 
-The brighter control API allows direct management of a Dispatcher node
+The Brighter Control API allows direct management of a Dispatcher node.
 
 ## Configuring the API
 

--- a/contents/BrighterInboxSupport.md
+++ b/contents/BrighterInboxSupport.md
@@ -1,3 +1,10 @@
+---
+description: "Messaging makes the guaranteed, at least once promise."
+layout:
+  description:
+    visible: false
+---
+
 # Brighter Inbox Support
 
 > **Explanation** · Applies to **Brighter V10**

--- a/contents/BrighterOutboxSupport.md
+++ b/contents/BrighterOutboxSupport.md
@@ -1,8 +1,15 @@
+---
+description: "Brighter supports storing messages that are sent via an External Bus in an Outbox, as per the Outbox Pattern."
+layout:
+  description:
+    visible: false
+---
+
 # Outbox Support
 
 > **Explanation** · Applies to **Brighter V10**
 
-Brighter supports storing messages that are sent via an External Bus in an Outbox, as per the [Outbox Pattern](/contents/OutboxPattern.md)
+Brighter supports storing messages that are sent via an External Bus in an Outbox, as per the [Outbox Pattern](/contents/OutboxPattern.md).
 
 This allows you to determine that a change to an entity owned by your application should always result in a message being sent i.e. you have Transactional Messaging.
 

--- a/contents/BrighterSchedulerSupport.md
+++ b/contents/BrighterSchedulerSupport.md
@@ -1,3 +1,10 @@
+---
+description: "In distributed applications, it is often necessary to schedule messages for deferred execution—whether for implementing delayed workflows, retry mechanisms, or time-based business processes."
+layout:
+  description:
+    visible: false
+---
+
 # Brighter Scheduler Support
 
 > **Explanation** · Applies to **Brighter V10**

--- a/contents/BuildingAPipeline.md
+++ b/contents/BuildingAPipeline.md
@@ -1,3 +1,10 @@
+---
+description: "Once Brighter is dispatching requests to your handlers, you can insert orthogonal operations into the pipeline that runs around each handler."
+layout:
+  description:
+    visible: false
+---
+
 # Building a Pipeline of Request Handlers
 
 > **How-to** · Applies to **Brighter V10**

--- a/contents/BuildingAnAsyncPipeline.md
+++ b/contents/BuildingAnAsyncPipeline.md
@@ -1,3 +1,10 @@
+---
+description: "An async pipeline wraps an async request handler in the same orthogonal operations a synchronous pipeline uses, with attributes whose handlers await."
+layout:
+  description:
+    visible: false
+---
+
 # Building a Pipeline of Async Request Handlers
 
 > **How-to** · Applies to **Brighter V10**

--- a/contents/CQRSUseCasesAndPatterns.md
+++ b/contents/CQRSUseCasesAndPatterns.md
@@ -1,3 +1,10 @@
+---
+description: "Four shapes a CQRS system takes in practice, from a single database with two models to event-sourced writes with projected reads."
+layout:
+  description:
+    visible: false
+---
+
 # CQRS Use Cases and Patterns
 
 > **Explanation** · Applies to **Brighter V10 and Darker V4** · Prerequisites: [CQRS with Brighter and Darker](/contents/CQRSWithBrighterAndDarker.md)

--- a/contents/CQRSWithBrighterAndDarker.md
+++ b/contents/CQRSWithBrighterAndDarker.md
@@ -1,3 +1,10 @@
+---
+description: "Command Query Responsibility Segregation (CQRS) separates the handling of commands, which change state, from queries, which read it."
+layout:
+  description:
+    visible: false
+---
+
 # CQRS with Brighter and Darker
 
 > **Explanation** · Applies to **Brighter V10 and Darker V4**

--- a/contents/CausationTrackingStores.md
+++ b/contents/CausationTrackingStores.md
@@ -1,11 +1,18 @@
+---
+description: "Replay On Seen needs two things from your storage."
+layout:
+  description:
+    visible: false
+---
+
 # Implementing Causation Tracking in Your Own Store
 
 > **How-to** · Applies to **Brighter V10**
 
-[Replay On Seen](/contents/ReplayOnSeen.md) needs two things from your storage: an Inbox
-that can hand back the [Causation Id](/contents/ReplayOnSeen.md#causation-id) it recorded
-when a request was first handled, and an Outbox that can find every message stored under
-that Causation Id and make it outstanding again. A **Causation Id** is the value shared by
+[Replay On Seen](/contents/ReplayOnSeen.md) needs two things from your storage. It needs
+an Inbox that can hand back the [Causation Id](/contents/ReplayOnSeen.md#causation-id) it
+recorded when a request was first handled, and an Outbox that can find every message stored
+under that Causation Id and make it outstanding again. A **Causation Id** is the value shared by
 an Inbox entry and every Outbox message the handler produced during that invocation; it
 defaults to the handled request's own `Id`. Brighter asks for both capabilities through a
 pair of optional role interfaces, and this page covers what your implementation has to do.

--- a/contents/ClaimCheck.md
+++ b/contents/ClaimCheck.md
@@ -1,3 +1,10 @@
+---
+description: "The Claim Check pattern helps us reduce the size of our messages, without losing information that we need to exchange."
+layout:
+  description:
+    visible: false
+---
+
 # Claim Check
 
 > **Explanation** · Applies to **Brighter V10**

--- a/contents/CloudEventsReference.md
+++ b/contents/CloudEventsReference.md
@@ -1,3 +1,10 @@
+---
+description: "CloudEvents defines both required and optional attributes for events."
+layout:
+  description:
+    visible: false
+---
+
 # CloudEvents Reference
 
 > **Reference** · Applies to **Brighter V10** · Prerequisites: [Cloud Events Support](/contents/CloudEventsSupport.md)

--- a/contents/CloudEventsSupport.md
+++ b/contents/CloudEventsSupport.md
@@ -1,3 +1,10 @@
+---
+description: "CloudEvents is a CNCF specification for describing event data in a common, standardized way."
+layout:
+  description:
+    visible: false
+---
+
 # Cloud Events Support
 
 > **How-to** · Applies to **Brighter V10**

--- a/contents/CommandProcessorConfigurationReference.md
+++ b/contents/CommandProcessorConfigurationReference.md
@@ -1,9 +1,16 @@
+---
+description: "Every option for configuring a Brighter Command Processor, in one place."
+layout:
+  description:
+    visible: false
+---
+
 # Command Processor Configuration Reference
 
 > **Reference** · Applies to **Brighter V10** · Prerequisites: [Basic Configuration](/contents/BrighterBasicConfiguration.md)
 
-Every option for configuring a Brighter **Command Processor** — the service
-collection extensions, the validation Brighter applies to them, and the
+Every option for configuring a Brighter **Command Processor**, in one place. That covers
+the service collection extensions, the validation Brighter applies to them, and the
 `IBrighterBuilder` fluent interface that configures an External Bus, an Outbox
 and JSON serialisation.
 

--- a/contents/CommandsCommandDispatcherandProcessor.md
+++ b/contents/CommandsCommandDispatcherandProcessor.md
@@ -1,3 +1,10 @@
+---
+description: "The Command design pattern encapsulates a request as an object, allowing reuse, queuing or logging of requests, or undoable operations."
+layout:
+  description:
+    visible: false
+---
+
 # Command Patterns
 
 > **Explanation** · Applies to **Brighter V10**

--- a/contents/Compression.md
+++ b/contents/Compression.md
@@ -1,3 +1,10 @@
+---
+description: "The Compression transform helps us reduce the size of a message using a compression algorithm."
+layout:
+  description:
+    visible: false
+---
+
 # Compression
 
 > **Explanation** · Applies to **Brighter V10**

--- a/contents/ConfiguringOpenTelemetry.md
+++ b/contents/ConfiguringOpenTelemetry.md
@@ -1,3 +1,10 @@
+---
+description: "The OpenTelemetry SDK can be configured to listen to Activities emitted by Brighter."
+layout:
+  description:
+    visible: false
+---
+
 # Configuring OpenTelemetry
 
 > **How-to** · Applies to **Brighter V10** · Prerequisites: [Telemetry](/contents/Telemetry.md)

--- a/contents/CustomScheduler.md
+++ b/contents/CustomScheduler.md
@@ -1,3 +1,10 @@
+---
+description: "To add support for a different scheduler provider, implement the appropriate interfaces based on your use case."
+layout:
+  description:
+    visible: false
+---
+
 # Custom Scheduler
 
 > **How-to** · Applies to **Brighter V10**

--- a/contents/DapperOutbox.md
+++ b/contents/DapperOutbox.md
@@ -1,3 +1,10 @@
+---
+description: "The Dapper Outbox allows integration between Dapper and Brighter's outbox support."
+layout:
+  description:
+    visible: false
+---
+
 # Dapper Outbox
 
 > **Reference** · Applies to **Brighter V10**

--- a/contents/DarkerAndBrighterPipelines.md
+++ b/contents/DarkerAndBrighterPipelines.md
@@ -1,3 +1,10 @@
+---
+description: "Darker's query pipeline shares many similarities with Brighter's request pipeline, as both implement the same Russian Doll Model for middleware composition."
+layout:
+  description:
+    visible: false
+---
+
 # Darker and Brighter Pipelines
 
 > **Explanation** · Applies to **Darker V4** · Prerequisites: [Query Pipeline and Decorators](/contents/QueryPipeline.md)

--- a/contents/DarkerBasicConfiguration.md
+++ b/contents/DarkerBasicConfiguration.md
@@ -1,3 +1,10 @@
+---
+description: "Darker is the query-side counterpart to Brighter, implementing the Query Object pattern for CQRS (Command Query Responsibility Segregation) architectures."
+layout:
+  description:
+    visible: false
+---
+
 # Basic Configuration
 
 > **How-to** · Applies to **Darker V4**

--- a/contents/DarkerConfigurationReference.md
+++ b/contents/DarkerConfigurationReference.md
@@ -1,3 +1,10 @@
+---
+description: "The options AddDarker and AddHandlersFromAssemblies take: the query processor's service lifetime, and the strategies available for registering handlers."
+layout:
+  description:
+    visible: false
+---
+
 # Darker Configuration Reference
 
 > **Reference** · Applies to **Darker V4** · Prerequisites: [Basic Configuration](/contents/DarkerBasicConfiguration.md)

--- a/contents/DefaultMessageMappers.md
+++ b/contents/DefaultMessageMappers.md
@@ -1,3 +1,10 @@
+---
+description: "You do not need to implement IAmAMessageMapper for every message type."
+layout:
+  description:
+    visible: false
+---
+
 # Default Message Mappers
 
 > **How-to** · Applies to **Brighter V10**

--- a/contents/DispatcherConfigurationReference.md
+++ b/contents/DispatcherConfigurationReference.md
@@ -1,10 +1,17 @@
+---
+description: "Every option for configuring a Brighter Dispatcher, in one place."
+layout:
+  description:
+    visible: false
+---
+
 # Dispatcher Configuration Reference
 
 > **Reference** · Applies to **Brighter V10** · Prerequisites: [Basic Configuration](/contents/BrighterBasicConfiguration.md)
 
-Every option for configuring a Brighter **Dispatcher** — the service collection
-extensions that register it, its subscriptions, gateway connections, channel
-factories and lifetimes, and the Inbox option that matters when receiving
+Every option for configuring a Brighter **Dispatcher**, in one place. That covers the
+service collection extensions that register it, its subscriptions, gateway connections,
+channel factories and lifetimes, and the Inbox option that matters when receiving
 requests.
 
 This page is consulted rather than read through. For the one path that works,

--- a/contents/DispatchingARequest.md
+++ b/contents/DispatchingARequest.md
@@ -1,3 +1,10 @@
+---
+description: "Once you have implemented your Request Handler, you will want to dispatch Commands and Events to it synchronously, through the Command Processor."
+layout:
+  description:
+    visible: false
+---
+
 # Dispatching Requests
 
 > **How-to** · Applies to **Brighter V10**

--- a/contents/DistributedLock.md
+++ b/contents/DistributedLock.md
@@ -1,3 +1,10 @@
+---
+description: "A distributed lock lets multiple instances of your application coordinate so that only one of them performs a given task at a time."
+layout:
+  description:
+    visible: false
+---
+
 # Distributed Lock
 
 > **Explanation** · Applies to **Brighter V10**

--- a/contents/DynamicMessageDeserialization.md
+++ b/contents/DynamicMessageDeserialization.md
@@ -1,3 +1,10 @@
+---
+description: "Brighter supports dynamic type resolution, allowing you to route multiple message types through a single channel."
+layout:
+  description:
+    visible: false
+---
+
 # Dynamic Message Deserialization
 
 > **Explanation** · Applies to **Brighter V10**

--- a/contents/DynamoDbDistributedLock.md
+++ b/contents/DynamoDbDistributedLock.md
@@ -1,3 +1,10 @@
+---
+description: "The DynamoDB locking provider implements Brighter's distributed lock on top of Amazon DynamoDB, so a single Outbox Sweeper and Archiver run when you scale out."
+layout:
+  description:
+    visible: false
+---
+
 # DynamoDB Distributed Lock
 
 > **Reference** · Applies to **Brighter V10**

--- a/contents/DynamoInbox.md
+++ b/contents/DynamoInbox.md
@@ -1,3 +1,10 @@
+---
+description: "The DynamoDb Inbox allows use of DynamoDb for Brighter's inbox support."
+layout:
+  description:
+    visible: false
+---
+
 # Dynamo Inbox
 
 > **Reference** · Applies to **Brighter V10**

--- a/contents/DynamoOutbox.md
+++ b/contents/DynamoOutbox.md
@@ -1,3 +1,10 @@
+---
+description: "The DynamoDb Outbox allows integration between DynamoDb and Brighter's outbox support."
+layout:
+  description:
+    visible: false
+---
+
 # DynamoDb Outbox
 
 > **Reference** · Applies to **Brighter V10**

--- a/contents/EFCoreOutbox.md
+++ b/contents/EFCoreOutbox.md
@@ -1,3 +1,10 @@
+---
+description: "The EFCore Outbox allows integration between EF Core and Brighter's outbox support."
+layout:
+  description:
+    visible: false
+---
+
 # EF Core Outbox
 
 > **Reference** · Applies to **Brighter V10**

--- a/contents/EFCoreQueryIntegration.md
+++ b/contents/EFCoreQueryIntegration.md
@@ -1,3 +1,10 @@
+---
+description: "How to run Darker queries against Entity Framework Core: tracking, eager loading, handler lifetime and compiled queries."
+layout:
+  description:
+    visible: false
+---
+
 # Entity Framework Core Query Integration
 
 > **How-to** · Applies to **Darker V4** · Prerequisites: [Query Patterns](/contents/QueryPatterns.md)

--- a/contents/ErrorHandlingOptions.md
+++ b/contents/ErrorHandlingOptions.md
@@ -1,3 +1,10 @@
+---
+description: "Brighter's message pump uses Subscription properties to control how it handles errors."
+layout:
+  description:
+    visible: false
+---
+
 # Error Handling Options
 
 > **Reference** · Applies to **Brighter V10** · Prerequisites: [Error Handling](/contents/HandlerFailure.md)

--- a/contents/EventCarriedStateTransfer.md
+++ b/contents/EventCarriedStateTransfer.md
@@ -1,3 +1,10 @@
+---
+description: 'In his white paper "Data on the Outside vs. Data on the Inside", Pat Helland classifies data according to whether it exists inside a service boundary or outside that boundary.'
+layout:
+  description:
+    visible: false
+---
+
 # Event Carried State Transfer (ECST)
 
 > **Explanation** · Applies to **Brighter V10**

--- a/contents/EventDrivenCollaboration.md
+++ b/contents/EventDrivenCollaboration.md
@@ -1,3 +1,10 @@
+---
+description: "Event Driven Architectures (EDA) are a major use case for Brighter's External Bus-you want processes to collaborate via messaging."
+layout:
+  description:
+    visible: false
+---
+
 # Event Driven Collaboration
 
 > **Explanation** · Applies to **Brighter V10**

--- a/contents/FAQ.md
+++ b/contents/FAQ.md
@@ -1,3 +1,10 @@
+---
+description: "This FAQ addresses common questions about using Brighter and Darker, organized by category."
+layout:
+  description:
+    visible: false
+---
+
 # Frequently Asked Questions
 
 > **Reference** · Applies to **Brighter V10**

--- a/contents/FeatureSwitches.md
+++ b/contents/FeatureSwitches.md
@@ -1,3 +1,10 @@
+---
+description: "We provide a FeatureSwitch Attribute and FeatureSwitchAsync Attribute that you can use on your IHandleRequests<TRequest>.Handle() method, and IHandleRequests<TRequest>.HandleAysnc() method."
+layout:
+  description:
+    visible: false
+---
+
 # Feature Switches
 
 > **How-to** · Applies to **Brighter V10**

--- a/contents/FirestoreDistributedLock.md
+++ b/contents/FirestoreDistributedLock.md
@@ -1,3 +1,10 @@
+---
+description: "The Firestore locking provider implements Brighter's distributed lock using Google Cloud Firestore, so a single Outbox Sweeper and Archiver run when you scale out."
+layout:
+  description:
+    visible: false
+---
+
 # Firestore Distributed Lock
 
 > **Reference** · Applies to **Brighter V10**

--- a/contents/Glossary.md
+++ b/contents/Glossary.md
@@ -1,3 +1,10 @@
+---
+description: "This glossary provides definitions for key terms used in Brighter and Darker."
+layout:
+  description:
+    visible: false
+---
+
 # Glossary
 
 > **Reference** · Applies to **Brighter V10 and Darker V4**

--- a/contents/HandlerFailure.md
+++ b/contents/HandlerFailure.md
@@ -1,3 +1,10 @@
+---
+description: "When your handler throws an exception on the External Bus, Brighter's message pump catches it and decides what to do with the message."
+layout:
+  description:
+    visible: false
+---
+
 # Error Handling
 
 > **Explanation** · Applies to **Brighter V10**

--- a/contents/HangfireScheduler.md
+++ b/contents/HangfireScheduler.md
@@ -1,3 +1,10 @@
+---
+description: "Hangfire is one of the most widely used background job processing libraries in the .NET community, featuring a built-in monitoring dashboard."
+layout:
+  description:
+    visible: false
+---
+
 # Hangfire Scheduler
 
 > **Reference** · Applies to **Brighter V10**

--- a/contents/HealthChecks.md
+++ b/contents/HealthChecks.md
@@ -1,8 +1,15 @@
+---
+description: "Brighter provides an AspNet Core Health check for the Dispatcher."
+layout:
+  description:
+    visible: false
+---
+
 # Health Checks
 
 > **How-to** · Applies to **Brighter V10**
 
-Brighter provides an AspNet Core Health check for the **Dispatcher**
+Brighter provides an AspNet Core Health check for the **Dispatcher**.
 
 ## Configure Health Checks
 

--- a/contents/HowBrighterWorks.md
+++ b/contents/HowBrighterWorks.md
@@ -1,3 +1,10 @@
+---
+description: "You don't need to understand how Brighter works under the hood to use it, but if you want to debug, or contribute to the project, it can help to know what is going on."
+layout:
+  description:
+    visible: false
+---
+
 # How The Command Processor Works
 
 > **Explanation** · Applies to **Brighter V10**

--- a/contents/HowConfiguringTheCommandProcessorWorks.md
+++ b/contents/HowConfiguringTheCommandProcessorWorks.md
@@ -1,3 +1,10 @@
+---
+description: "Brighter does not have a dependency on an Inversion Of Control (IoC) framework."
+layout:
+  description:
+    visible: false
+---
+
 # How Configuring the Command Processor Works
 
 > **Explanation** · Applies to **Brighter V10**

--- a/contents/HowConfiguringTheDispatcherWorks.md
+++ b/contents/HowConfiguringTheDispatcherWorks.md
@@ -1,3 +1,10 @@
+---
+description: "In order to receive messages from Message Oriented Middleware (MoM) such as RabbitMQ or Kafka you have to configure a Dispatcher."
+layout:
+  description:
+    visible: false
+---
+
 # How Configuring a Dispatcher for an External Bus Works
 
 > **Explanation** · Applies to **Brighter V10**

--- a/contents/HowServiceActivatorWorks.md
+++ b/contents/HowServiceActivatorWorks.md
@@ -1,8 +1,15 @@
+---
+description: "The Dispatcher is the component in the Brighter.ServiceActivator assembly that orchestrates your Performers."
+layout:
+  description:
+    visible: false
+---
+
 # How The Dispatcher Works
 
 > **Explanation** · Applies to **Brighter V10**
 
-The **Dispatcher** is the component in the `Brighter.ServiceActivator` assembly orchestrates your `Performers`. Each `Performer` is a single-thread that runs a `MessagePump`. The `MessagePump` consumes messages from streams or queues, calls a `IAmAMessageMapper` or `IAmAMessageMapperAsync` to map them to a C# type and then dispatches that type to your registered `IHandleRequests` or `IHandleRequestsAsync`. The Command Processor handles in-process request dispatching, and the Dispatcher orchestrates the threads that provide external message consumption and routing.
+The **Dispatcher** is the component in the `Brighter.ServiceActivator` assembly that orchestrates your `Performers`. Each `Performer` is a single-thread that runs a `MessagePump`. The `MessagePump` consumes messages from streams or queues, calls a `IAmAMessageMapper` or `IAmAMessageMapperAsync` to map them to a C# type and then dispatches that type to your registered `IHandleRequests` or `IHandleRequestsAsync`. The Command Processor handles in-process request dispatching, and the Dispatcher orchestrates the threads that provide external message consumption and routing.
 
 ## Dispatcher Overview
 

--- a/contents/ImplementAQueryHandler.md
+++ b/contents/ImplementAQueryHandler.md
@@ -1,3 +1,10 @@
+---
+description: "Query handlers are the entry point to your query execution logic in Darker."
+layout:
+  description:
+    visible: false
+---
+
 # Implementing a Query Handler
 
 > **How-to** · Applies to **Darker V4**

--- a/contents/ImplementingAHandler.md
+++ b/contents/ImplementingAHandler.md
@@ -1,3 +1,10 @@
+---
+description: "To implement a handler, derive from RequestHandler<T> where T should be the Command or Event derived type that you wish to handle."
+layout:
+  description:
+    visible: false
+---
+
 # How to Implement a Request Handler
 
 > **How-to** · Applies to **Brighter V10**

--- a/contents/ImplementingAsyncHandler.md
+++ b/contents/ImplementingAsyncHandler.md
@@ -1,3 +1,10 @@
+---
+description: "To implement an asynchronous handler, derive from RequestHandlerAsync<T> where T should be the Command or Event derived type that you wish to handle."
+layout:
+  description:
+    visible: false
+---
+
 # How to Implement an Asynchronous Request Handler
 
 > **How-to** · Applies to **Brighter V10**

--- a/contents/ImplementingExternalBus.md
+++ b/contents/ImplementingExternalBus.md
@@ -1,3 +1,10 @@
+---
+description: "Brighter provides support for an External Bus."
+layout:
+  description:
+    visible: false
+---
+
 # Using an External Bus 
 
 > **How-to** · Applies to **Brighter V10**

--- a/contents/InMemoryInbox.md
+++ b/contents/InMemoryInbox.md
@@ -1,3 +1,10 @@
+---
+description: "The in-process Inbox: when to use it, how to configure it, and its limits."
+layout:
+  description:
+    visible: false
+---
+
 # InMemory Inbox
 
 > **Reference** · Applies to **Brighter V10** · Prerequisites: [InMemory Options for Development and Testing](/contents/InMemoryOptions.md)

--- a/contents/InMemoryOptions.md
+++ b/contents/InMemoryOptions.md
@@ -1,3 +1,10 @@
+---
+description: "Brighter V10 provides a comprehensive suite of in-memory implementations for key components, making it easy to develop and test applications without external dependencies."
+layout:
+  description:
+    visible: false
+---
+
 # InMemory Options for Development and Testing
 
 > **How-to** · Applies to **Brighter V10**

--- a/contents/InMemoryOutbox.md
+++ b/contents/InMemoryOutbox.md
@@ -1,3 +1,10 @@
+---
+description: "The in-process Outbox: flushing, compaction, configuration and limits."
+layout:
+  description:
+    visible: false
+---
+
 # InMemory Outbox
 
 > **Reference** · Applies to **Brighter V10** · Prerequisites: [InMemory Options for Development and Testing](/contents/InMemoryOptions.md)

--- a/contents/InMemoryScheduler.md
+++ b/contents/InMemoryScheduler.md
@@ -1,3 +1,10 @@
+---
+description: "The InMemory Scheduler is a lightweight, timer-based scheduling implementation provided by Brighter for testing, development, and demonstration purposes."
+layout:
+  description:
+    visible: false
+---
+
 # InMemory Scheduler
 
 > **Reference** · Applies to **Brighter V10**

--- a/contents/InMemoryTransport.md
+++ b/contents/InMemoryTransport.md
@@ -1,3 +1,10 @@
+---
+description: "The in-process transport: when to use it, how to configure it, a complete example, and its limits."
+layout:
+  description:
+    visible: false
+---
+
 # InMemory Transport
 
 > **Reference** · Applies to **Brighter V10** · Prerequisites: [InMemory Options for Development and Testing](/contents/InMemoryOptions.md)

--- a/contents/KafkaConfiguration.md
+++ b/contents/KafkaConfiguration.md
@@ -1,3 +1,10 @@
+---
+description: "Kafka is OSS message-oriented-middleware and is well documented."
+layout:
+  description:
+    visible: false
+---
+
 # Kafka Configuration
 
 > **Reference** · Applies to **Brighter V10**

--- a/contents/Logging.md
+++ b/contents/Logging.md
@@ -1,5 +1,151 @@
+---
+description: "Brighter writes its diagnostics through Microsoft.Extensions.Logging, and takes its ILoggerFactory from a single static holder rather than from your container."
+layout:
+  description:
+    visible: false
+---
+
 # Logging
 
-> **Reference** · Applies to **Brighter V10**
+> **Reference** · Applies to **Brighter V10** · Prerequisites: [Basic Configuration](/contents/BrighterBasicConfiguration.md)
 
-TODO
+Brighter writes its diagnostics through `Microsoft.Extensions.Logging`, and takes its
+`ILoggerFactory` from a single static holder rather than from your container.
+
+That one design decision explains everything else on this page, including why Brighter can
+appear to log nothing at all.
+
+## How Brighter Gets Its Logger
+
+Every Brighter type that logs holds its logger in a static field, built once from
+`Paramore.Brighter.Logging.ApplicationLogging`:
+
+```csharp
+using Microsoft.Extensions.Logging;
+using Paramore.Brighter.Logging;
+
+public class CommandProcessor
+{
+    private static readonly ILogger s_logger = ApplicationLogging.CreateLogger<CommandProcessor>();
+    // ...
+}
+```
+
+`ApplicationLogging` is a static holder with a settable factory:
+
+```csharp
+using Microsoft.Extensions.Logging;
+
+namespace Paramore.Brighter.Logging;
+
+public static class ApplicationLogging
+{
+    public static ILoggerFactory LoggerFactory { get; set; } = new LoggerFactory();
+    public static ILogger CreateLogger<T>() => LoggerFactory.CreateLogger<T>();
+}
+```
+
+**The default is a `LoggerFactory` with no providers**, which accepts every call and writes
+nothing. Brighter is never silent because logging is switched off; it is silent because
+nothing has been given somewhere to write to.
+
+Because `CreateLogger<T>()` is called with the type, the **category name is the full type
+name** — `Paramore.Brighter.CommandProcessor`,
+`Paramore.Brighter.ServiceActivator.Dispatcher`. Filtering on the `Paramore.Brighter` prefix
+therefore catches all of it.
+
+## Logging with Dependency Injection
+
+If you use the DI extensions, there is nothing to do. Both `AddBrighter` and `AddConsumers`
+resolve `ILoggerFactory` from the container as they build, and hand it to
+`ApplicationLogging`:
+
+```csharp
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Paramore.Brighter.Extensions.DependencyInjection;
+
+var builder = Host.CreateApplicationBuilder(args);
+
+// The generic host registers ILoggerFactory, so Brighter finds one.
+builder.Services.AddBrighter()
+    .AutoFromAssemblies([typeof(GreetingCommand).Assembly]);
+
+var host = builder.Build();
+```
+
+The resolution is `GetService<ILoggerFactory>()`, not `GetRequiredService`, so a container
+with no factory registered is not an error — Brighter keeps the empty default and writes
+nothing.
+
+## Logging Without Dependency Injection
+
+If you build a Command Processor by hand, assign the factory yourself:
+
+```csharp
+using Microsoft.Extensions.Logging;
+using Paramore.Brighter;
+using Paramore.Brighter.Logging;
+
+ApplicationLogging.LoggerFactory = LoggerFactory.Create(logging =>
+{
+    logging.AddConsole();
+    logging.SetMinimumLevel(LogLevel.Information);
+});
+
+var commandProcessor = CommandProcessorBuilder.StartNew()
+    // ... handler configuration, policies, request context factory
+    .Build();
+```
+
+**Assign it before you build anything.** Each type caches its logger in a `static readonly`
+field the first time that type is used, so a factory installed afterwards is never seen by
+the types that have already initialised.
+
+## What Brighter Logs
+
+Log methods are source-generated with `[LoggerMessage]`, so the messages are structured
+rather than interpolated:
+
+```csharp
+using Microsoft.Extensions.Logging;
+
+private static partial class Log
+{
+    [LoggerMessage(LogLevel.Information, "Building send pipeline for command: {CommandType} {Id}")]
+    public static partial void BuildingSendPipelineForCommand(ILogger logger, Type commandType, string id);
+}
+```
+
+`{CommandType}` and `{Id}` reach a structured sink as named fields, so you can query on them.
+
+Across the Brighter source the levels divide roughly as:
+
+| Level | Used for |
+|---|---|
+| `Trace` | the finest pipeline detail |
+| `Debug` | pipeline construction and message pump steps |
+| `Information` | dispatch, handler counts, connection lifecycle |
+| `Warning` | recoverable faults — a missing mapper, a retried delivery |
+| `Error` | a failure Brighter could not handle for you |
+
+`Information` is a reasonable production level for Brighter's categories; `Debug` is verbose,
+because a pipeline logs as it is built for every request.
+
+## Logging Common Pitfalls
+
+- **Nothing appears.** No provider is registered, or the factory was assigned after a
+  Brighter type had already initialised its static logger. Check the order.
+- **Logs stop when you move off DI.** The DI extensions were doing the assignment for you;
+  the manual path does not.
+- **Setting `ApplicationLogging.LoggerFactory` in a test affects the whole process.** It is
+  static and shared, so set it once in fixture setup rather than per test.
+- **Logging is not tracing.** For distributed traces across message boundaries, use
+  [Telemetry](/contents/Telemetry.md); Brighter's logs are not a substitute for spans.
+
+## Further Reading
+
+- [Telemetry](/contents/Telemetry.md)
+- [Configuring OpenTelemetry](/contents/ConfiguringOpenTelemetry.md)
+- [Monitoring](/contents/Monitoring.md)
+- [Basic Configuration](/contents/BrighterBasicConfiguration.md)

--- a/contents/MSSQLInbox.md
+++ b/contents/MSSQLInbox.md
@@ -1,3 +1,10 @@
+---
+description: "The MSSQL Inbox allows use of MSSQL for Brighter's inbox support."
+layout:
+  description:
+    visible: false
+---
+
 # MSSQL Inbox
 
 > **Reference** · Applies to **Brighter V10**

--- a/contents/MSSQLOutbox.md
+++ b/contents/MSSQLOutbox.md
@@ -1,3 +1,10 @@
+---
+description: "The MSSQL Outbox provides a message store for the Transactional Outbox pattern using a Microsoft SQL Server database."
+layout:
+  description:
+    visible: false
+---
+
 # **Using the MSSQL Outbox**
 
 > **Reference** · Applies to **Brighter V10**

--- a/contents/MessageMappers.md
+++ b/contents/MessageMappers.md
@@ -1,3 +1,10 @@
+---
+description: "A message mapper turns domain code into a Brighter Message."
+layout:
+  description:
+    visible: false
+---
+
 # Message Mappers
 
 > **Explanation** · Applies to **Brighter V10**

--- a/contents/MessageTransforms.md
+++ b/contents/MessageTransforms.md
@@ -1,3 +1,10 @@
+---
+description: "A transform is middleware in the mapping pipeline, and Brighter finds it by reflecting over the attributes on your mapper's MapToMessage and MapToRequest methods."
+layout:
+  description:
+    visible: false
+---
+
 # Message Transforms
 
 > **Explanation** · Applies to **Brighter V10** · Prerequisites: [Message Mappers](/contents/MessageMappers.md)

--- a/contents/Microservices.md
+++ b/contents/Microservices.md
@@ -1,3 +1,10 @@
+---
+description: "It is possible to think of microservices as 3rd generation SOA."
+layout:
+  description:
+    visible: false
+---
+
 # Microservices
 
 > **Explanation** · Applies to **Brighter V10**

--- a/contents/MigratingToNullableReferenceTypes.md
+++ b/contents/MigratingToNullableReferenceTypes.md
@@ -1,9 +1,16 @@
+---
+description: "Four steps to turn nullable reference types on in a project that uses Brighter."
+layout:
+  description:
+    visible: false
+---
+
 # Migrating to Nullable Reference Types
 
 > **How-to** · Applies to **Brighter V10** · Prerequisites: [Nullable Reference Types](/contents/NullableReferenceTypes.md)
 
-Four steps to turn nullable reference types on in a project that uses Brighter: enable the
-feature, work through the compiler warnings it raises, and update your handlers and message
+Four steps to turn nullable reference types on in a project that uses Brighter. Enable the
+feature, work through the compiler warnings it raises, then update your handlers and message
 mappers for the annotations. [Nullable Reference Types](/contents/NullableReferenceTypes.md)
 explains what the annotations mean and how Brighter's own API is annotated.
 

--- a/contents/MigratingToPollyV8.md
+++ b/contents/MigratingToPollyV8.md
@@ -1,10 +1,17 @@
+---
+description: "Both tails of the Polly story in one place."
+layout:
+  description:
+    visible: false
+---
+
 # Migrating to Polly v8
 
 > **How-to** · Applies to **Brighter V10** · Prerequisites: [Supporting Retry and Circuit Breaker](/contents/PolicyRetryAndCircuitBreaker.md)
 
-Both tails of the Polly story in one place: the four steps that take a V9 handler using
+Both tails of the Polly story in one place. Four steps take a V9 handler using
 `[UsePolicy]` to a V10 handler using `[UseResiliencePipeline]`, and the deprecated Polly v7
-attribute itself, kept because it is what you are migrating *from*.
+attribute is kept here because it is what you are migrating *from*.
 [Supporting Retry and Circuit Breaker](/contents/PolicyRetryAndCircuitBreaker.md) is the
 current reference.
 

--- a/contents/MongoDBInbox.md
+++ b/contents/MongoDBInbox.md
@@ -1,3 +1,10 @@
+---
+description: "The MongoDB Inbox allows use of MongoDB for Brighter's inbox support."
+layout:
+  description:
+    visible: false
+---
+
 # MongoDB Inbox
 
 > **Reference** · Applies to **Brighter V10**

--- a/contents/MongoDBOutbox.md
+++ b/contents/MongoDBOutbox.md
@@ -1,3 +1,10 @@
+---
+description: "The MongoDB Outbox allows integration between MongoDB and Brighter's outbox support."
+layout:
+  description:
+    visible: false
+---
+
 # MongoDB Outbox
 
 > **Reference** · Applies to **Brighter V10**

--- a/contents/MongoDbDistributedLock.md
+++ b/contents/MongoDbDistributedLock.md
@@ -1,3 +1,10 @@
+---
+description: "The MongoDB locking provider implements Brighter's distributed lock by writing lock documents to a MongoDB collection, so a single Outbox Sweeper and Archiver run when you scale out."
+layout:
+  description:
+    visible: false
+---
+
 # MongoDB Distributed Lock
 
 > **Reference** · Applies to **Brighter V10**

--- a/contents/Monitoring.md
+++ b/contents/Monitoring.md
@@ -1,8 +1,15 @@
+---
+description: "Brighter emits monitoring information from an External Bus using a configured Control Bus."
+layout:
+  description:
+    visible: false
+---
+
 # Monitoring
 
 > **Reference** · Applies to **Brighter V10**
 
-Brighter emits monitoring information from an External Bus using a configured [Control Bus](https://brightercommand.github.io/Brighter/ControlBus.html)
+Brighter emits monitoring information from an External Bus using a configured [Control Bus](https://brightercommand.github.io/Brighter/ControlBus.html).
 
 ## Configuring Monitoring
 

--- a/contents/MsSqlDistributedLock.md
+++ b/contents/MsSqlDistributedLock.md
@@ -1,11 +1,18 @@
+---
+description: "The MS SQL locking provider implements Brighter's distributed lock using SQL Server application locks (sp_getapplock / sp_releaseapplock)."
+layout:
+  description:
+    visible: false
+---
+
 # MS SQL Distributed Lock
 
 > **Reference** · Applies to **Brighter V10**
 
 The MS SQL locking provider implements Brighter's [distributed
 lock](/contents/DistributedLock.md) using SQL Server **application locks**
-(`sp_getapplock` / `sp_releaseapplock`), so a single [Outbox
-Sweeper](/contents/BrighterOutboxSupport.md#implicit-clear) and Archiver run when you
+(`sp_getapplock` / `sp_releaseapplock`). That keeps a single [Outbox
+Sweeper](/contents/BrighterOutboxSupport.md#implicit-clear) and Archiver running when you
 scale out. It pairs naturally with the [MSSQL Outbox](/contents/MSSQLOutbox.md).
 
 ## MS SQL Distributed Lock Package

--- a/contents/MySQLInbox.md
+++ b/contents/MySQLInbox.md
@@ -1,3 +1,10 @@
+---
+description: "The MySQL Inbox allows use of MySQL for Brighter's inbox support."
+layout:
+  description:
+    visible: false
+---
+
 # MySQL Inbox
 
 > **Reference** · Applies to **Brighter V10**

--- a/contents/MySQLOutbox.md
+++ b/contents/MySQLOutbox.md
@@ -1,3 +1,10 @@
+---
+description: "The MySQL Outbox provides a message store for the Transactional Outbox pattern using a MySQL database."
+layout:
+  description:
+    visible: false
+---
+
 # **Using the MySQL Outbox**
 
 > **Reference** · Applies to **Brighter V10**

--- a/contents/MySqlDistributedLock.md
+++ b/contents/MySqlDistributedLock.md
@@ -1,3 +1,10 @@
+---
+description: "The MySQL locking provider implements Brighter's distributed lock using MySQL's named locks (GET_LOCK / RELEASE_LOCK), so a single Outbox Sweeper and Archiver run when you scale out."
+layout:
+  description:
+    visible: false
+---
+
 # MySQL Distributed Lock
 
 > **Reference** · Applies to **Brighter V10**

--- a/contents/NullableReferenceTypes.md
+++ b/contents/NullableReferenceTypes.md
@@ -1,3 +1,10 @@
+---
+description: "V10 enables nullable reference types across all Brighter projects, providing improved type safety and helping prevent null reference exceptions."
+layout:
+  description:
+    visible: false
+---
+
 # Nullable Reference Types
 
 > **Reference** · Applies to **Brighter V10**

--- a/contents/OutboxArchiver.md
+++ b/contents/OutboxArchiver.md
@@ -1,3 +1,10 @@
+---
+description: "The Outbox Archiver is a background service that monitors an Outbox and moves messages older than a certain age into long-term storage, keeping your Outbox small."
+layout:
+  description:
+    visible: false
+---
+
 # Outbox Archiver
 
 > **Reference** · Applies to **Brighter V10** · Prerequisites: [Outbox Support](/contents/BrighterOutboxSupport.md)

--- a/contents/OutboxPattern.md
+++ b/contents/OutboxPattern.md
@@ -1,3 +1,10 @@
+---
+description: "The Outbox Pattern is what stops a state change and the event announcing it from diverging."
+layout:
+  description:
+    visible: false
+---
+
 # Outbox Pattern Support
 
 > **Explanation** · Applies to **Brighter V10**

--- a/contents/PaginationQueryPatterns.md
+++ b/contents/PaginationQueryPatterns.md
@@ -1,3 +1,10 @@
+---
+description: "How to page through a large result set in Darker, by offset and by cursor, with the trade-offs of each."
+layout:
+  description:
+    visible: false
+---
+
 # Pagination Query Patterns
 
 > **How-to** · Applies to **Darker V4** · Prerequisites: [Query Patterns](/contents/QueryPatterns.md)

--- a/contents/ParameterizedQueryPatterns.md
+++ b/contents/ParameterizedQueryPatterns.md
@@ -1,3 +1,10 @@
+---
+description: "Query recipes that take parameters: looking up a single entity, filtering a list, and searching on several criteria at once."
+layout:
+  description:
+    visible: false
+---
+
 # Parameterized Query Patterns
 
 > **How-to** · Applies to **Darker V4** · Prerequisites: [Query Patterns](/contents/QueryPatterns.md)

--- a/contents/PipelineValidation.md
+++ b/contents/PipelineValidation.md
@@ -1,3 +1,10 @@
+---
+description: "Brighter can validate your pipeline configuration at startup, catching common mistakes before any messages are sent or consumed."
+layout:
+  description:
+    visible: false
+---
+
 # Pipeline Validation and Diagnostics
 
 > **How-to** · Applies to **Brighter V10**

--- a/contents/PolicyFallback.md
+++ b/contents/PolicyFallback.md
@@ -1,3 +1,10 @@
+---
+description: "A Fallback is a backstop exception handler, which runs when a request has failed and lets you take compensating action."
+layout:
+  description:
+    visible: false
+---
+
 # Fallback
 
 > **How-to** · Applies to **Brighter V10**

--- a/contents/PolicyRetryAndCircuitBreaker.md
+++ b/contents/PolicyRetryAndCircuitBreaker.md
@@ -1,3 +1,10 @@
+---
+description: "Brighter is a Command Processor and supports a pipeline of Handlers to handle orthogonal requests."
+layout:
+  description:
+    visible: false
+---
+
 # Supporting Retry and Circuit Breaker
 
 > **How-to** · Applies to **Brighter V10**

--- a/contents/PostgreSQLBrokerTradeOffs.md
+++ b/contents/PostgreSQLBrokerTradeOffs.md
@@ -1,3 +1,10 @@
+---
+description: "This page is what you read when deciding whether to use PostgreSQL as a broker at all: what it buys you, where it runs out, how it stores a payload, and how it compares with the dedicated brokers."
+layout:
+  description:
+    visible: false
+---
+
 # PostgreSQL Broker Trade-Offs
 
 > **Explanation** · Applies to **Brighter V10** · Prerequisites: [PostgreSQL Message Broker](/contents/PostgreSQLMessageBroker.md)

--- a/contents/PostgreSQLMessageBroker.md
+++ b/contents/PostgreSQLMessageBroker.md
@@ -1,3 +1,10 @@
+---
+description: "Brighter supports for using PostgreSQL as a message broker, enabling pub/sub messaging patterns using your existing PostgreSQL infrastructure."
+layout:
+  description:
+    visible: false
+---
+
 # PostgreSQL Message Broker
 
 > **Reference** · Applies to **Brighter V10**

--- a/contents/PostgresDistributedLock.md
+++ b/contents/PostgresDistributedLock.md
@@ -1,3 +1,10 @@
+---
+description: "The Postgres locking provider implements Brighter's distributed lock using PostgreSQL advisory locks, so a single Outbox Sweeper and Archiver run when you scale out."
+layout:
+  description:
+    visible: false
+---
+
 # Postgres Distributed Lock
 
 > **Reference** · Applies to **Brighter V10**

--- a/contents/PostgresInbox.md
+++ b/contents/PostgresInbox.md
@@ -1,3 +1,10 @@
+---
+description: "The Postgres Inbox allows use of Postgres for Brighter's inbox support."
+layout:
+  description:
+    visible: false
+---
+
 # Postgres Inbox
 
 > **Reference** · Applies to **Brighter V10**

--- a/contents/PostgresOutbox.md
+++ b/contents/PostgresOutbox.md
@@ -1,3 +1,10 @@
+---
+description: "The PostgreSQL Outbox provides a message store for the Transactional Outbox pattern using a PostgreSQL database."
+layout:
+  description:
+    visible: false
+---
+
 # **Using the PostgreSQL Outbox**
 
 > **Reference** · Applies to **Brighter V10**

--- a/contents/ProjectionQueryPatterns.md
+++ b/contents/ProjectionQueryPatterns.md
@@ -1,3 +1,10 @@
+---
+description: "How to return only the fields a caller needs: simple projections, projections across joins, and calculated fields."
+layout:
+  description:
+    visible: false
+---
+
 # Projection Query Patterns
 
 > **How-to** · Applies to **Darker V4** · Prerequisites: [Query Patterns](/contents/QueryPatterns.md)

--- a/contents/QuartzScheduler.md
+++ b/contents/QuartzScheduler.md
@@ -1,3 +1,10 @@
+---
+description: "Quartz.NET is one of the most widely used enterprise-grade scheduling libraries in the .NET community."
+layout:
+  description:
+    visible: false
+---
+
 # Quartz Scheduler
 
 > **Reference** · Applies to **Brighter V10**

--- a/contents/QueriesAndQueryObjects.md
+++ b/contents/QueriesAndQueryObjects.md
@@ -1,3 +1,10 @@
+---
+description: "The Query Object pattern separates the parameters of a query from the execution of that query."
+layout:
+  description:
+    visible: false
+---
+
 # Queries and Query Objects
 
 > **Explanation** · Applies to **Darker V4**

--- a/contents/QueryHandlerDependencies.md
+++ b/contents/QueryHandlerDependencies.md
@@ -1,3 +1,10 @@
+---
+description: "Query handlers typically need dependencies like repositories, database contexts, or services to execute queries."
+layout:
+  description:
+    visible: false
+---
+
 # Query Handler Dependencies
 
 > **How-to** · Applies to **Darker V4** · Prerequisites: [Implementing a Query Handler](/contents/ImplementAQueryHandler.md)

--- a/contents/QueryObjectValidation.md
+++ b/contents/QueryObjectValidation.md
@@ -1,3 +1,10 @@
+---
+description: "Query objects should validate their parameters to ensure they receive valid data."
+layout:
+  description:
+    visible: false
+---
+
 # Query Object Validation
 
 > **How-to** · Applies to **Darker V4** · Prerequisites: [Queries and Query Objects](/contents/QueriesAndQueryObjects.md)

--- a/contents/QueryPatterns.md
+++ b/contents/QueryPatterns.md
@@ -1,3 +1,10 @@
+---
+description: "This guide presents common query patterns you'll encounter when building real-world applications with Darker."
+layout:
+  description:
+    visible: false
+---
+
 # Query Patterns
 
 > **How-to** · Applies to **Darker V4**

--- a/contents/QueryPipeline.md
+++ b/contents/QueryPipeline.md
@@ -1,3 +1,10 @@
+---
+description: "The Query Pipeline in Darker provides a powerful way to add cross-cutting concerns to your query handlers without modifying the handler code itself."
+layout:
+  description:
+    visible: false
+---
+
 # Query Pipeline and Decorators
 
 > **How-to** · Applies to **Darker V4**

--- a/contents/QueryPipelinePolicies.md
+++ b/contents/QueryPipelinePolicies.md
@@ -1,3 +1,10 @@
+---
+description: "Darker's policy decorators are powered by Polly, a .NET resilience and transient-fault-handling library."
+layout:
+  description:
+    visible: false
+---
+
 # Query Pipeline Policies
 
 > **How-to** · Applies to **Darker V4** · Prerequisites: [Query Pipeline and Decorators](/contents/QueryPipeline.md)

--- a/contents/QueryResultTypes.md
+++ b/contents/QueryResultTypes.md
@@ -1,3 +1,10 @@
+---
+description: "The result type specified in IQuery<TResult> can be any C# type."
+layout:
+  description:
+    visible: false
+---
+
 # Query Result Types
 
 > **Explanation** · Applies to **Darker V4** · Prerequisites: [Queries and Query Objects](/contents/QueriesAndQueryObjects.md)

--- a/contents/RabbitMQConfiguration.md
+++ b/contents/RabbitMQConfiguration.md
@@ -1,3 +1,10 @@
+---
+description: "RabbitMQ is OSS message-oriented-middleware and is well documented."
+layout:
+  description:
+    visible: false
+---
+
 # RabbitMQ Configuration
 
 > **Reference** · Applies to **Brighter V10**

--- a/contents/RabbitMQConnectionStability.md
+++ b/contents/RabbitMQConnectionStability.md
@@ -1,3 +1,10 @@
+---
+description: "V10 includes improvements to RabbitMQ connection handling and error recovery, making applications more resilient to network issues and broker restarts."
+layout:
+  description:
+    visible: false
+---
+
 # RabbitMQ Connection Stability
 
 > **How-to** · Applies to **Brighter V10** · Prerequisites: [RabbitMQ Configuration](/contents/RabbitMQConfiguration.md)

--- a/contents/RabbitMQDurability.md
+++ b/contents/RabbitMQDurability.md
@@ -1,3 +1,10 @@
+---
+description: "RabbitMQ offers two independent durability mechanisms, and they answer different questions."
+layout:
+  description:
+    visible: false
+---
+
 # RabbitMQ Durability: Quorum Queues and Persistence
 
 > **Explanation** · Applies to **Brighter V10** · Prerequisites: [RabbitMQ Configuration](/contents/RabbitMQConfiguration.md)

--- a/contents/RabbitMQMigrateToQuorumQueues.md
+++ b/contents/RabbitMQMigrateToQuorumQueues.md
@@ -1,3 +1,10 @@
+---
+description: "This guide moves an existing Brighter subscription from a classic queue to a quorum queue, and enables message persistence alongside it."
+layout:
+  description:
+    visible: false
+---
+
 # Migrating to Quorum Queues
 
 > **How-to** · Applies to **Brighter V10** · Prerequisites: [RabbitMQ Configuration](/contents/RabbitMQConfiguration.md)

--- a/contents/ReactorAndProactor.md
+++ b/contents/ReactorAndProactor.md
@@ -1,3 +1,10 @@
+---
+description: "Brighter V10 introduces clearer terminology for its concurrency models: Reactor and Proactor."
+layout:
+  description:
+    visible: false
+---
+
 # Reactor and Proactor: Concurrency Models
 
 > **Explanation** · Applies to **Brighter V10**

--- a/contents/ReplayOnSeen.md
+++ b/contents/ReplayOnSeen.md
@@ -1,3 +1,10 @@
+---
+description: "When your Inbox recognises a message it has already handled, it normally throws or logs a warning and stops — the work is done, so there is nothing to do."
+layout:
+  description:
+    visible: false
+---
+
 # Replay On Seen
 
 > **Explanation** · Applies to **Brighter V10**

--- a/contents/ReplayOnSeenReference.md
+++ b/contents/ReplayOnSeenReference.md
@@ -1,3 +1,10 @@
+---
+description: "Which stores support Replay On Seen, the cases where it does not fire, the events it emits, and its limitations."
+layout:
+  description:
+    visible: false
+---
+
 # Replay On Seen Reference
 
 > **Reference** · Applies to **Brighter V10** · Prerequisites: [Replay On Seen](/contents/ReplayOnSeen.md)

--- a/contents/RequestValidation.md
+++ b/contents/RequestValidation.md
@@ -1,3 +1,10 @@
+---
+description: "Brighter can validate a request in its handler pipeline before your business handler runs."
+layout:
+  description:
+    visible: false
+---
+
 # Request Validation
 
 > **How-to** · Applies to **Brighter V10**

--- a/contents/Requests, Commands and Events.md
+++ b/contents/Requests, Commands and Events.md
@@ -1,3 +1,10 @@
+---
+description: "We use the term Request for a data object containing parameters that you want to dispatch to a handler."
+layout:
+  description:
+    visible: false
+---
+
 # Requests, Commands and Events
 
 > **Explanation** · Applies to **Brighter V10**

--- a/contents/ReturningResultsFromAHandler.md
+++ b/contents/ReturningResultsFromAHandler.md
@@ -1,10 +1,16 @@
+---
+description: "We use Command-Query separation so a Command does not have a return value and CommandDispatcher.Send() does not return anything."
+layout:
+  description:
+    visible: false
+---
 
 # Returning Results from a Handler
 
 > **How-to** · Applies to **Brighter V10**
 
 We use [Command-Query
-separation](https://martinfowler.com/bliki/CommandQuerySeparation.html) so a Command does not have return value and **CommandDispatcher.Send()** does not return anything. Our project Darker provides a Query Processor that can be used to return results in response to queries. You can use both together to provide CQRS.
+separation](https://martinfowler.com/bliki/CommandQuerySeparation.html) so a Command does not have a return value and **CommandDispatcher.Send()** does not return anything. Our project Darker provides a Query Processor that can be used to return results in response to queries. You can use both together to provide CQRS.
 
 This in turn leads to a set of questions that we need to answer about common scenarios:
 

--- a/contents/Routing.md
+++ b/contents/Routing.md
@@ -1,3 +1,10 @@
+---
+description: "A producer routes messages to subscribers by setting a Topic on the MessageHeader."
+layout:
+  description:
+    visible: false
+---
+
 # Routing
 
 > **Explanation** · Applies to **Brighter V10**

--- a/contents/RoutingMultipleMessageTypes.md
+++ b/contents/RoutingMultipleMessageTypes.md
@@ -1,3 +1,10 @@
+---
+description: "The most common approach for dynamic deserialization is using the CloudEvents type attribute."
+layout:
+  description:
+    visible: false
+---
+
 # Routing Multiple Message Types
 
 > **How-to** · Applies to **Brighter V10** · Prerequisites: [Dynamic Message Deserialization](/contents/DynamicMessageDeserialization.md)

--- a/contents/S3LuggageStore.md
+++ b/contents/S3LuggageStore.md
@@ -1,3 +1,10 @@
+---
+description: "The S3LuggageStore is an implementation of IAmAStorageProviderAsync for AWS S3 Object Storage."
+layout:
+  description:
+    visible: false
+---
+
 # S3 Luggage Store
 
 > **Reference** · Applies to **Brighter V10**

--- a/contents/SchedulingAMessage.md
+++ b/contents/SchedulingAMessage.md
@@ -1,3 +1,10 @@
+---
+description: "This page shows you how to schedule a message or request for deferred execution, how to cancel one you have already scheduled, and how to configure each scheduler for the job."
+layout:
+  description:
+    visible: false
+---
+
 # Scheduling a Message
 
 > **How-to** · Applies to **Brighter V10** · Prerequisites: [Scheduler](/contents/BrighterSchedulerSupport.md)

--- a/contents/ShowMeTheCode.md
+++ b/contents/ShowMeTheCode.md
@@ -1,3 +1,10 @@
+---
+description: "There is an old principle: show don't tell, and this introduction is about showing you what you can do with Brighter and Darker."
+layout:
+  description:
+    visible: false
+---
+
 # Show me the code!
 
 > **How-to** · Applies to **Brighter V10 and Darker V4**

--- a/contents/SqliteInbox.md
+++ b/contents/SqliteInbox.md
@@ -1,3 +1,10 @@
+---
+description: "The Sqlite Inbox allows use of Sqlite for Brighter's inbox support."
+layout:
+  description:
+    visible: false
+---
+
 # Sqlite Inbox
 
 > **Reference** · Applies to **Brighter V10**

--- a/contents/SqliteOutbox.md
+++ b/contents/SqliteOutbox.md
@@ -1,3 +1,10 @@
+---
+description: "The SQLite Outbox provides a message store for the Transactional Outbox pattern using a SQLite database."
+layout:
+  description:
+    visible: false
+---
+
 # **Using the SQLite Outbox**
 
 > **Reference** · Applies to **Brighter V10**

--- a/contents/SweeperCircuitBreaking.md
+++ b/contents/SweeperCircuitBreaking.md
@@ -1,3 +1,10 @@
+---
+description: "Sweeper Circuit Breaking is a resilience feature that prevents failures to publish to one topic from blocking attempts to publish to other topics, when publishing messages from the Outbox."
+layout:
+  description:
+    visible: false
+---
+
 # Sweeper Circuit Breaking
 
 > **Reference** · Applies to **Brighter V10**

--- a/contents/SwitchingSchedulers.md
+++ b/contents/SwitchingSchedulers.md
@@ -1,3 +1,10 @@
+---
+description: "This page shows you how to move an existing application from one Brighter scheduler to another."
+layout:
+  description:
+    visible: false
+---
+
 # Switching Schedulers
 
 > **How-to** · Applies to **Brighter V10** · Prerequisites: [Scheduler](/contents/BrighterSchedulerSupport.md)

--- a/contents/TaskQueuePattern.md
+++ b/contents/TaskQueuePattern.md
@@ -1,3 +1,10 @@
+---
+description: "The Task Queue Pattern let's you use an External Bus to handle work asynchronously."
+layout:
+  description:
+    visible: false
+---
+
 # The Task Queue Pattern
 
 > **Explanation** · Applies to **Brighter V10**

--- a/contents/Telemetry.md
+++ b/contents/Telemetry.md
@@ -1,3 +1,10 @@
+---
+description: "Brighter provides comprehensive OpenTelemetry integration for distributed tracing across message boundaries, enabling end-to-end observability in distributed systems."
+layout:
+  description:
+    visible: false
+---
+
 # Telemetry
 
 > **Reference** · Applies to **Brighter V10**

--- a/contents/TestDoubleOptions.md
+++ b/contents/TestDoubleOptions.md
@@ -1,3 +1,10 @@
+---
+description: "When handlers depend on IAmACommandProcessor to publish events or send commands, you need a way to verify those interactions in tests."
+layout:
+  description:
+    visible: false
+---
+
 # Test Double Options for Command Processor
 
 > **How-to** · Applies to **Brighter V10**

--- a/contents/TestingQueryHandlers.md
+++ b/contents/TestingQueryHandlers.md
@@ -1,3 +1,10 @@
+---
+description: "Query handlers are easy to test because they have clear inputs (queries) and outputs (results), with dependencies that can be mocked or replaced."
+layout:
+  description:
+    visible: false
+---
+
 # Testing Query Handlers
 
 > **How-to** · Applies to **Darker V4** · Prerequisites: [Implementing a Query Handler](/contents/ImplementAQueryHandler.md)

--- a/contents/TickerQScheduler.md
+++ b/contents/TickerQScheduler.md
@@ -1,3 +1,10 @@
+---
+description: "TickerQ is a high-performance, reflection-free background task scheduler for .NET that uses source generators."
+layout:
+  description:
+    visible: false
+---
+
 # TickerQ Scheduler
 
 > **Reference** · Applies to **Brighter V10**

--- a/contents/TransactionalMessagingWithTheOutbox.md
+++ b/contents/TransactionalMessagingWithTheOutbox.md
@@ -1,3 +1,10 @@
+---
+description: "This section provides a complete example showing both producer and consumer using transactional messaging with the Outbox and Inbox patterns."
+layout:
+  description:
+    visible: false
+---
+
 # Transactional Messaging with the Outbox
 
 > **How-to** · Applies to **Brighter V10** · Prerequisites: [Outbox Support](/contents/BrighterOutboxSupport.md)

--- a/contents/TurningOnReplayOnSeen.md
+++ b/contents/TurningOnReplayOnSeen.md
@@ -1,3 +1,10 @@
+---
+description: "This page is the procedure: what to switch on, what you must thread through your code, what to check before you enable it, and a worked example."
+layout:
+  description:
+    visible: false
+---
+
 # Turning On Replay On Seen
 
 > **How-to** · Applies to **Brighter V10** · Prerequisites: [Replay On Seen](/contents/ReplayOnSeen.md)

--- a/contents/UsingSweeperCircuitBreaking.md
+++ b/contents/UsingSweeperCircuitBreaking.md
@@ -1,3 +1,10 @@
+---
+description: "How to wire circuit breaking into an Outbox Sweeper, tune its cooldown, and extend it with your own or a distributed breaker."
+layout:
+  description:
+    visible: false
+---
+
 # Using Sweeper Circuit Breaking
 
 > **How-to** · Applies to **Brighter V10** · Prerequisites: [Sweeper Circuit Breaking](/contents/SweeperCircuitBreaking.md)

--- a/contents/UsingTheContextBag.md
+++ b/contents/UsingTheContextBag.md
@@ -1,3 +1,10 @@
+---
+description: "A key constraint of the Pipes and Filters architectural style is that Filters do not share state."
+layout:
+  description:
+    visible: false
+---
+
 # Passing Information Between Handlers in the Pipeline
 
 > **How-to** · Applies to **Brighter V10**

--- a/contents/V10MigrationGuide.md
+++ b/contents/V10MigrationGuide.md
@@ -1,3 +1,10 @@
+---
+description: "Brighter V10 introduces significant improvements and new features while maintaining a clear migration path from V9."
+layout:
+  description:
+    visible: false
+---
+
 # Brighter V10 Migration Guide
 
 > **How-to** · Applies to **Brighter V10**

--- a/contents/WhyBrighter.md
+++ b/contents/WhyBrighter.md
@@ -1,3 +1,10 @@
+---
+description: "Brighter and Darker are two of many options open to a .NET developer who needs a command processor, a command dispatcher, or a messaging framework."
+layout:
+  description:
+    visible: false
+---
+
 # Why Brighter?
 
 > **Explanation** · Applies to **Brighter V10 and Darker V4**

--- a/spec/010-information_architecture/tasks.md
+++ b/spec/010-information_architecture/tasks.md
@@ -2585,6 +2585,88 @@ not read* — and enumerate **both** directions.
 
 - [x] **Task 10.4** — rule 7 in `pagelint.py`, `CLAUDE.md` in the same commit, 8 pages fixed
 
+### The sweep as executed — 2026-08-22
+
+**142 of 142 pages carry a `description:`, and the whole sweep is one command.** The
+generator is not a script under `spec/`; it is a **third `--fix` repair** in `pagelint.py`,
+which qualifies on `--fix`'s own stated test — exactly one correct answer, derivable from the
+page. That keeps the convention maintainable after this spec closes: a new page gets its
+description from the tool that already checks it.
+
+**Reading the data before sweeping it found four defects, three of them in the rule.** Rule 7
+had passed at 0 errors across 142 pages the day before. Dumping all 142 extracted sentences
+and reading them is what disagreed:
+
+1. **The extractor read one line, and this corpus hard-wraps its prose.** **20 of 142
+   summaries were truncated mid-sentence**, four of them mid-link — `ReturningResultsFromAHandler.md`
+   summarised as *"We use [Command-Query"*, eight `…DistributedLock.md` pages as
+   *"…implements Brighter's [distributed"*. **Every one passed rule 7**, by being short,
+   unique and free of a trailing colon. Fixed by joining the paragraph. **The fix immediately
+   surfaced six genuine `SUMMARY TOO LONG` findings that truncation had been hiding**, which is
+   the measure of how vacuous the green run was.
+2. **`first_sentence` broke at "vs."** `EventCarriedStateTransfer.md` became *"In his white
+   paper "Data on the Outside vs."* — a truncation that is short, unique and ends in a period,
+   so all three clauses accepted it. An explicit `ABBREVIATIONS` set, plus single initials,
+   replaced a lookbehind that only knew "e.g.", "i.e." and "etc.".
+3. **`rendered()` left markdown backslash escapes in**, so `\"` and `\'` would have gone into
+   meta tags and the public index as backslashes.
+4. **Five pages had no terminal punctuation at all**, which no clause tested. Added as
+   `SUMMARY NOT A SENTENCE` — and **ordered *after* the colon check**, because a colon is also
+   a missing full stop and the other order silently retires a rule the task explicitly asked
+   for.
+
+> **The lesson underneath all four: rule 7 was green on 142 pages and wrong about 20 of them.**
+> A rule that measures a fragment measures it correctly. *A check that passes has not
+> necessarily checked anything* — met here not on a new gate, as in Phase 4, but on a gate
+> that had already been proved red on four branches. **Proving a rule fires does not prove it
+> reads the right input.**
+
+**The fifth defect was content, and it was the reason the fourth clause was worth adding.**
+`contents/Logging.md` — published, linked from `SUMMARY.md`, in `/llms.txt` — had a body
+consisting of the word **`TODO`**, and Spec 011's banner sweep had given it a banner, so it
+looked like a Reference page. **Ruled by the maintainer: write it.** Logging is genuinely
+undocumented; no other page carries a `## …Logging` section. The page was written from source
+— `ApplicationLogging` is a static holder whose default `LoggerFactory` has **no providers**,
+`AddBrighter` and `AddConsumers` each resolve `ILoggerFactory` with `GetService`, not
+`GetRequiredService`, and 124 files hold a `static readonly` logger built once at type
+initialisation, which is why a factory assigned late is never seen. Its type stays `Reference`,
+so `pagetypes.tsv` needed no row change — standing obligation 7 satisfied by not moving.
+
+**Two defects the sweep itself created, both caught before the commit:**
+
+- **A page whose front matter would never be read.** `ReturningResultsFromAHandler.md` begins
+  with a **newline** before its H1 — the only page in the corpus that does — so the block
+  landed on line 2. GitBook reads front matter only at the very first byte, so the page would
+  have rendered perfectly with no description and nothing anywhere to say so. `--fix` now
+  **refuses when the H1 is not on line 1**, and the leading newline was removed by hand.
+- **Rule 5 firing on a description derived from compliant prose.**
+  `HowServiceActivatorWorks.md` opens with `` `Brighter.ServiceActivator` `` in backticks —
+  legitimate, and rule 5 exempts code spans. But `rendered()` *strips* the backticks, so the
+  description carried the bare word and rule 5 fired on line 2. **Front matter is now excluded
+  from `page.prose`**, which loses nothing: `DESCRIPTION MISMATCH` keeps the description equal
+  to the sentence, so checking the body checks both.
+
+**Both of those sentences also had grammar errors** — *"the component in the assembly
+orchestrates your Performers"* and *"a Command does not have return value"* — which had sat
+unread for years and were about to become two pages' public descriptions. **A sentence
+promoted to a description gets read properly for the first time.**
+
+**Validated independently of the tool that wrote them.** `pagelint.py` parses front matter
+with a deliberately naive reader, so a green run proves nothing about YAML. Re-parsed with
+**PyYAML in a throwaway venv**: **142 of 142 parse, all carry a `description` and
+`layout.description.visible: false`, none is a duplicate**, longest 196 characters, shortest
+43. *A test can be vacuous in exactly the way a check can* — so the check was not its own
+witness.
+
+**Gates after the sweep:** linkcheck 144 files, pagelint **0 errors** / 791 warnings / 142
+pages, `--check-shape` 0, `--check-redirects` 0 at 77 entries, `--changed origin/master` 0
+with all 142 staged. **The using-directive debt did not move** — 791, as through Phases 6
+to 9.
+
+**What is left in Phase 10:** Task 10.2's *fix* — the 59 pages on `v9`, whose descriptions
+carry the version marker their bodies lack. A separate PR: a different branch, a different
+space, no banners, and nothing `pagelint.py` can see.
+
 ---
 
 ## Phase 11 — Close (PR 11)

--- a/tools/pagelint.py
+++ b/tools/pagelint.py
@@ -80,10 +80,19 @@ block still counts towards the debt and still says so, in its own words. Without
 it, moving a block verbatim between pages is indistinguishable from writing a
 new one, and a page split cannot honour "move text, do not improve it".
 
---fix repairs the two rules that have exactly one correct answer: a banner whose
-version segment is stale against APPLIES_TO, and an untagged fence whose body
-shows no evidence of being code. It never decides a page type. See the --fix
-section below for why that boundary is where it is.
+--fix repairs the three rules that have exactly one correct answer: a banner
+whose version segment is stale against APPLIES_TO, an untagged fence whose body
+shows no evidence of being code, and a missing `description:` front matter,
+which is the page's own opening sentence with its markdown stripped. It never
+decides a page type. See the --fix section below for why that boundary is where
+it is.
+
+The description repair refuses whenever the sentence it would copy fails rule 7,
+so --fix cannot manufacture a description the linter then rejects -- nor, worse,
+one it accepts. It also refuses when the H1 is not on line 1: GitBook reads front
+matter only at the very first byte, and a block written under a leading blank
+line is not front matter at all. That failure is silent, which is why it is a
+refusal rather than a best effort.
 
 Usage:
     python3 tools/pagelint.py                          # whole repo
@@ -545,6 +554,98 @@ def fix_banner_version(page):
                    f'{stale} -> {current}')], []
 
 
+def yaml_quote(value):
+    """A YAML scalar for `value`, or None when the answer is not unique.
+
+    Double quotes by default, so the apostrophes in "Brighter's" need no
+    thought. Single quotes when the value itself contains a double quote --
+    EventCarriedStateTransfer.md opens by naming a paper in quotes. Refuses
+    when it contains both, or a backslash, rather than guessing at an escape:
+    GitBook's failure mode for malformed front matter is a page that imports
+    with no title and no error, so a wrong guess here is invisible.
+    """
+    if '\\' in value:
+        return None
+    if '"' not in value:
+        return '"' + value + '"'
+    if "'" not in value:
+        return "'" + value + "'"
+    return None
+
+
+def fix_description(page):
+    """Write `description:` front matter from the page's own opening sentence.
+
+    This qualifies for --fix on the same test as the other two repairs: there
+    is exactly one correct answer and it is derivable from the page. It refuses
+    whenever the sentence itself would fail rule 7, so --fix cannot manufacture
+    a description that the linter then rejects -- or worse, accept one.
+    """
+    got, why = opening_sentence(page)
+    if got is None:
+        return [], [Refusal(page.rel, 1, f'{why}, so there is no sentence to describe it with')]
+    sentence, lineno = got
+    shown = rendered(sentence)
+
+    if len(shown) > SUMMARY_LIMIT or shown.endswith(':') \
+            or not shown.endswith(('.', '!', '?')):
+        return [], [Refusal(page.rel, lineno,
+                            'the opening sentence does not satisfy rule 7; fix the '
+                            'sentence and the description follows from it')]
+
+    quoted = yaml_quote(shown)
+    if quoted is None:
+        return [], [Refusal(page.rel, lineno,
+                            'the opening sentence contains a backslash, or both quote '
+                            'characters, so its YAML scalar is not unique')]
+
+    existing, unreadable = front_matter_description(page)
+    if unreadable:
+        return [], [Refusal(page.rel, 1, unreadable)]
+
+    if existing is not None:
+        if existing == shown:
+            return [], []
+        for line in range(1, len(page.lines) + 1):
+            if page.lines[line - 1].startswith('description:'):
+                return [Change(page.rel, line, page.lines[line - 1],
+                               'description: ' + quoted,
+                               'description retargeted at the opening sentence')], []
+        return [], [Refusal(page.rel, 1, 'the description moved under the fix')]
+
+    if page.lines and page.lines[0].strip() == '---':
+        return [], [Refusal(page.rel, 1,
+                            'the page has front matter but no `description:`; adding a key '
+                            'to a block someone else wrote is an editorial change')]
+
+    # GitBook requires front matter at the very first byte of the file. A page
+    # with a blank line before its H1 would take the block at line 2, where it
+    # is not front matter at all -- and the failure is silent, because the page
+    # still renders and simply has no description. Caught on
+    # ReturningResultsFromAHandler.md, the one page in the corpus that opens
+    # with a newline.
+    if page.h1_line != 1:
+        return [], [Refusal(page.rel, 1,
+                            f'the H1 is on line {page.h1_line}, so front matter written '
+                            'above it would not be the first bytes of the file, and '
+                            'GitBook would ignore it')]
+
+    # No front matter at all: the block goes above the H1, and carries the
+    # layout switch with it. Without `visible: false` GitBook renders the
+    # description as a subtitle, and the page then opens with the same sentence
+    # twice -- once as the subtitle, once as the paragraph it was taken from.
+    h1 = page.lines[page.h1_line - 1]
+    block = ('---\n'
+             f'description: {quoted}\n'
+             'layout:\n'
+             '  description:\n'
+             '    visible: false\n'
+             '---\n'
+             '\n') + h1
+    return [Change(page.rel, page.h1_line, h1, block,
+                   'description written from the opening sentence')], []
+
+
 # Evidence that a block is code, and so not this tool's to tag. Each entry is
 # (what it recognises, pattern); the first to match a line holds the fix back.
 CODE_EVIDENCE = (
@@ -658,8 +759,16 @@ def check_terminology(page):
             line.strip() == OPT_OUT for line in page.lines):
         return []
 
+    # Front matter is not prose, and reading it as prose double-reports. The
+    # `description:` value is the opening sentence with its code spans stripped,
+    # so an assembly name legitimately in backticks -- `Brighter.ServiceActivator`
+    # on HowServiceActivatorWorks.md -- arrives here bare and fires a rule the
+    # body it came from already passes. DESCRIPTION MISMATCH keeps the two
+    # equal, so checking the body checks both.
     findings = []
     for lineno, line in page.prose:
+        if lineno <= front_matter_end(page):
+            continue
         if OPT_OUT in line:
             continue
         stripped = LINK_TARGET_RE.sub(']()', INLINE_CODE_RE.sub('``', line))
@@ -693,18 +802,44 @@ def rendered(text):
     text = re.sub(r'`([^`]*)`', r'\1', text)
     text = re.sub(r'\*\*([^*]*)\*\*', r'\1', text)
     text = re.sub(r'\*([^*]*)\*', r'\1', text)
+    # Markdown backslash escapes are punctuation to a reader and backslashes to
+    # everyone else. EventCarriedStateTransfer.md opens with an escaped quote,
+    # and without this the description written from it carries the backslashes
+    # into the page's meta tags and the published index.
+    text = re.sub(r'\\([\\`*_{}\[\]()#+\-.!"<>|\'])', r'\1', text)
     return text.strip()
+
+
+# Sentence-enders that are not. Kept explicit rather than clever: a page opening
+# "Data on the Outside vs. Data on the Inside" was being summarised as
+# "In his white paper "Data on the Outside vs." -- accepted by every clause of
+# rule 7, because a truncated sentence is short, unique and ends in a period.
+ABBREVIATIONS = frozenset({
+    'e.g', 'i.e', 'etc', 'vs', 'cf', 'approx', 'viz', 'resp', 'al', 'ca',
+    'inc', 'ltd', 'co', 'corp', 'fig', 'no', 'dr', 'mr', 'mrs', 'ms', 'st',
+    'jr', 'sr',
+})
+
+TRAILING_WORD_RE = re.compile(r'([A-Za-z.]+)$')
 
 
 def first_sentence(text):
     """Up to the first sentence-ending period, else the whole line.
 
-    The lookbehinds keep "e.g." and "i.e." from ending a sentence mid-clause;
-    without them a page opening "Brighter supports several brokers, e.g. Kafka."
-    would be summarised as four words.
+    A period ends a sentence unless the word before it is an abbreviation or a
+    single initial. Guessing the other way -- treating every period as a
+    boundary -- produces a summary that passes all of rule 7's checks and is
+    nonsense, which is the worst of both: enforced, and wrong.
     """
-    match = re.search(r'(?<!\be\.g)(?<!\bi\.e)(?<!\betc)[.!?](\s|$)', text)
-    return text[:match.start() + 1].strip() if match else text.strip()
+    for match in re.finditer(r'[.!?](\s|$)', text):
+        word = TRAILING_WORD_RE.search(text[:match.start()])
+        token = word.group(1) if word else ''
+        if token.lower().rstrip('.') in ABBREVIATIONS:
+            continue
+        if re.fullmatch(r'[A-Za-z]', token):      # an initial: "Pat J. Helland"
+            continue
+        return text[:match.start() + 1].strip()
+    return text.strip()
 
 
 def opening_sentence(page):
@@ -744,8 +879,29 @@ def opening_sentence(page):
         text = line.strip()
         if not text or HEADING_RE.match(line) or text.startswith('>'):
             continue
-        return (first_sentence(text), lineno), None
+        # The whole paragraph, not the line. Prose here is hard-wrapped, so a
+        # sentence routinely runs past a newline -- and a line-at-a-time reader
+        # returns a fragment that passes every clause of rule 7 by being short,
+        # unique and punctuation-free. Measured before this was fixed: 20 of
+        # 142 summaries were truncated mid-sentence, four of them mid-link.
+        para = [text]
+        for follow in range(lineno + 1, len(page.lines) + 1):
+            nxt = page.lines[follow - 1]
+            if not nxt.strip() or HEADING_RE.match(nxt) or FENCE_RE.match(nxt):
+                break
+            para.append(nxt.strip())
+        return (first_sentence(' '.join(para)), lineno), None
     return None, 'the page has no prose after its banner'
+
+
+def front_matter_end(page):
+    """Line number of the closing `---`, or 0 when the page has no front matter."""
+    if not page.lines or page.lines[0].strip() != '---':
+        return 0
+    for lineno in range(2, len(page.lines) + 1):
+        if page.lines[lineno - 1].strip() == '---':
+            return lineno
+    return 0
 
 
 def front_matter_description(page):
@@ -824,12 +980,21 @@ def check_summaries(pages, reported):
                 f'the opening sentence is {len(shown)} characters rendered; '
                 f'the limit is {SUMMARY_LIMIT}. Split it — the first sentence '
                 'has to survive being read on its own, in a search result'))
+        # Colon first, then the general case. A colon IS a missing terminal
+        # stop, so the other order makes this branch unreachable and silently
+        # retires a rule -- the specific message has the specific remedy.
         if shown.endswith(':'):
             findings.append(error(
                 rel, lineno, 'SUMMARY ENDS IN COLON',
                 'the opening sentence ends in a colon, so it promises a list '
                 'that an index will not print. Say what the page is about, then '
                 'introduce the list'))
+        elif not shown.endswith(('.', '!', '?')):
+            findings.append(error(
+                rel, lineno, 'SUMMARY NOT A SENTENCE',
+                f'the page opens with "{shown[:60]}…", which has no terminal '
+                'punctuation. An index prints it as the page\'s whole description, '
+                'so a fragment reads as a truncation of something better'))
 
         # Parity with the front matter, on pages that carry one. The whole point
         # of deriving the description from the page is that the two cannot
@@ -969,7 +1134,7 @@ def main(argv):
     if fix:
         changes, refusals = [], []
         for rel in reported:
-            for fixer in (fix_banner_version, fix_language_tags):
+            for fixer in (fix_banner_version, fix_language_tags, fix_description):
                 made, held = fixer(pages[rel])
                 changes += made
                 refusals += held


### PR DESCRIPTION
Every page now carries a `description:` that GitBook publishes into the canonical `/llms.txt`, its `<meta name="description">` and its social cards. **The generator is a third `--fix` repair**, not a script under `spec/` — it qualifies on `--fix`'s own stated test (exactly one correct answer, derivable from the page), so a new page gets its description from the tool that already checks it, long after this spec closes.

## Reading the data before sweeping it found four defects — three in the rule

Rule 7 passed at **0 errors across 142 pages** the day before. Dumping all 142 extracted sentences and reading them is what disagreed.

1. **The extractor read one line, and this corpus hard-wraps its prose.** **20 of 142 summaries were truncated mid-sentence**, four of them mid-link — `ReturningResultsFromAHandler.md` as *"We use [Command-Query"*, eight `…DistributedLock.md` pages as *"…implements Brighter's [distributed"*. **Every one passed rule 7**, by being short, unique and free of a trailing colon. Joining the paragraph **immediately surfaced six genuine `SUMMARY TOO LONG` findings that truncation had been hiding** — the measure of how vacuous the green run was.
2. **`first_sentence` broke at "vs."** — `EventCarriedStateTransfer.md` became *"In his white paper "Data on the Outside vs."*, which is short, unique and ends in a period, so all three clauses accepted it.
3. **`rendered()` left markdown backslash escapes in**, so `\"` would have reached meta tags and the public index as a backslash.
4. **Five pages had no terminal punctuation at all** — no clause tested it. Added as `SUMMARY NOT A SENTENCE`, **ordered after the colon check**, because a colon is also a missing full stop and the other order silently retires a rule the task asked for.

> **Rule 7 was green on 142 pages and wrong about 20 of them.** A rule that measures a fragment measures it correctly. **Proving a rule fires does not prove it reads the right input** — and this gate had already been proved red on four branches.

## The fifth defect was content

`contents/Logging.md` — published, linked from `SUMMARY.md`, in `/llms.txt` — had a body consisting of the word **`TODO`**, with a banner from Spec 011's sweep making it look like a Reference page. **Written from source at your ruling**: `ApplicationLogging`'s default factory has no providers, `AddBrighter`/`AddConsumers` resolve `ILoggerFactory` with `GetService` not `GetRequiredService`, and 124 files hold a `static readonly` logger built once at type initialisation — which is why a factory assigned late is never seen. Type stays `Reference`, so `pagetypes.tsv` needed no change.

## Two defects the sweep itself created, both caught before the commit

- **A page whose front matter would never be read.** `ReturningResultsFromAHandler.md` begins with a **newline** before its H1 — the only page that does — so the block landed on line 2. GitBook reads front matter only at the very first byte, so the page would render perfectly with no description and **nothing anywhere to say so**. `--fix` now refuses when the H1 is not on line 1.
- **Rule 5 firing on a description derived from compliant prose.** `HowServiceActivatorWorks.md` opens with `` `Brighter.ServiceActivator` `` in backticks, which rule 5 exempts — but `rendered()` *strips* backticks, so the description carried the bare word. Front matter is now excluded from `page.prose`; nothing is lost, because `DESCRIPTION MISMATCH` keeps description and sentence equal.

**Both of those sentences also carried grammar errors** — *"the component in the assembly orchestrates your Performers"*, *"a Command does not have return value"* — unread for years, and about to become two pages' public descriptions. A sentence promoted to a description gets read properly for the first time.

## Validated independently of the tool that wrote it

`pagelint.py` parses front matter with a deliberately naive reader, so a green run proves nothing about YAML. Re-parsed with **PyYAML**: **142 of 142 parse**, all carry `description` and `layout.description.visible: false`, **none is a duplicate**, longest **196**, shortest **43**.

## Gates

linkcheck **144 files**; pagelint **0 errors** / 791 warnings / 142 pages; `--check-shape` 0; `--check-redirects` 0 at 77 entries; `--changed origin/master` 0 with all 142 staged. **The using-directive debt did not move.**

## What is left in Phase 10

Task 10.2's *fix* — the 59 pages on `v9`, whose descriptions carry the version marker their bodies lack. A separate PR: different branch, different space, no banners, nothing `pagelint.py` can see.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012tcdwxVb8NmKaX2S6fvyFg