### PR TITLE
docs: V9 — version-marked descriptions, and a SUMMARY that matches its files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+---
+description: "Brighter V9 (superseded). Documentation for the Brighter and Darker projects."
+---
+
 # Brighter and Darker Documentation
 
 Documentation for the [Brighter](https://github.com/BrighterCommand/Brighter) and [Darker](https://github.com/BrighterCommand/Darker) projects.

--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -13,7 +13,7 @@
  * [AWS SNS Configuration](/contents/AWSSQSConfiguration.md)
  * [Kafka Configuration](/contents/KafkaConfiguration.md)
  * [Azure Service Bus Configuration](/contents/AzureServiceBusConfiguration.md)
- * [Azure Archive Provider Configuration](/contents/)
+ * [Azure Archive Provider Configuration](/contents/AzureBlobConfiguration.md)
  * [Brighter Control API](/contents/BrighterControlAPI.md)
 
 ## Darker Configuration
@@ -23,7 +23,7 @@
 ## Brighter Request Handlers and Middleware Pipelines
 
  * [Building an Async Pipeline of Request Handlers](/contents/BuildingAnAsyncPipeline.md)
- * [Basic Configuration](/contents/DarkerBasicConfiguration.md)
+ * [How to Implement a Request Handler](/contents/ImplementingAHandler.md)
  * [How to Implement an Async Request Handler](/contents/ImplementingAsyncHandler.md)
  * [Requests, Commands and an Events](/contents/Requests%2C%20Commands%20and%20Events.md)
  * [Dispatching Requests](/contents/DispatchingARequest.md)
@@ -31,6 +31,9 @@
  * [Returning results from a Handler](/contents/ReturningResultsFromAHandler.md)
  * [Using an External Bus](/contents/ImplementingExternalBus.md)
  * [Message Mappers](/contents/MessageMappers.md)
+ * [Claim Check](/contents/ClaimCheck.md)
+ * [Compression](/contents/Compression.md)
+ * [S3 Luggage Store](/contents/S3LuggageStore.md)
  * [Routing](/contents/Routing.md)
  * [Building a Pipeline of Request Handlers](/contents/BuildingAPipeline.md)
  * [Passing information between Handlers in the Pipeline](/contents/UsingTheContextBag.md)
@@ -51,6 +54,7 @@
  * [Postgres Inbox](/contents/PostgresInbox.md)
  * [Sqlite Inbox](/contents/SqliteInbox.md)
  * [Dynamo Inbox](/contents/DynamoInbox.md)
+ * [Azure Blob Archive Provider](/contents/AzureBlobArchiveProvider.md)
 
 ## Darker Query Handlers and Middleware Pipelines
 
@@ -66,15 +70,6 @@
 ## Command, Processors and Dispatchers
 
  * [Command, Processor and Dispatcher Patterns](/contents/CommandsCommandDispatcherandProcessor.md)
-
-## Scheduler
-
- * [Scheduler](/contents/BrighterSchedulerSupport.md)
- * [Hangfire](/contents/HangfireScheduler.md)
- * [Quartz](/contents/Quartzcheduler.md)
- * [Aws Scheduler](/contents/AwsScheduler.md)
- * [Azure Scheduler](/contents/AzureScheduler.md)
- * [Custom Scheduler](/contents/CustomScheduler.md)
 
 ## Under the Hood
 

--- a/contents/AWSSQSConfiguration.md
+++ b/contents/AWSSQSConfiguration.md
@@ -1,3 +1,7 @@
+---
+description: "Brighter V9 (superseded). SNS and SQS are proprietary message-oriented-middleware available on the AWS platform."
+---
+
 # AWS SQS Configuration
 
 ## General

--- a/contents/AsyncDispatchARequest.md
+++ b/contents/AsyncDispatchARequest.md
@@ -1,3 +1,7 @@
+---
+description: "Brighter V9 (superseded). Once you have implemented your Request Handler, you will want to dispatch Commands or Events to that Handler."
+---
+
 # Dispatching Requests Asynchronously
 
 Once you have [implemented your Request Handler](ImplementingAHandler.html), you will want to dispatch **Commands** or **Events** to that Handler.

--- a/contents/AzureBlobArchiveProvider.md
+++ b/contents/AzureBlobArchiveProvider.md
@@ -1,3 +1,7 @@
+---
+description: "Brighter V9 (superseded). The Azure Blob Archive Provider is a provider for Outbox Archiver."
+---
+
 # Azure Blob Archive Provider
 
 ## Usage

--- a/contents/AzureBlobConfiguration.md
+++ b/contents/AzureBlobConfiguration.md
@@ -1,3 +1,7 @@
+---
+description: "Brighter V9 (superseded). Azure Service Bus (ASB) is a fully managed enterprise message broker and is well documented Brighter handles the details of sending to or receiving from ASB."
+---
+
 # Azure Archive Provider Configuration
 
 ## General

--- a/contents/AzureServiceBusConfiguration.md
+++ b/contents/AzureServiceBusConfiguration.md
@@ -1,3 +1,7 @@
+---
+description: "Brighter V9 (superseded). Azure Service Bus (ASB) is a fully managed enterprise message broker and is well documented Brighter handles the details of sending to or receiving from ASB."
+---
+
 # Azure Service Bus Configuration
 
 ## General

--- a/contents/BasicConcepts.md
+++ b/contents/BasicConcepts.md
@@ -1,3 +1,7 @@
+---
+description: "Brighter V9 (superseded). A command is an instruction to carry out work."
+---
+
 # Basic Concepts
 
 ## Command

--- a/contents/BrighterBasicConfiguration.md
+++ b/contents/BrighterBasicConfiguration.md
@@ -1,3 +1,7 @@
+---
+description: "Brighter V9 (superseded). Configuration is the most labor-intensive part of using Brighter.Once you have configured Brighter, using its model of requests and handlers is straightforward"
+---
+
 # **Basic Configuration**
 
 Configuration is the most labor-intensive part of using Brighter.Once you have configured Brighter, using its model of requests and handlers is straightforward

--- a/contents/BrighterControlAPI.md
+++ b/contents/BrighterControlAPI.md
@@ -1,3 +1,7 @@
+---
+description: "Brighter V9 (superseded). The brighter control API allows direct management of a Service Activator node"
+---
+
 # **Brighter Control API**
 The brighter control API allows direct management of a Service Activator node
 

--- a/contents/BrighterInboxSupport.md
+++ b/contents/BrighterInboxSupport.md
@@ -1,3 +1,7 @@
+---
+description: "Brighter V9 (superseded). Messaging makes the guaranteed, at least once promise."
+---
+
 # Brighter Inbox Support
 
 ## Guaranteed, At Least Once

--- a/contents/BrighterOutboxSupport.md
+++ b/contents/BrighterOutboxSupport.md
@@ -1,3 +1,7 @@
+---
+description: "Brighter V9 (superseded). Brighter supports storing messages that are sent via an External Bus in an Outbox, as per the Outbox Pattern"
+---
+
 # Outbox Support
 
 Brighter supports storing messages that are sent via an External Bus in an Outbox, as per the [Outbox Pattern](/contents/OutboxPattern.md)

--- a/contents/BuildingAPipeline.md
+++ b/contents/BuildingAPipeline.md
@@ -1,3 +1,7 @@
+---
+description: "Brighter V9 (superseded). Once you are using the features of Brighter to act as a command dispatcher and send or publish messages to a target handler, you may want to use its command processor…"
+---
+
 # Building a Pipeline of Request Handlers
 
 Once you are using the features of Brighter to act as a [command dispatcher](CommandsCommandDispatcherAndProcessor.html#command-dispatcher) and send or publish messages to a target handler, you may want to use

--- a/contents/BuildingAnAsyncPipeline.md
+++ b/contents/BuildingAnAsyncPipeline.md
@@ -1,3 +1,7 @@
+---
+description: "Brighter V9 (superseded). Once you are using the features of Brighter to act as a command dispatcher and send or publish messages to a target handler, you may want to use its command processor…"
+---
+
 # Building a Pipeline of Async Request Handlers
 
 Once you are using the features of Brighter to act as a [command dispatcher](CommandsCommandDispatcherAndProcessor.html#command-dispatcher) and send or publish messages to a target handler, you may want to use

--- a/contents/ClaimCheck.md
+++ b/contents/ClaimCheck.md
@@ -1,3 +1,7 @@
+---
+description: "Brighter V9 (superseded). The Claim Check pattern helps us reduce the size of our messages, without losing information that we need to exchange."
+---
+
 # Claim Check
 
 The [Claim Check](https://www.enterpriseintegrationpatterns.com/patterns/messaging/StoreInLibrary.html) pattern helps us reduce the size of our messages, without losing information that we need to exchange. 

--- a/contents/CommandsCommandDispatcherandProcessor.md
+++ b/contents/CommandsCommandDispatcherandProcessor.md
@@ -1,3 +1,7 @@
+---
+description: "Brighter V9 (superseded). The Command design pattern encapsulates a request as an object, allowing reuse, queuing or logging of requests, or undoable operations."
+---
+
 # Command Patterns
 
 ## Command

--- a/contents/Compression.md
+++ b/contents/Compression.md
@@ -1,3 +1,7 @@
+---
+description: "Brighter V9 (superseded). The Compression transform helps us reduce the size of a message using a compression algorithm."
+---
+
 # Compression
 
 The Compression transform helps us reduce the size of a message using a compression algorithm. It is an efficient approach to reducing the size of a payload. 

--- a/contents/DapperOutbox.md
+++ b/contents/DapperOutbox.md
@@ -1,3 +1,7 @@
+---
+description: "Brighter V9 (superseded). The Dapper Outbox allows integration between Dapper and Brighter's outbox support."
+---
+
 # Dapper Outbox
 
 ## Usage

--- a/contents/DarkerBasicConfiguration.md
+++ b/contents/DarkerBasicConfiguration.md
@@ -1,1 +1,5 @@
+---
+description: "Brighter V9 (superseded)."
+---
+
 # Basic Configuration

--- a/contents/DispatchingARequest.md
+++ b/contents/DispatchingARequest.md
@@ -1,3 +1,7 @@
+---
+description: "Brighter V9 (superseded). Once you have implemented your Request Handler, you will want to dispatch Commands or Events to that Handler."
+---
+
 # Dispatching Requests
 
 Once you have [implemented your Request Handler](ImplementingAHandler.html), you will want to dispatch **Commands** or **Events** to that Handler.

--- a/contents/DynamoInbox.md
+++ b/contents/DynamoInbox.md
@@ -1,3 +1,7 @@
+---
+description: "Brighter V9 (superseded). The DynamoDb Inbox allows use of DynamoDb for Brighter's inbox support."
+---
+
 # Dynamo Inbox
 
 ## Usage

--- a/contents/DynamoOutbox.md
+++ b/contents/DynamoOutbox.md
@@ -1,3 +1,7 @@
+---
+description: "Brighter V9 (superseded). The DynamoDb Outbox allows integration between DynamoDb and Brighter's outbox support."
+---
+
 # DynamoDb Outbox
 
 ## Usage

--- a/contents/EFCoreOutbox.md
+++ b/contents/EFCoreOutbox.md
@@ -1,3 +1,7 @@
+---
+description: "Brighter V9 (superseded). The EFCore Outbox allows integration between EF Core and Brighter's outbox support."
+---
+
 # EF Core Outbox
 
 ## Usage

--- a/contents/EventCarriedStateTransfer.md
+++ b/contents/EventCarriedStateTransfer.md
@@ -1,3 +1,7 @@
+---
+description: 'Brighter V9 (superseded). In his white paper "Data on the Outside vs. Data on the Inside", Pat Helland classifies data according to whether it exists inside a service boundary or outside that…'
+---
+
 # Event Carried State Transfer (ECST)
 
 ## Outside and Inside Data 

--- a/contents/EventDrivenCollaboration.md
+++ b/contents/EventDrivenCollaboration.md
@@ -1,3 +1,7 @@
+---
+description: "Brighter V9 (superseded). Event Driven Architectures (EDA) are a major use case for Brighter's External Bus-you want processes to collaborate via messaging."
+---
+
 # Event Driven Collaboration
 
 Event Driven Architectures (EDA) are a major use case for Brighter's External Bus-you want processes to collaborate via messaging.

--- a/contents/FAQ.md
+++ b/contents/FAQ.md
@@ -1,3 +1,7 @@
+---
+description: "Brighter V9 (superseded). When should you use an asynchronous pipeline to handle work and when should you use an External Bus."
+---
+
 # FAQ
 
 ## Asynchronous or External Bus

--- a/contents/FeatureSwitches.md
+++ b/contents/FeatureSwitches.md
@@ -1,3 +1,7 @@
+---
+description: "Brighter V9 (superseded). We provide a FeatureSwitch Attribute and FeatureSwitchAsync Attribute that you can use on your IHandleRequests<TRequest>.Handle() method, and…"
+---
+
 # Feature Switches
 
 We provide a **FeatureSwitch** Attribute and **FeatureSwitchAsync** Attribute that you can use on your **IHandleRequests\<TRequest\>.Handle()** method, and **IHandleRequests\<TRequest\>.HandleAysnc()** method. The **FeatureSwitch** Attribute and **FeatureSwitchAsync** Attribute that you have configured will determine whether or not the

--- a/contents/HandlerFailure.md
+++ b/contents/HandlerFailure.md
@@ -1,3 +1,7 @@
+---
+description: "Brighter V9 (superseded). When a Request is passed to RequestHandler.Handle() it runs in your application code."
+---
+
 # Failure and Dead Letter Queues
 
 When a *Request* is passed to **RequestHandler.Handle()** it runs in your application code. If your application code fails, you have a number of options:

--- a/contents/HealthChecks.md
+++ b/contents/HealthChecks.md
@@ -1,3 +1,7 @@
+---
+description: "Brighter V9 (superseded). Brighter provides an AspNet Core Health check for Service Activator"
+---
+
 # Health Checks
 
 Brighter provides an AspNet Core Health check for **Service Activator**

--- a/contents/HowBrighterWorks.md
+++ b/contents/HowBrighterWorks.md
@@ -1,3 +1,7 @@
+---
+description: "Brighter V9 (superseded). You don't need to understand how Brighter works under the hood to use it, but if you want to debug, or contribute to the project, it can help to know what is going on."
+---
+
 # How The Command Processor Works
 
 You don\'t need to understand how Brighter works under the hood to use it, but if you want to debug, or contribute to the project, it can help to know what is going on.

--- a/contents/HowConfiguringTheCommandProcessorWorks.md
+++ b/contents/HowConfiguringTheCommandProcessorWorks.md
@@ -1,3 +1,7 @@
+---
+description: "Brighter V9 (superseded). Brighter does not have a dependency on an Inversion Of Control (IoC) framework."
+---
+
 # How Configuring the Command Processor Works
 
 Brighter does not have a dependency on an Inversion Of Control (IoC) framework. This gives you freedom to choose the DI libraries you want for your project.

--- a/contents/HowConfiguringTheDispatcherWorks.md
+++ b/contents/HowConfiguringTheDispatcherWorks.md
@@ -1,3 +1,7 @@
+---
+description: "Brighter V9 (superseded). In order to receive messages from Message Oriented Middleware (MoM) such as RabbitMQ or Kafka you have to configure a Dispatcher."
+---
+
 # How Configuring a Dispatcher for an External Bus Works
 
 In order to receive messages from Message Oriented Middleware (MoM) such as RabbitMQ or Kafka you have to configure a *Dispatcher*. The *Dispatcher* works with a *Command Processor* to deliver messages read from a queue or stream to your *Request Handler*. You write a Request Handler as you would for a request sent over an Internal Bus, and hook it up to Message Oriented Middleware via a *Dispatcher*. 

--- a/contents/HowServiceActivatorWorks.md
+++ b/contents/HowServiceActivatorWorks.md
@@ -1,3 +1,7 @@
+---
+description: "Brighter V9 (superseded). Coming Soon..."
+---
+
 # How The Service Activator Works
 
 Coming Soon...

--- a/contents/ImplementAQueryHandler.md
+++ b/contents/ImplementAQueryHandler.md
@@ -1,3 +1,7 @@
+---
+description: "Brighter V9 (superseded)."
+---
+
 # Implementing a Query Handler
 
 TODO

--- a/contents/ImplementingAHandler.md
+++ b/contents/ImplementingAHandler.md
@@ -1,3 +1,7 @@
+---
+description: "Brighter V9 (superseded). To implement a handler, derive from RequestHandler<T> where T should be the Command or Event derived type that you wish to handle."
+---
+
 # How to Implement a Request Handler
 
 To implement a handler, derive from RequestHandler\<T\> where T should be the **Command** or **Event** derived type that you wish to handle. Then override the base class Handle() method to implement your handling

--- a/contents/ImplementingAsyncHandler.md
+++ b/contents/ImplementingAsyncHandler.md
@@ -1,3 +1,7 @@
+---
+description: "Brighter V9 (superseded). To implement an asynchronous handler, derive from RequestHandlerAsync<T> where T should be the Command or Event derived type that you wish to handle."
+---
+
 # How to Implement an Asynchronous Request Handler
 
 To implement an asynchronous handler, derive from **RequestHandlerAsync\<T\>** where *T* should be the **Command** or **Event** derived type that you wish to handle. Then override the base

--- a/contents/ImplementingExternalBus.md
+++ b/contents/ImplementingExternalBus.md
@@ -1,3 +1,7 @@
+---
+description: "Brighter V9 (superseded). Brighter provides support for an External Bus."
+---
+
 # Using an External Bus 
 
 Brighter provides support for an External Bus. Instead of handling a command or event, synchronously and in-process, (an Internal Event Bus) work can be dispatched to a distributed queue to be handled

--- a/contents/KafkaConfiguration.md
+++ b/contents/KafkaConfiguration.md
@@ -1,3 +1,7 @@
+---
+description: "Brighter V9 (superseded). Kafka is OSS message-oriented-middleware and is well documented."
+---
+
 # Kafka Configuration
 
 ## General

--- a/contents/Logging.md
+++ b/contents/Logging.md
@@ -1,3 +1,7 @@
+---
+description: "Brighter V9 (superseded)."
+---
+
 # Logging
 
 TODO

--- a/contents/MSSQLInbox.md
+++ b/contents/MSSQLInbox.md
@@ -1,3 +1,7 @@
+---
+description: "Brighter V9 (superseded). The MSSQL Inbox allows use of MSSQL for Brighter's inbox support."
+---
+
 # MSSQL Inbox
 
 ## Usage

--- a/contents/MessageMappers.md
+++ b/contents/MessageMappers.md
@@ -1,3 +1,7 @@
+---
+description: "Brighter V9 (superseded). A message mapper turns domain code into a Brighter Message."
+---
+
 # Message Mappers
 
 A message mapper turns domain code into a Brighter **Message**. A Brighter **Message** has a **MessageHeader** for information about the message. Key properties are: **TimeStamp**, **Topic**, and **Id**.  The **Message** also has a **MessageBody**, which contains the payload. 

--- a/contents/Microservices.md
+++ b/contents/Microservices.md
@@ -1,3 +1,7 @@
+---
+description: "Brighter V9 (superseded). It is possible to think of microservices as 3rd generation SOA."
+---
+
 # Microservices
 
 It is possible to think of microservices as 3rd generation SOA. First generation SOA was SOAP based web services. 2nd generation SOA was messaging, sometimes over SOAP, but also over middleware, often an

--- a/contents/Monitoring.md
+++ b/contents/Monitoring.md
@@ -1,3 +1,7 @@
+---
+description: "Brighter V9 (superseded). Brighter emits monitoring information from an External Bus using a configured Control Bus"
+---
+
 # Monitoring
 
 Brighter emits monitoring information from an External Bus using a configured [Control Bus](https://brightercommand.github.io/Brighter/ControlBus.html)

--- a/contents/MySQLInbox.md
+++ b/contents/MySQLInbox.md
@@ -1,3 +1,7 @@
+---
+description: "Brighter V9 (superseded). The MySQL Inbox allows use of MySQL for Brighter's inbox support."
+---
+
 # MySQL Inbox
 
 ## Usage

--- a/contents/OutboxPattern.md
+++ b/contents/OutboxPattern.md
@@ -1,3 +1,7 @@
+---
+description: "Brighter V9 (superseded). When a microservice changes the state for which it is the system of record, and then signals to subscribers via an event that it has changed its state, how do we ensure…"
+---
+
 # Outbox Pattern Support
 
 ## Producer Correctness

--- a/contents/PolicyFallback.md
+++ b/contents/PolicyFallback.md
@@ -1,3 +1,7 @@
+---
+description: "Brighter V9 (superseded). You may want some sort of backstop exception handler, that allows you to take compensating action, such as undoing any partially committed work, issuing a compensating…"
+---
+
 # Fallback
 
 You may want some sort of backstop exception handler, that allows you to take compensating action, such as undoing any partially committed work, issuing a compensating transaction, or queuing work for later delivery (perhaps using the [External Bus](/contents/ImplementingExternalBus.md)).

--- a/contents/PolicyRetryAndCircuitBreaker.md
+++ b/contents/PolicyRetryAndCircuitBreaker.md
@@ -1,3 +1,7 @@
+---
+description: "Brighter V9 (superseded). Brighter is a Command Processor and supports a pipeline of Handlers to handle orthogonal requests."
+---
+
 # Supporting Retry and Circuit Breaker
 
 Brighter is a [Command Processor](https://www.goparamore.io/control-bus-and-data-bus/) and

--- a/contents/PostgresInbox.md
+++ b/contents/PostgresInbox.md
@@ -1,3 +1,7 @@
+---
+description: "Brighter V9 (superseded). The Postgres Inbox allows use of Postgres for Brighter's inbox support."
+---
+
 # Postgres Inbox
 
 ## Usage

--- a/contents/RabbitMQConfiguration.md
+++ b/contents/RabbitMQConfiguration.md
@@ -1,3 +1,7 @@
+---
+description: "Brighter V9 (superseded). RabbitMQ is OSS message-oriented-middleware and is well documented."
+---
+
 # RabbitMQ Configuration
 
 ## General

--- a/contents/Requests, Commands and Events.md
+++ b/contents/Requests, Commands and Events.md
@@ -1,3 +1,7 @@
+---
+description: "Brighter V9 (superseded). We use the term Request for a data object containing parameters that you want to dispatch to a handler."
+---
+
 # Requests, Commands and Events
 ## The IRequest Interface
 

--- a/contents/ReturningResultsFromAHandler.md
+++ b/contents/ReturningResultsFromAHandler.md
@@ -1,3 +1,6 @@
+---
+description: "Brighter V9 (superseded). We use Command-Query separation so a Command does not have return value and CommandDispatcher.Send() does not return anything."
+---
 
 # Returning Results from a Handler
 

--- a/contents/Routing.md
+++ b/contents/Routing.md
@@ -1,3 +1,7 @@
+---
+description: "Brighter V9 (superseded). A producer routes messages to subscribers by setting a Topic on the MessageHeader."
+---
+
 # Routing
 
 ### Routing Messages

--- a/contents/S3LuggageStore.md
+++ b/contents/S3LuggageStore.md
@@ -1,3 +1,7 @@
+---
+description: "Brighter V9 (superseded). The S3LuggageStore is an implementation of IAmAStorageProviderAsync for AWS S3 Object Storage."
+---
+
 # S3 Luggage Store
 
 The **S3LuggageStore** is an implementation of **IAmAStorageProviderAsync** for AWS S3 Object Storage. It allows use of the [Claim Check](/contents/ClaimCheck.md) *Transformer* with S3 Object Storage as the *Luggage Store*.

--- a/contents/ShowMeTheCode.md
+++ b/contents/ShowMeTheCode.md
@@ -1,3 +1,7 @@
+---
+description: "Brighter V9 (superseded). There is an old principle: show don't tell, and this introduction is about showing you what you can do with Brighter and Darker."
+---
+
 # Show me the code!
 
 There is an old principle: show don't tell, and this introduction is about showing you what you can do with Brighter and Darker. It's not about how - more detailed documentation elsewhere shows you how to write this code. It's not about why - articles elsewhere discuss some of the reasons behind this approach. It is just, let me see how Brighter works. 

--- a/contents/SqliteInbox.md
+++ b/contents/SqliteInbox.md
@@ -1,3 +1,7 @@
+---
+description: "Brighter V9 (superseded). The Sqlite Inbox allows use of Sqlite for Brighter's inbox support."
+---
+
 # Sqlite Inbox
 
 ## Usage

--- a/contents/TaskQueuePattern.md
+++ b/contents/TaskQueuePattern.md
@@ -1,3 +1,7 @@
+---
+description: "Brighter V9 (superseded). The Task Queue Pattern let's you use an External Bus to handle work asynchronously."
+---
+
 # The Task Queue Pattern
 
 The Task Queue Pattern let's you use an External Bus to handle work asynchronously. It is a common use of an External Bus outside of using it for an [Event Driven Architecture](/contents/EventDrivenCollaboration.md).

--- a/contents/Telemetry.md
+++ b/contents/Telemetry.md
@@ -1,3 +1,7 @@
+---
+description: "Brighter V9 (superseded). Starting in version 9.2.1 Brighter now supports Open Telemetry Tracing"
+---
+
 # Telemetry
 
 Starting in version 9.2.1 Brighter now supports Open Telemetry Tracing

--- a/contents/UsingTheContextBag.md
+++ b/contents/UsingTheContextBag.md
@@ -1,3 +1,7 @@
+---
+description: "Brighter V9 (superseded). A key constraint of the Pipes and Filters architectural style is that Filters do not share state."
+---
+
 # Passing information between Handlers in the Pipeline
 
 A key constraint of the Pipes and Filters architectural style is that Filters do not share state. One reason is that this limits your ability to recompose the pipeline as steps must follow other steps.

--- a/contents/WhyBrighter.md
+++ b/contents/WhyBrighter.md
@@ -1,3 +1,7 @@
+---
+description: "Brighter V9 (superseded). There are many options for .NET developers looking for either a package to use as a command processor/dispatcher pattern implementation (sometimes confused with the…"
+---
+
 # Why Brighter?
 
 There are many options for .NET developers looking for either a package to use as a command processor/dispatcher pattern implementation (sometimes confused with the mediator pattern) or package to use as a messaging framework. So why would you choose Brighter & Darker?


### PR DESCRIPTION
**Task 10.2 of spec 010**, plus the structural cleanup. Base is `v9`, not `master`.

## 1. The measured defect: 59 index entries with no discriminator

`/llms.txt` lists **202 entries — 143 ours and 59 from this space — with nothing to tell them apart.** A V10 page's markdown leads with `> **Reference** · Applies to **Brighter V10**`; a V9 page has no banner and never has. The banner does its job on our pages while the index quietly undoes it.

**There is no way to exclude a space from the index** — checked against `llm-ready-docs`, `site-sections`, `seo` and GitBook's own `?ask=` endpoint. Hiding does not help: hidden pages stay in `llms-full.txt` and in the MCP server. **So the discriminator has to travel in the entry itself.**

**58 pages** now carry `Brighter V9 (superseded).` prefixed to their own opening sentence. Three have no prose to summarise and carry the marker alone — two of those previously extracted to the literal word **`TODO`**.

### Two deliberate inversions of the `master` convention

- **The version is prefixed.** Master's descriptions carry no *type* prefix, because there the type is one line below the H1 and a prefix would only degrade the search snippet. **On a V9 page the version is recoverable from nothing.** Same rule, opposite answer, because the facts are opposite.
- **`layout.description.visible` is left at its default**, so the marker **renders as a subtitle** — the only way it reaches a reader who never looks at the index.

Validated with **PyYAML**, not the naive reader that wrote them: all 58 valid, all marked, longest **195** characters.

## 2. The cleanup: SUMMARY and files now map 1:1

**57 entries, 57 files — no missing target, no orphan, no duplicate.** It was 59 published pages from a SUMMARY naming **seven files that do not exist**, while **six real pages were never linked at all**.

**Six of the seven are the entire `## Scheduler` section.** Scheduling is a V10 feature; none of `BrighterSchedulerSupport`, `HangfireScheduler`, `Quartzcheduler` (note the missing `S`), `AwsScheduler`, `AzureScheduler` or `CustomScheduler` has ever existed here — the section was copied from `master`. GitBook published all six as **empty pages**, so six V9 URLs served a title and nothing else, competing in search with the real V10 scheduler docs. **Removed — those six URLs will 404.**

**The seventh was a link to `/contents/`** — the directory, no filename — publishing *"Azure Archive Provider Configuration"* as another empty page. Now points at `AzureBlobConfiguration.md`. **The slug comes from the title, so the published URL does not move**; it simply gains the page it was always meant to show. This one was invisible to the first pass, because a regex looking for a filename after `/contents/` does not match when there is no filename.

**A dead duplicate was occupying the slot the sync handler page needed.** The Brighter request-handler section carried a second copy of the Darker *Basic Configuration* entry, which GitBook never published — a page can only sit at one place in the tree, confirmed against the URL list where `darkerbasicconfiguration` appears exactly once and under *Darker Configuration*. Meanwhile the section listed *"How to Implement an **Async** Request Handler"* and nothing for the synchronous one, while `ImplementingAHandler.md` sat unlinked with the H1 *"How to Implement a Request Handler"*. Replaced with that.

**Four more unlinked files now publish.** *Claim Check*, *Compression* and *S3 Luggage Store* join the request-handler section — transforms are middleware in the mapping pipeline and belong beside *Message Mappers*; *Azure Blob Archive Provider* joins *Guaranteed At Least Once* beside the Outbox pages.

> **This publishes documentation V9 already had and never showed. It does not rewrite anything V9 said.**

## 3. Fixed in passing, because both blocked the front matter

- **`ReturningResultsFromAHandler.md` began with a newline**, so front matter would have landed on line 2 where GitBook does not read it — silently, since the page still renders. The same defect its `master` twin had, which given the shared ancestry is unsurprising.
- **`DarkerBasicConfiguration.md` is a one-line file** containing only its H1.

## 4. Recorded and deliberately not fixed

- **Three inherited duplicate opening sentences** — the async/sync dispatch pair, the pipeline pair, and `AzureBlobConfiguration.md` opening with an Azure *Service Bus* paragraph. The same three `master` carried until this spec corrected them there, which dates them to before the fork. Rewriting them would change what V9 said.
- **One `SUMMARY.md` link is URL-encoded** — `Requests%2C%20Commands%20and%20Events.md`. It resolves and publishes correctly, so changing it would risk a working URL for cosmetics.
- **`.gitbook.yaml` still carries 2 × U+200B**, the vendor bug `master` shed in session 7. It is inert here: `structure:` is not parsed, and the defaults it would have set are the values already in use.

## 5. What cannot be verified before merge

**This branch has no CI, and GitBook built no preview revision for this PR** — it built one for every `master` PR in this session. That is evidence, not proof, about whether the V9 space still syncs from this branch. The change is correct in the repository either way; whether it reaches the published index is only knowable after merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012tcdwxVb8NmKaX2S6fvyFg