### PR TITLE
spec: 010 Task 11.7 — the .html links, and the 27 links nobody was checking

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -496,13 +496,23 @@ When unclear about a feature:
 ### Cross-Linking Documentation
 
 **Verifying links:** `python3 tools/linkcheck.py` checks every internal link in
-the published docs. It reports four faults:
+the published docs. It reports five faults:
 
 - **MISSING FILE** — the target does not exist
 - **MISSING ANCHOR** — the file exists, but no heading slugifies to the anchor
 - **WRONG CASE** — the target exists only under different capitalisation. macOS
   and Windows resolve these; GitBook does not, so they 404 once published
+- **LEGACY HTML** — a link to a `.html` path. The published site serves none:
+  every page has an extensionless URL. These are survivals from the pre-GitBook
+  site, and until Spec 010 Phase 11 the checker *skipped* them for not ending
+  in `.md` — so 23 of them, one naming a page that has never existed, were
+  green in every run it had ever made
 - **ORPHAN** — a page under `contents/` that `SUMMARY.md` never links to
+
+**A link's text may wrap across lines**, and the checker reads whole files rather
+than lines so that it sees one when it does. Extracted per line, 27 links in this
+corpus were invisible to it — including that dead one. Report a fault at the line
+carrying the **target**, which is where you fix it, not where the text opens.
 
 Pass file paths to check just those files; orphans are only reported on a
 whole-repo run, since that check needs every page in view. It exits non-zero

--- a/contents/BuildingAPipeline.md
+++ b/contents/BuildingAPipeline.md
@@ -23,12 +23,12 @@ Common examples of orthogonal operations include:
 -   Supporting re-sequencing of messages
 -   Handling exceptions
 -   [Providing Timeout, Retry, and Circuit Breaker
-    support](QualityOfServicePatterns.html)
+    support](/contents/PolicyRetryAndCircuitBreaker.md)
 -   Providing undo support, or rollback
 
 ## The Pipes and Filters Architectural Style
 
