### PR TITLE
docs: redirect the one V9 URL that moved, and retype .gitbook.yaml

### DIFF
--- a/.gitbook.yaml
+++ b/.gitbook.yaml
@@ -1,5 +1,8 @@
 root: ./
 
-​structure:  
-    readme: README.md  
-    summary: SUMMARY.md​
+structure:
+  readme: README.md
+  summary: SUMMARY.md
+
+redirects:
+  brighter-configuration/azure-archive-provider-configuration: contents/AzureBlobConfiguration.md


### PR DESCRIPTION
Follow-up to #100, correcting a prediction it made. Base is `v9`.

## The prediction, and what actually happened

#100 said the *Azure Archive Provider Configuration* URL **would not move** when its `SUMMARY.md` entry was repointed from `/contents/` at the real file — the reasoning being that GitBook slugs a page from its SUMMARY title. Measured after the merge:

```
was:  …/v9-…/brighter-configuration/azure-archive-provider-configuration
is:   …/v9-…/brighter-configuration/azureblobconfiguration
```

**The model is the other way round: the slug comes from the FILENAME**, and falls back to the SUMMARY title only when no file exists. That is exactly why the seven fileless entries had title-shaped slugs while all fifty-one real pages had filename-shaped ones — evidence that was in the URL list before the prediction was made.

## One redirect, and only one

`brighter-configuration/azure-archive-provider-configuration` → `contents/AzureBlobConfiguration.md`.

**The six removed scheduler URLs get none, deliberately.** Scheduling does not exist in V9, so nothing in this space is a correct target, and a redirect to an unrelated page is worse than a 404.

## `.gitbook.yaml` retyped, not edited

It still carried the **two U+200B** that `master` shed in session 7, and this change adds a key to it. **Typed from scratch and asserted pure ASCII before writing: 173 bytes, zero non-ASCII.** *Type config; never paste it* — the vendor's own published example is where those characters came from, and it still contains them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012tcdwxVb8NmKaX2S6fvyFg