-To handle these orthogonal concerns our [command processor](CommandsCommandDispatcherAndProcessor.html#command-processor) uses a pipes and filters architectural style: the filters are where
+To handle these orthogonal concerns our [command processor](/contents/CommandsCommandDispatcherandProcessor.md#the-command-processor-pattern) uses a pipes and filters architectural style: the filters are where
 processing occurs, they do not share state with other filters, nor do they know about adjacent filters. The pipe is the connector between the filters in our case this is provided by the
 **IHandleRequests\<TRequest\>** interface which has a method **IHandleRequests\<TRequest\> Successor** that allows us to chain filters together.
 

--- a/contents/CommandsCommandDispatcherandProcessor.md
+++ b/contents/CommandsCommandDispatcherandProcessor.md
@@ -112,7 +112,7 @@ The central command processor easily allows the addition of services related to 
 processor can queue commands and schedule them at a later time. This is useful if commands should execute at a specified time, if they are handled according to priority, or if they will execute in a separate
 thread of control. An additional example is a single command processor shared by several concurrent applications that provides a transaction control mechanism with logging and rollback of commands.
 
-A Command Processor enforces quality of service and maximizes throughput. A Command Processor forms a juncture at which concerns like: [retry, timeout and circuit breaker](PolicyRetryAndCircuitBreaker.html)
+A Command Processor enforces quality of service and maximizes throughput. A Command Processor forms a juncture at which concerns like: [retry, timeout and circuit breaker](/contents/PolicyRetryAndCircuitBreaker.md)
 can be implemented for all commands.
 
 ![CommandProcesorCapitalize](_static/images/CommandProcesorCapitalize.png)

--- a/contents/EventCarriedStateTransfer.md
+++ b/contents/EventCarriedStateTransfer.md
@@ -120,4 +120,4 @@ Our preference for the two may depend on the extent to which we want to allow Cr
 
 ## Next Steps
 
-See [Correctness in Brighter](BrighterOutboxSupport.html) for guidance on how to use Brighter's support for the Outbox pattern to ensure producer-consumer correctness.
+See [Correctness in Brighter](/contents/BrighterOutboxSupport.md) for guidance on how to use Brighter's support for the Outbox pattern to ensure producer-consumer correctness.

--- a/contents/EventDrivenCollaboration.md
+++ b/contents/EventDrivenCollaboration.md
@@ -107,4 +107,4 @@ So an Event Driven Architecture benefits from a lack of behavioral coupling too.
 
 ## Next Steps
 
-See [Event Carried State Transfer](EventCarriedStateTransfer.html) for guidance on how to \'join\' data between two microservices, when you need data from more than one service to carry out an operation.
+See [Event Carried State Transfer](/contents/EventCarriedStateTransfer.md) for guidance on how to \'join\' data between two microservices, when you need data from more than one service to carry out an operation.

--- a/contents/FeatureSwitches.md
+++ b/contents/FeatureSwitches.md
@@ -20,7 +20,7 @@ By adding the **FeatureSwitch** Attribute or **FeatureSwitchAsync** Attribute, y
 -   not execute the handler, this is **FeatureSwitchStatus.Off**.
 -   detemine whether to run the handler based on a **Feature Switch
     Registry**, [creating of which is described
-    later](FeatureSwitches.html#building-a-config-for-feature-switches-with-fluentconfigregistrybuilder).
+    later](/contents/FeatureSwitches.md#building-a-config-for-feature-switches-with-fluentconfigregistrybuilder).
 
 In the following example, **MyFeatureSwitchedHandler** will only be run if it has been configured in the **Feature Switch Registry** and set to **FeatureSwitchStatus.On**.
 

--- a/contents/HowConfiguringTheCommandProcessorWorks.md
+++ b/contents/HowConfiguringTheCommandProcessorWorks.md
@@ -91,7 +91,7 @@ internal class HandlerFactory : IAmAHandlerFactory
 
 ## Policy Registry and Resilience Pipelines
 
-If you intend to use [Polly](https://github.com/App-vNext/Polly) to support [Retry and Circuit-Breaker](PolicyRetryAndCircuitBreaker.html) then you will need to register your policies or resilience pipelines.
+If you intend to use [Polly](https://github.com/App-vNext/Polly) to support [Retry and Circuit-Breaker](/contents/PolicyRetryAndCircuitBreaker.md) then you will need to register your policies or resilience pipelines.
 
 ### Resilience Pipeline Registry (Recommended)
 
@@ -157,7 +157,7 @@ public override TaskReminderCommand Handle(TaskReminderCommand command)
 
 > **⚠️ DEPRECATED**: The following approach uses Polly v7 policies, which are deprecated in favor of Polly v8 resilience pipelines.
 
-If you intend to use a [Polly](https://github.com/App-vNext/Polly) Policy to support [Retry and Circuit-Breaker](PolicyRetryAndCircuitBreaker.html) then you will need to register the Policies in the **Policy Registry**.
+If you intend to use a [Polly](https://github.com/App-vNext/Polly) Policy to support [Retry and Circuit-Breaker](/contents/PolicyRetryAndCircuitBreaker.md) then you will need to register the Policies in the **Policy Registry**.
 
 This is just the Polly **PolicyRegistry**.
 
@@ -224,7 +224,7 @@ public override TaskReminderCommand Handle(TaskReminderCommand command)
 
 ## Request Context Factory
 
-You need to provide a factory to give us instances of a [Context](UsingTheContextBag.html). If you have no implementation to use, just use the default **InMemoryRequestContextFactory**. Typically you would replace ours if you wanted to support initializing the context outside of our pipeline, for tracing for example.
+You need to provide a factory to give us instances of a [Context](/contents/UsingTheContextBag.md). If you have no implementation to use, just use the default **InMemoryRequestContextFactory**. Typically you would replace ours if you wanted to support initializing the context outside of our pipeline, for tracing for example.
 
 ## Command Processor Builder
 

--- a/contents/Microservices.md
+++ b/contents/Microservices.md
@@ -53,4 +53,4 @@ For our microservices to communicate we need to agree on the protocols we will u
 
 ## Next Steps
 
-See [Event Driven Collaboration](EventDrivenCollaboration.html) for guidance on how to integrate microservices using events.
+See [Event Driven Collaboration](/contents/EventDrivenCollaboration.md) for guidance on how to integrate microservices using events.

--- a/contents/OutboxPattern.md
+++ b/contents/OutboxPattern.md
@@ -51,4 +51,4 @@ It is possible that the write to the row to update the dispatched status will fa
 
 For this reason, the Outbox pattern offers us **guaranteed, at least once** delivery. Consumers must be prepared for this. Either they can use an *Inbox*, which records all the messages they have seen recently and discards duplicates, or they must be idempotent and the result of processing the message twice has no side-affects.
 
-See [Brighter Outbox Support](BrighterOutboxSupport.html) for more on how to ensure Producer-Consumer correctness in Brighter.
+See [Brighter Outbox Support](/contents/BrighterOutboxSupport.md) for more on how to ensure Producer-Consumer correctness in Brighter.

--- a/contents/PolicyFallback.md
+++ b/contents/PolicyFallback.md
@@ -15,17 +15,17 @@ To support this we provide a **IHandleRequests\<TRequest\>Fallback** method. In 
 
 ## Calling the Fallback Pipeline
 
-We provide a **FallbackPolicy** Attribute that you can use on your **IHandleRequests\<TRequest\>.Handle()** method. The implementation of the **Fallback Policy Handler** is straightforward: it creates a backstop exception handler by encompassing later requests in the [Request Handling Pipeline](BuildingAPipeline.html) in a try\...catch block. You can configure it to catch all exceptions, or just [Broken Circuit Exceptions](PolicyRetryAndCircuitBreaker.html) when a Circuit Breaker has tripped.
+We provide a **FallbackPolicy** Attribute that you can use on your **IHandleRequests\<TRequest\>.Handle()** method. The implementation of the **Fallback Policy Handler** is straightforward: it creates a backstop exception handler by encompassing later requests in the [Request Handling Pipeline](/contents/BuildingAPipeline.md) in a try\...catch block. You can configure it to catch all exceptions, or just [Broken Circuit Exceptions](/contents/PolicyRetryAndCircuitBreaker.md) when a Circuit Breaker has tripped.
 
 When the **Fallback Policy Handler** catches an exception it calls the **IHandleRequests\<TRequest\>.Fallback()** method of the next Handler in the pipeline, as determined by **IHandleRequests\<TRequest\>.Successor**
 
-The implementation of **RequestHandler\<T\>.Fallback()** uses the same [Russian Doll](BuildingAPipeline.html) approach as it uses for **RequestHandler\<T\>.Handle()**. This means that the request to take compensating action for failure, flows through the same pipeline as the request for service, allowing each Handler in the chain to contribute.
+The implementation of **RequestHandler\<T\>.Fallback()** uses the same [Russian Doll](/contents/BuildingAPipeline.md) approach as it uses for **RequestHandler\<T\>.Handle()**. This means that the request to take compensating action for failure, flows through the same pipeline as the request for service, allowing each Handler in the chain to contribute.
 
 In addition the **Fallback Policy Handler** makes the originating exception available to subsequent Handlers using the **Context Bag** with the key: **CAUSE_OF_FALLBACK_EXCEPTION**
 
 ## Using the FallbackPolicy Attribute
 
-The following example shows a Handler with **Request Handler Attributes** for [Retry and Circuit Breaker policies](PolicyRetryAndCircuitBreaker.html) that is configured with a **Fallback Policy** which catches a **Broken Circuit Exception** (raised when the Circuit Breaker is tripped) and initiates the Fallback chain.
+The following example shows a Handler with **Request Handler Attributes** for [Retry and Circuit Breaker policies](/contents/PolicyRetryAndCircuitBreaker.md) that is configured with a **Fallback Policy** which catches a **Broken Circuit Exception** (raised when the Circuit Breaker is tripped) and initiates the Fallback chain.
 
 ### Example with Resilience Pipelines (V10)
 

--- a/contents/PolicyRetryAndCircuitBreaker.md
+++ b/contents/PolicyRetryAndCircuitBreaker.md
@@ -9,13 +9,13 @@ layout:
 
 > **How-to** · Applies to **Brighter V10**
 
-Brighter is a [Command Processor](https://www.goparamore.io/control-bus-and-data-bus/) and supports a [pipeline of Handlers to handle orthogonal requests](BuildingAPipeline.html).
+Brighter is a [Command Processor](https://www.goparamore.io/control-bus-and-data-bus/) and supports a [pipeline of Handlers to handle orthogonal requests](/contents/BuildingAPipeline.md).
 
-Amongst the valuable uses of orthogonal requests is patterns to support Quality of Service in a distributed environment: [Timeout, Retry, and Circuit Breaker](PolicyRetryAndCircuitBreaker.html#using-brighters-useresiliencepipeline-attribute).
+Amongst the valuable uses of orthogonal requests is patterns to support Quality of Service in a distributed environment: [Timeout, Retry, and Circuit Breaker](/contents/PolicyRetryAndCircuitBreaker.md#using-brighters-useresiliencepipeline-attribute).
 
 Even if you don't believe that you are writing a distributed system that needs this protection, consider that as soon as you have multiple processes, such as a database server, you are distributed.
 
-Brighter uses [Polly](https://github.com/App-vNext/Polly) to support Retry and Circuit-Breaker. Through our [Russian Doll Model](BuildingAPipeline.html) we are able to run the target handler in the context of a Policy Handler, that catches exceptions, and applies a Policy on how to deal with them.
+Brighter uses [Polly](https://github.com/App-vNext/Polly) to support Retry and Circuit-Breaker. Through our [Russian Doll Model](/contents/BuildingAPipeline.md) we are able to run the target handler in the context of a Policy Handler, that catches exceptions, and applies a Policy on how to deal with them.
 
 ## Polly v8 Resilience Pipelines
 

--- a/contents/Requests, Commands and Events.md
+++ b/contents/Requests, Commands and Events.md
@@ -30,7 +30,7 @@ not, then we have a failure condition (and I am thirsty and cranky). If I say \"
 
 So choosing between **Command** or **Event** effects how the **Command Dispatcher** routes requests.
 
-See [Dispatching a Request](DispatchingARequest.html) for more on how to dispatch **Requests** to handlers.
+See [Dispatching a Request](/contents/DispatchingARequest.md) for more on how to dispatch **Requests** to handlers.
 
 ## Message Definitions and Independent Deployability
 

--- a/contents/ReturningResultsFromAHandler.md
+++ b/contents/ReturningResultsFromAHandler.md
@@ -22,10 +22,10 @@ This in turn leads to a set of questions that we need to answer about common sce
 If we don\'t allow return values, what do you do on failure?
 
 -   The basic failure strategy is to throw an exception. This will terminate the request handling pipeline.
--   If you want *Internal Bus* support for [Retry, and Circuit Breaker](PolicyRetryAndCircuitBreaker.html) you can use our support for [Polly](https://github.com/App-vNext/Polly) Policies
+-   If you want *Internal Bus* support for [Retry, and Circuit Breaker](/contents/PolicyRetryAndCircuitBreaker.md) you can use our support for [Polly](https://github.com/App-vNext/Polly) Policies
 -   If you want to Requeue (with Delay) to an *External Bus*, you should throw a **DeferMessageAction** exception.
--   Finally you can use our support for a [Fallback](PolicyFallback.html) handler to provide backstop exception handling.
--   You can also build your own exception handling into your [Pipeline](BuildingAPipeline.html).
+-   Finally you can use our support for a [Fallback](/contents/PolicyFallback.md) handler to provide backstop exception handling.
+-   You can also build your own exception handling into your [Pipeline](/contents/BuildingAPipeline.md).
 
 We discuss these options in more detail in [Handler Failure](/contents/HandlerFailure.md).
 

--- a/contents/UsingTheContextBag.md
+++ b/contents/UsingTheContextBag.md
@@ -40,7 +40,7 @@ public class MyContextAwareCommandHandler : RequestHandler<MyCommand>
 }
 ```
 
-Internally we use the **Context Bag** in a number of the Quality of Service supporting Attributes we provide. See [Fallback](PolicyFallback.html) for example.
+Internally we use the **Context Bag** in a number of the Quality of Service supporting Attributes we provide. See [Fallback](/contents/PolicyFallback.md) for example.
 
 ## Request Context Capabilities
 

--- a/spec/010-information_architecture/tasks.md
+++ b/spec/010-information_architecture/tasks.md
@@ -2913,7 +2913,7 @@ are in a spec about enforcement at all.
     records it. Keep the section's *purpose* — a reader needs to know where the index comes
     from and what governs a page's line in it — and drop the generator that was never built.
 
-- [ ] **Task 11.7:** The 23 internal `.html` links, and the two blind spots that hid them
+- [x] **Task 11.7:** The 23 internal `.html` links, and the two blind spots that hid them
   - Input: the 23 links across 13 pages, 11 targets, measured at `3178d68`
   - Output: every internal link resolves as `.md`; `linkcheck.py` reports an internal `.html`
     link rather than skipping it
@@ -2922,9 +2922,83 @@ are in a spec about enforcement at all.
     including **`QualityOfServicePatterns.html`, which has no page at all**. The rewrite is
     **not mechanical**: the file is `CommandsCommandDispatcher`***a***`ndProcessor.md`, so
     the obvious conversion lands on **WRONG CASE**, the fault class the checker exists for,
-    hidden behind an extension it does not read. And some anchors never existed —
-    `#command-processor` is really `#the-command-processor-pattern`. **Check every anchor
-    against the target's headings; do not carry the fragment across.**
+    hidden behind an extension it does not read. And some anchors have gone stale —
+    `#command-processor` is now `#the-command-processor-pattern`. **Check every anchor
+    against the target's headings; do not carry the fragment across.** *(As written, this
+    task said that anchor "never existed". It existed from 2022 until `0b1b841` renamed the
+    heading sixteen days ago — see the execution note below.)*
+  - **Done 2026-08-22.** All 23 rewritten, `linkcheck.py` clean at 144 files, and the rule
+    that would have caught them is now in the tool. See *Task 11.7 as executed*, below.
+
+### Task 11.7 as executed — 2026-08-22
+
+**The rule was red on an untouched tree before a link moved**, which is the one red-proof
+this programme never has to manufacture: `LEGACY HTML (23)`, exit 1, on `3178d68` plus the
+rule. No mutation, no probe, nothing to assert had landed — the corpus was the fixture.
+
+**There were two blind spots, and only one of them was known.** The recorded one is that
+`linkcheck.py` resolves `.md` and skips every other extension, so a `.html` link was not
+merely unchecked but **reported as fine**. The second was found while re-deriving the
+count:
+
+> **`linkcheck.py` extracted links a line at a time, and this corpus hard-wraps its prose.**
+> **27 links were invisible to it** — 21 internal `.md` links and a same-page anchor, four
+> external, and **two of the `.html` ones**. So the blind spots overlapped: the grep Phase 10
+> counted with was per-line too, which is why *"29, twelve targets"* and the truth agree on
+> the total and not on the pages. **Every one of the 21 internal links resolves today**,
+> checked one by one before the extractor changed, so nothing was hiding behind it — but
+> `linkcheck.py` has been reporting *"144 files checked"* while never reading 27 of the links
+> in them. **A checker's coverage is a measurement, not a property of having run it.**
+
+Extraction is now whole-file with `re.DOTALL`. The label cannot cross a `]` and the target
+cannot cross a newline, so neither a stray bracket in prose nor an unclosed `](` can swallow
+what follows. **Spaces stay legal inside a target**, because one page in this corpus is
+`Requests, Commands and Events.md` and `SUMMARY.md` links it by that name — tightening the
+pattern to `[^)\s]+` would have made that page an ORPHAN, a false positive manufactured by a
+fix for a false negative. A fault is reported at the line carrying the **target**, not the
+line the text opens on, because that is the line you edit.
+
+**Nineteen of the 23 were conversion; two were judgement; two more were the trap.**
+
+| Link | Ruling |
+|---|---|
+| `BuildingAPipeline.md:26` → `QualityOfServicePatterns.html` | **No such page, ever.** Text reads *"Providing Timeout, Retry, and Circuit Breaker support"* → `/contents/PolicyRetryAndCircuitBreaker.md`, whose own line 14 calls those three *"patterns to support Quality of Service"* — the page absorbed the title |
+| `BuildingAPipeline.md:31` → `…AndProcessor.html#command-processor` | Both halves wrong. File is `CommandsCommandDispatcher`***a***`ndProcessor.md`; the heading is `## The Command Processor Pattern`, so the anchor is `#the-command-processor-pattern` |
+
+> **The inherited reason for that second one was wrong, and checking it took one command.**
+> Phase 10 recorded — and `PROMPT.md` repeated — that `#command-processor` *"never existed"*.
+> It existed for four years. `## Command Processor` was written into that page by `21a08e8`
+> on **2022-03-15** and requalified to `## The Command Processor Pattern` by **`0b1b841`**,
+> Spec 011's own cross-page heading pass, on 2026-08-04. `git log -p --follow` over the
+> file's heading lines shows both spellings and the moment one replaced the other.
+>
+> **So the link was correct when it was written, and this programme broke it** — sixteen days
+> ago, in the commit that qualified 260 headings, and behind an extension that made it
+> invisible to the checker which would otherwise have said so immediately. It is Phase 9's
+> naming trap again (`Use Cases` and `Limitations` were pre-qualification titles too), with
+> the roles reversed: there the *plan* was stale against the corpus, here the *corpus* went
+> stale against a link. **The remedy is unchanged and the diagnosis is not** — *"a dead anchor
+> nobody ever had"* invites you to delete the fragment; *"an anchor we renamed"* tells you to
+> repoint it, which is what a reader of that sentence still needs.
+
+The other two are `FeatureSwitches.md:23` and `PolicyRetryAndCircuitBreaker.md:14`, both
+**self-links** carrying anchors — the shape most likely to be waved through, since a page
+linking itself looks harmless. Both anchors were checked against their own page's headings
+and both resolve.
+
+**`html_advice()` resolves the counterpart rather than swapping the extension**, and the
+case above is why. A rule that reported a fault and then advised a second one would be worse
+than no rule: the obvious rewrite of that link lands on `WRONG CASE`, the exact fault class
+this tool exists for. It also **refuses to carry the anchor across**, saying *re-derive it*
+instead — these links predate the headings they point into, and an anchor that survives a
+rewrite is an anchor nobody checked.
+
+**Gates after:** linkcheck **144 files, clean**; pagelint 0 errors / **791** warnings / 142
+pages; `--check-shape` 0; `--check-redirects` 0 at 77 entries; `--changed origin/master` 0,
+reporting **14 files, 33 hunks, 13 pages, 0 code blocks strict** — Task 11.3's report earning
+its place immediately, since a prose-only PR of this size is exactly the run that used to be
+indistinguishable from a real one. **No URL moves and no redirect is owed**: every rewrite
+changes a link's *target*, not any page's path.
 
 - [ ] **Task 11.8:** `BuildingAnAsyncPipeline.md` has two H1s
   - Input: the page, lines 1 and 8

--- a/tools/linkcheck.py
+++ b/tools/linkcheck.py
@@ -1,12 +1,19 @@
 #!/usr/bin/env python3
 """Check internal markdown links across the documentation.
 
-Reports four kinds of breakage:
+Reports five kinds of breakage:
 
   MISSING FILE    the link target file does not exist
   MISSING ANCHOR  the file exists, but no heading in it slugifies to the anchor
   WRONG CASE      the target exists only under different capitalisation
+  LEGACY HTML     a link to a `.html` path, which the published site never serves
   ORPHAN          a published page nothing in SUMMARY.md links to
+
+LEGACY HTML is the fault class this tool used to *create*. Only `.md` targets
+were resolved and everything else was skipped, so links left over from the
+pre-GitBook site were not merely unchecked but reported as fine -- one of them
+naming a page that has never existed. An extension is not a reason to skip a
+link; it is the reason to look at it.
 
 WRONG CASE matters because macOS and Windows resolve paths case-insensitively
 while GitBook and GitHub do not. A link that works on the machine that wrote it
@@ -48,8 +55,23 @@ SKIP_FILES = {'CLAUDE.md', 'PROMPT.md'}
 
 TOC = 'SUMMARY.md'
 
-LINK_RE = re.compile(r'\[([^\]]*)\]\(([^)]+)\)')
+# DOTALL, because a link's *text* may wrap across lines and this corpus hard-wraps
+# its prose. Extracted per line, 27 links in the corpus were invisible to this
+# tool — including one dead link and the only two `.html` links a grep for
+# `](...html` on a single line also missed. The label cannot cross a `]`, so a
+# stray bracket in prose still cannot swallow the paragraph after it, and the
+# target cannot cross a newline, so an unclosed `](` cannot swallow the rest of
+# the file. Spaces stay legal inside a target: one page in this corpus is called
+# `Requests, Commands and Events.md`, and SUMMARY.md links it by that name.
+LINK_RE = re.compile(r'\[([^\]]*)\]\(([^)\n]+)\)', re.S)
 HEADING_RE = re.compile(r'^(#{1,6})\s+(.*?)\s*#*$', re.M)
+
+# The published site serves no `.html` path: GitBook renders every page at an
+# extensionless URL. Links carrying the extension are survivals from the
+# pre-GitBook site, and they are worse than an ordinary broken link, because
+# `.md` is the only extension resolved below -- so they have been skipped, and
+# have been green, in every run this checker has ever made.
+HTML_RE = re.compile(r'\.html$', re.I)
 
 
 def slug(text):
@@ -132,6 +154,33 @@ def orphans():
     return sorted(out)
 
 
+def html_advice(target, on_disk):
+    """What to replace a `.html` link with, resolved rather than guessed.
+
+    The obvious rewrite is the target with its extension swapped, and for one
+    of the targets in this corpus that lands on WRONG CASE:
+    `CommandsCommandDispatcherAndProcessor.html` against a file spelled
+    `...DispatcherandProcessor.md`. Reporting a fault and then advising a second
+    fault would be worse than saying nothing, so the counterpart is looked up by
+    its lowercased path and quoted in the spelling that is on disk.
+
+    The anchor is deliberately *not* carried across. These links predate the
+    headings they point into -- `#command-processor` names a section now called
+    "The Command Processor Pattern" -- so an anchor that survives the rewrite is
+    an anchor nobody checked. Once the link ends in `.md` the anchor rules apply
+    to it, which is the point of converting them.
+    """
+    base = target.split('#')[0]
+    counterpart = on_disk.get(os.path.join('contents', base[:-5] + '.md').lower())
+    if not counterpart:
+        return (f'no page serves {base}; the published site has no .html paths, '
+                'so this link is dead and has never been checked')
+    advice = f'the published site has no .html paths; link /{counterpart}'
+    if '#' in target:
+        advice += ' and re-derive the anchor against that page\'s headings'
+    return advice
+
+
 def check(paths):
     anchor_cache = {}
     on_disk = real_paths()
@@ -140,41 +189,50 @@ def check(paths):
         with open(src, encoding='utf-8') as fh:
             content = fh.read()
         rel_src = os.path.relpath(src, ROOT)
-        for lineno, line in enumerate(content.splitlines(), 1):
-            for label, raw in LINK_RE.findall(line):
-                target = unquote(raw.strip())
-                if target.startswith(('http://', 'https://', 'mailto:')):
+        for match in LINK_RE.finditer(content):
+            label, raw = match.group(1), match.group(2)
+            # The line the *target* sits on, not the line the text opens on:
+            # a wrapped link is fixed where its URL is.
+            lineno = content.count('\n', 0, match.start(2)) + 1
+            label = ' '.join(label.split())
+            target = unquote(raw.strip())
+            if target.startswith(('http://', 'https://', 'mailto:')):
+                continue
+            if HTML_RE.search(target.split('#')[0]):
+                problems.append(
+                    ('LEGACY HTML', rel_src, lineno, raw,
+                     html_advice(target, on_disk)))
+                continue
+            if target.startswith('#'):
+                path, anchor = src, target[1:]
+            else:
+                path, _, anchor = target.partition('#')
+                if not path:
                     continue
-                if target.startswith('#'):
-                    path, anchor = src, target[1:]
+                if path.startswith('/'):
+                    path = os.path.join(ROOT, path.lstrip('/'))
                 else:
-                    path, _, anchor = target.partition('#')
-                    if not path:
-                        continue
-                    if path.startswith('/'):
-                        path = os.path.join(ROOT, path.lstrip('/'))
-                    else:
-                        path = os.path.normpath(
-                            os.path.join(os.path.dirname(src), path))
-                if not path.endswith('.md'):
-                    continue
-                if not os.path.isfile(path):
-                    problems.append(('MISSING FILE', rel_src, lineno, raw, label))
-                    continue
-                # isfile() is case-insensitive on macOS/Windows, so a link that
-                # resolves here can still 404 on GitBook. Compare spellings.
-                rel_target = os.path.relpath(path, ROOT)
-                actual = on_disk.get(rel_target.lower())
-                if actual and actual != rel_target:
+                    path = os.path.normpath(
+                        os.path.join(os.path.dirname(src), path))
+            if not path.endswith('.md'):
+                continue
+            if not os.path.isfile(path):
+                problems.append(('MISSING FILE', rel_src, lineno, raw, label))
+                continue
+            # isfile() is case-insensitive on macOS/Windows, so a link that
+            # resolves here can still 404 on GitBook. Compare spellings.
+            rel_target = os.path.relpath(path, ROOT)
+            actual = on_disk.get(rel_target.lower())
+            if actual and actual != rel_target:
+                problems.append(
+                    ('WRONG CASE', rel_src, lineno, raw, f'file is {actual}'))
+                continue
+            if anchor:
+                if path not in anchor_cache:
+                    anchor_cache[path] = anchors_for(path)
+                if anchor.lower() not in anchor_cache[path]:
                     problems.append(
-                        ('WRONG CASE', rel_src, lineno, raw, f'file is {actual}'))
-                    continue
-                if anchor:
-                    if path not in anchor_cache:
-                        anchor_cache[path] = anchors_for(path)
-                    if anchor.lower() not in anchor_cache[path]:
-                        problems.append(
-                            ('MISSING ANCHOR', rel_src, lineno, raw, label))
+                        ('MISSING ANCHOR', rel_src, lineno, raw, label))
     return problems
 
 
@@ -197,13 +255,18 @@ def main(argv):
         print(f"No broken internal links ({len(paths)} files checked).")
         return 0
 
-    for kind in ('MISSING FILE', 'WRONG CASE', 'MISSING ANCHOR'):
+    for kind in ('MISSING FILE', 'WRONG CASE', 'MISSING ANCHOR', 'LEGACY HTML'):
         rows = [p for p in problems if p[0] == kind]
         if not rows:
             continue
         print(f"\n===== {kind} ({len(rows)}) =====")
         for _, src, lineno, target, label in rows:
-            print(f"{src}:{lineno}  [{label}]({target})")
+            # LEGACY HTML's fifth field is advice on what to write instead, not
+            # the link's text, so it goes after the link rather than inside it.
+            if kind == 'LEGACY HTML':
+                print(f"{src}:{lineno}  ({target})\n    {label}")
+            else:
+                print(f"{src}:{lineno}  [{label}]({target})")
 
     if stranded:
         print(f"\n===== ORPHAN ({len(stranded)}) =====")


### PR DESCRIPTION
**Spec 010, Phase 11, Task 11.7.** 13 published pages change; **no URL moves and no redirect is owed** — every edit changes a link's target, not any page's path.

### The rule was red before a link moved

`LEGACY HTML (23)`, exit 1, on an untouched tree. No mutation, no probe, nothing to assert had landed: the corpus was the fixture.

### Two blind spots, and only one was known

**Known:** `linkcheck.py` resolves `.md` and skips every other extension, so a `.html` link was not merely unchecked but *reported as fine*. One of them, `QualityOfServicePatterns.html`, names a page that has never existed — a dead link green in every CI run this repo has ever done.

**Found while re-deriving the count:** links were extracted **a line at a time**, and this corpus hard-wraps its prose. **27 links were invisible to the checker** — 21 internal `.md` links plus a same-page anchor, four external, and *two of the `.html` ones*. The blind spots overlapped: Phase 10's grep was per-line too, which is why its *"29, twelve targets"* agrees with the truth on the total and not on the pages.

Every one of the 21 internal links resolves today — checked individually before the extractor changed, so nothing was hiding behind it. But the tool has been printing *"144 files checked"* while never reading 27 of the links in them. **A checker's coverage is a measurement, not a property of having run it.**

Extraction is now whole-file. The label cannot cross a `]` and the target cannot cross a newline. **Spaces stay legal inside a target**, because one page here is `Requests, Commands and Events.md` and `SUMMARY.md` links it by that name — tightening the pattern to `[^)\s]+` would have made that page an ORPHAN, a false positive manufactured by a fix for a false negative.

### Two judgements

| Link | Ruling |
|---|---|
| `BuildingAPipeline.md:26` → `QualityOfServicePatterns.html` | No such page. Text reads *"Providing Timeout, Retry, and Circuit Breaker support"* → `/contents/PolicyRetryAndCircuitBreaker.md`, whose own line 14 calls those three *"patterns to support Quality of Service"* — the page absorbed the title |
| `BuildingAPipeline.md:31` → `…AndProcessor.html#command-processor` | File is `CommandsCommandDispatcher`***a***`ndProcessor.md`; heading is `## The Command Processor Pattern` |

`html_advice()` resolves the counterpart rather than swapping the extension, and that second row is why: the obvious rewrite lands on **WRONG CASE**, the fault class this tool exists for. It also refuses to carry an anchor across, saying *re-derive it* instead.

### The inherited reason for that anchor was wrong

Phase 10 recorded, and `PROMPT.md` repeated, that `#command-processor` **"never existed"**. It existed for four years: `## Command Processor` was written by `21a08e8` on 2022-03-15 and requalified to `## The Command Processor Pattern` by **`0b1b841`** — spec 011's own cross-page heading pass — on 2026-08-04.

**So the link was correct when written, and this programme broke it sixteen days ago**, behind an extension that made it invisible to the checker that would otherwise have said so at once. The remedy is unchanged; the diagnosis is not. *"An anchor nobody ever had"* invites you to delete the fragment. *"An anchor we renamed"* tells you to repoint it.

### Gates

linkcheck **144 files, clean**; pagelint **0 errors / 791 warnings / 142 pages**; `--check-shape` **0**; `--check-redirects` **0** at 77 entries; `--changed origin/master` **0**, reporting *14 files, 33 hunks, 13 pages, 0 code blocks strict* — Task 11.3's report earning its keep on the very next PR.

`CLAUDE.md` documents the fault classes, so it moves in the same commit: four become five, plus the wrapped-link rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)