### PR TITLE
spec: 010 Task 11.1 — the glossary links, and the nine terms that had no entry

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -496,7 +496,7 @@ When unclear about a feature:
 ### Cross-Linking Documentation
 
 **Verifying links:** `python3 tools/linkcheck.py` checks every internal link in
-the published docs. It reports five faults:
+the published docs. It reports six faults:
 
 - **MISSING FILE** — the target does not exist
 - **MISSING ANCHOR** — the file exists, but no heading slugifies to the anchor
@@ -507,6 +507,9 @@ the published docs. It reports five faults:
   site, and until Spec 010 Phase 11 the checker *skipped* them for not ending
   in `.md` — so 23 of them, one naming a page that has never existed, were
   green in every run it had ever made
+- **EMPTY TARGET** — a link written `[text](#)`, which goes nowhere. It reaches
+  a reader as a live link and reached the checker as a same-page link with no
+  anchor to look up
 - **ORPHAN** — a page under `contents/` that `SUMMARY.md` never links to
 
 **A link's text may wrap across lines**, and the checker reads whole files rather

--- a/contents/BasicConcepts.md
+++ b/contents/BasicConcepts.md
@@ -15,9 +15,13 @@ A command is an instruction to carry out work. It exercises the domain and resul
 
 An [event](#event) may be used to indicate the outcome of a command.
 
+*Glossary: [Command](/contents/Glossary.md#command)*
+
 ## Dead Letter Queue (DLQ)
 
 A queue where messages that cannot be processed are sent for later investigation. When Brighter rejects a message (via `RejectMessageAction` or after exceeding the requeue count), and a DLQ is configured on the subscription, the message is routed there instead of being discarded. Some transports (RabbitMQ, Azure Service Bus) provide native DLQ support; for others, Brighter manages the DLQ by producing the rejected message to a separate channel.
+
+*Glossary: [Dead Letter Queue (DLQ)](/contents/Glossary.md#dead-letter-queue-dlq)*
 
 ## Command Processor
 
@@ -25,9 +29,13 @@ In Brighter, a command processor allows you to use the *Command Pattern* to sepa
 
 The Command Processor may dispatch to an [Internal Bus](#internal-bus) or an [External Bus](#external-bus).
 
+*Glossary: [Command Processor](/contents/Glossary.md#command-processor)*
+
 ## Command-Query Separation (CQS)
 
 Command-Query separation is the principle that because a [query](#query) should never have the unexpected *side-effect* of updating state, a query should clearly be distinguished from a [command](#request). A query reports on the state of a domain, a command changes it. 
+
+*Glossary: [Command-Query Separation (CQS)](/contents/Glossary.md#command-query-separation-cqs)*
 
 ## Event
 
@@ -35,11 +43,15 @@ An event is a fact. The domain may be updated to reflect the fact represented by
 
 An event may be used to indicate the outcome of a [command](#command).
 
+*Glossary: [Event](/contents/Glossary.md#event)*
+
 ## Event Stream
 
 In [message oriented middleware](#message-oriented-middleware-mom), an event stream delivers [messages](#message) (or records) via a stream. A consumer reads the stream at a specific offset from the start. Consumers can store their offsets to resume reading the stream for where they left off, or reset their offset to re-read a stream. Consumers neither lock, nor delete messages from the stream. For consuming apps to scale, the stream can be partitioned, allowing offsets to be maintained of a partition of the stream. By using separate consumer threads or processes to read a partition, an application can ensure that it is able to reduce the latency of reading the stream.
 
 Examples: Kafka, Kinesis, Redis Streams
+
+*Glossary: [Event Stream](/contents/Glossary.md#event-stream)*
 
 ## External Bus 
 
@@ -47,13 +59,19 @@ An external bus allows a [command](#command) or [event](#event) to be turned int
 
 Brighter also offers a [service activator](#service-activator) to listen for messages published to a queue or stream and forward them to an [internal bus](#internal-bus) within another process.
 
+*Glossary: [External Bus](/contents/Glossary.md#external-bus)*
+
 ## Internal Bus 
 
-A [command](#command), [event](#event) or [query](#query) is executed in-process, passed from the [command processor](#command-processor) or [query processor](#) to a [handler](#request-handler) [pipeline](#pipeline).
+A [command](#command), [event](#event) or [query](#query) is executed in-process, passed from the [command processor](#command-processor) or [query processor](#query-processor) to a [handler](#request-handler) [pipeline](#pipeline).
+
+*Glossary: [Internal Bus](/contents/Glossary.md#internal-bus)*
 
 ## Message
 
 A message is a packet of data sent over message-oriented-middleware. It's on-the-wire representation is defined by the protocol used by [message-oriented-middleware](#message-oriented-middleware-mom).
+
+*Glossary: [Message](/contents/Glossary.md#message)*
 
 ## Message Oriented Middleware (MoM)
 
@@ -63,11 +81,15 @@ Brighter abstracts a specific type of message-oriented middleware by a *Transpor
 
 For simplicity, Brighter only supports transports that have a broker configuration, not point-to-point. If you need point-to-point semantics, configure your routing table entry so that it only delivers to one consuming queue or stream.
 
+*Glossary: [Message Oriented Middleware (MoM)](/contents/Glossary.md#message-oriented-middleware-mom)*
+
 ## Message Mappers
 
 A message mapper turns domain code into a message: a header and a body, or turns a message into domain code. Because [message oriented middleware](#message-oriented-middleware-mom) typically looks in a header for routing information, it is also where you add routing information via the header.
 
 Each individual transport has code to turn a Brighter format message into a message oriented middleware compatible message, and vice versa, so your code only needs to translate to and from the Brighter format.
+
+*Glossary: [Message Mapper](/contents/Glossary.md#message-mapper)*
 
 ## Message Queue
 
@@ -75,9 +97,13 @@ In [message oriented middleware](#message-oriented-middleware-mom), a message qu
 
 Examples: SQS, AMQP 0-9-1 (Rabbit MQ), AMQP 1-0 (Azure Service Bus).
 
+*Glossary: [Message Queue](/contents/Glossary.md#message-queue)*
+
 ## Nack (Negative Acknowledgment)
 
 A signal to the transport that a message was not successfully processed. The transport's behavior on nack varies: RabbitMQ requeues the message, SQS resets its visibility timeout, Azure Service Bus releases the lock, and stream-based transports like Kafka simply do not commit the offset. In Brighter, throwing `DontAckAction` from a handler triggers a nack.
+
+*Glossary: [Nack (Negative Acknowledgment)](/contents/Glossary.md#nack-negative-acknowledgment)*
 
 ## Pipeline
 
@@ -85,19 +111,27 @@ A pipeline is a sequence of [handlers](#request-handler) that respond to a [requ
 
 Brighter and Darker's pipelines use a "Russian Doll Model" that is, each handler in the pipeline encompasses the call to the next handler, allowing the handler chain to behave like a call stack. 
 
+*Glossary: [Pipeline](/contents/Glossary.md#pipeline)*
+
 ## Poison Message
 
 A message that repeatedly fails processing. Without safeguards, a poison message blocks the message pump in an infinite failure-requeue-failure loop. Brighter prevents this with `RequeueCount`, which limits the number of requeue attempts before the message is rejected. The default behavior — acknowledging on failure — also prevents poison messages by ensuring the pump always moves on.
 
+*Glossary: [Poison Message](/contents/Glossary.md#poison-message)*
+
 ## Query
 
 A query asks the domain for facts. The [result](#result) of the query reports these facts - the state of the domain. A query does not change the state of the domain, for that use a [request](#request).
+
+*Glossary: [Query](/contents/Glossary.md#query)*
 
 ## Query Handler
 
 A handler is the entry point to domain code. It receives a query and returns a [result](#result) to the caller. A handler is always part of an [internal bus](#internal-bus). As such a handler forms part of a [pipeline](#pipeline).
 
 It is analogous to a method on an ASP.NET Controller.
+
+*Glossary: [Query Handler](/contents/Glossary.md#query-handler)*
 
 ## Query Processor
 
@@ -107,19 +141,27 @@ The Query Processor dispatches to an [Internal Bus](#internal-bus).
 
 The Query Processor returns a [result](#result).
 
+*Glossary: [Query Processor](/contents/Glossary.md#query-processor)*
+
 ## Result
 
 The return value from a [query](#query). The result is returned from a [query handler](#query-handler) and exposed to the caller via the [QueryProcessor](#query-processor).
 
+*Glossary: [Result](/contents/Glossary.md#result)*
+
 ## Request
 
 In Brighter, either a [command](#command) or an [event](#event), a request for the domain to (potentially) change state in response to an instruction or new facts.
+
+*Glossary: [Request](/contents/Glossary.md#request)*
 
 ## Request Handler 
 
 A handler is the entry point to domain code. It receives a request, which may be a [command](#command) or an [event](#event). A handler is always part of an [internal bus](#internal-bus) even when the call to the handler was triggered by a [service activator](#service-activator) receiving a [message](#message) sent by another process to an [external bus](#external-bus). As such a handler forms part of a [pipeline](#pipeline).
 
 It is analogous to a method on an ASP.NET Controller.
+
+*Glossary: [Request Handler](/contents/Glossary.md#request-handler)*
 
 ## Request-Reply
 
@@ -135,12 +177,18 @@ A common approach is to change state via Brighter and query for the results of t
 
 If the call to Brighter results in a new entity, and the id for the new entity was not given to the command (for example it relies on the Database generating the id), a common problem is how to then request the details of that newly created entity via Darker. A simple solution is to update the command with the id (as a conceptual *out* parameter), and then retrieve it from there to use in the Darker query. See [update a field on a command](/contents/ReturningResultsFromAHandler.md#update-a-field-on-the-command) for more. 
 
+*Glossary: [Request-Reply](/contents/Glossary.md#request-reply)*
+
 ## Routing Key (Topic)
 
 A routing key, also called a topic is the key used by message broker to route published messages to a subscriber.
+
+*Glossary: [Routing Key](/contents/Glossary.md#routing-key)*
 
 ## Service Activator
 
 A Service Activator triggers execution of your code due to an external input, such as an HTTP call, or a [message](#message) sent over middleware. <!-- pagelint: allow-serviceactivator -->
 
 In Brighter, the *Dispatcher* acts as a Service Activator, listening for a message from middleware, which it delivers via the [command processor](#command-processor) to a [handler](#request-handler). As such, it turns messages sent over middleware to a call on your [internal bus](#internal-bus). <!-- pagelint: allow-serviceactivator -->
+
+*Glossary: [`ServiceActivator`](/contents/Glossary.md#serviceactivator)*

--- a/contents/Glossary.md
+++ b/contents/Glossary.md
@@ -43,6 +43,13 @@ Example: `GetPersonNameQuery`, `GetOrderDetailsQuery`, `SearchProductsQuery`
 
 See: [Queries and Query Objects](/contents/QueriesAndQueryObjects.md), [CQRS with Brighter and Darker](/contents/CQRSWithBrighterAndDarker.md)
 
+### Result
+
+The value a Query returns. A Query Handler produces the Result and the Query Processor hands it back
+to the caller; a Query declares the type it returns by implementing `IQuery<TResult>`.
+
+See: [Query Result Types](/contents/QueryResultTypes.md)
+
 ### Query Object
 
 A pattern where query parameters are encapsulated in an object that implements `IQuery<TResult>`. The Query Object pattern separates the definition of a query from its execution, enabling middleware pipelines and testability.
@@ -66,6 +73,14 @@ See: [Query Pipeline and Decorators](/contents/QueryPipeline.md)
 A middleware component that wraps query handlers to add cross-cutting functionality. Common decorators include `QueryLogging`, `RetryableQuery`, and `FallbackPolicy`.
 
 See: [Query Pipeline and Decorators](/contents/QueryPipeline.md)
+
+### Command-Query Separation (CQS)
+
+The principle that a method either changes state or reports it, never both, so a Query never has the
+side-effect of an update. Brighter handles the Commands and Events that change state and Darker the
+Queries that report it: the split between the two frameworks is this principle made structural.
+
+See: [CQRS with Brighter and Darker](/contents/CQRSWithBrighterAndDarker.md)
 
 ## Processors
 
@@ -216,6 +231,15 @@ A pattern for handling large messages. Instead of sending the entire message thr
 
 See: [Default Message Mappers](/contents/DefaultMessageMappers.md), [S3 Luggage Store](/contents/S3LuggageStore.md)
 
+### Request-Reply
+
+A pattern in which a request for work has a matching response. Because Brighter and Darker enforce
+Command-Query Separation between them, a request that changes state is a Command with an Event
+describing the change, while a request for state is a Query returning a Result. A common shape is to
+change state through Brighter and read the result of that change back through Darker.
+
+See: [Returning Results from a Handler](/contents/ReturningResultsFromAHandler.md)
+
 ## Database Provisioning
 
 ### BoxProvisioning
@@ -297,6 +321,62 @@ The wire format representation of a Request. Contains headers (metadata) and bod
 Class: `Message`
 
 See: [Message Mappers](/contents/MessageMappers.md)
+
+### Message Oriented Middleware (MoM)
+
+The class of software that delivers a Message from one process to another. Brighter reaches it
+through a Transport, and supports only broker-based middleware rather than point-to-point; for
+point-to-point semantics, configure a routing table entry that delivers to a single queue or stream.
+
+See: [The Task Queue Pattern](/contents/TaskQueuePattern.md)
+
+### Message Queue
+
+Middleware that delivers Messages via a queue. A consumer locks a message, processes it and
+acknowledges it, at which point it is deleted; other consumers read past a locked message, which is
+what makes competing consumers possible. A nack releases the lock and makes the message visible
+again, sometimes after a delay.
+
+Examples: SQS, AMQP 0-9-1 (RabbitMQ), AMQP 1.0 (Azure Service Bus)
+
+See: [RabbitMQ Configuration](/contents/RabbitMQConfiguration.md)
+
+### Event Stream
+
+Middleware that delivers Messages via a stream. A consumer reads from an offset and stores its own
+position, so it can resume where it left off or reset and re-read; it neither locks nor deletes what
+it reads. Partitioning a stream lets consumers scale.
+
+Examples: Kafka, Kinesis, Redis Streams
+
+See: [Kafka Configuration](/contents/KafkaConfiguration.md)
+
+### Dead Letter Queue (DLQ)
+
+A queue holding messages that could not be processed, kept for investigation rather than discarded.
+Brighter routes a message there when a handler throws `RejectMessageAction`, and when the requeue
+count is exceeded on a subscription that names one. RabbitMQ and Azure Service Bus provide a DLQ
+natively; for other transports Brighter produces the rejected message to a separate channel.
+
+See: [Error Handling Options](/contents/ErrorHandlingOptions.md)
+
+### Nack (Negative Acknowledgment)
+
+Telling the transport that a message was not processed successfully. Throwing `DontAckAction` from a
+handler has the message pump apply the transport's own not-acknowledged behaviour: RabbitMQ requeues,
+SQS resets the visibility timeout, Azure Service Bus releases the lock, and a stream transport such
+as Kafka simply does not commit the offset. Contrast `DeferMessageAction`, which schedules a requeue
+with a delay, and `RejectMessageAction`, which ends processing.
+
+See: [Error Handling](/contents/HandlerFailure.md)
+
+### Poison Message
+
+A message that fails every time it is delivered. Left alone it blocks the message pump in a
+failure-requeue-failure loop, so `RequeueCount` on the Subscription caps the attempts before the
+message is rejected.
+
+See: [Error Handling](/contents/HandlerFailure.md)
 
 ## Routing
 

--- a/spec/010-information_architecture/tasks.md
+++ b/spec/010-information_architecture/tasks.md
@@ -2815,7 +2815,7 @@ total; never subtract from one either.**
 > both right** — design §16 finding 1's lesson, arriving through a filename rather than a
 > newline.
 
-- [ ] **Task 11.1:** D8 — per-term links from `BasicConcepts.md` into `Glossary.md`
+- [x] **Task 11.1:** D8 — per-term links from `BasicConcepts.md` into `Glossary.md`
   - Input: `BasicConcepts.md`'s 24 terms; `Glossary.md`'s 100
   - Output: each of the 24 linked to its matching `Glossary.md` anchor
   - Notes: **There are zero such links today.** This replaces the withdrawn
@@ -2824,6 +2824,62 @@ total; never subtract from one either.**
     set a newcomer can read *without* working through the 100-term glossary. **Do not
     re-open the merge.** Every link carries an `#anchor`, which puts all 24 under
     `linkcheck.py`'s MISSING ANCHOR check — that is the point of doing it this way.
+  - **Done 2026-08-22.** All 24 linked — but **nine of them had nothing to link to**, and
+    the maintainer ruled *write the entries*. See *Task 11.1 as executed*, below.
+
+### Task 11.1 as executed — 2026-08-22
+
+**The task presupposed a mapping that did not exist.** *"Each of the 24 linked to its
+matching `Glossary.md` anchor"* reads as bookkeeping; it is a claim about the Glossary, and
+it was **wrong for nine of the 24**. Mapped by slug against the Glossary's 81 entries:
+
+| | Terms |
+|---|---|
+| Matched exactly | 12 |
+| Matched under a different spelling | 3 — `Message Mappers`→`Message Mapper`, `Routing Key (Topic)`→`Routing Key`, `Service Activator`→`ServiceActivator` |
+| **No entry at all** | **9** — Dead Letter Queue (DLQ), Command-Query Separation (CQS), Event Stream, Message Oriented Middleware (MoM), Message Queue, Nack, Poison Message, Result, Request-Reply |
+
+**`Middleware` was the near-miss worth naming.** A loose match offers it for *Message
+Oriented Middleware*, and the Glossary's entry reads *"a handler that wraps other handlers"*
+— pipeline middleware, the opposite end of the system. **A slug that nearly matches is not a
+term that matches**, and a linker working from string distance would have pointed the reader
+at the wrong concept while every check stayed green.
+
+**Ruled by the maintainer: write the nine.** They are Brighter's own vocabulary — a
+messaging framework's glossary with no entry for *dead letter queue*, *nack* or *poison
+message* is missing the words a reader arrives with. Written into the categories that already
+existed (six into *Messaging Terms*, two into *Core Concepts*, `Request-Reply` into
+*Patterns*), in the house format, and **checked against the Brighter source rather than
+paraphrased from `BasicConcepts.md`**: `RejectMessageAction`, `DontAckAction` and
+`DeferMessageAction` are three distinct dispositions in `Paramore.Brighter/Actions/`, and
+their XML docs are where the DLQ entry's *"when the requeue count is exceeded"* and the Nack
+entry's per-transport list come from. `RequeueCount` is a `Subscription` property, checked at
+`Subscription.cs:109`. The Glossary is **81 entries → 90**.
+
+**The link line goes at the end of each section, and that placement is load-bearing.** A
+page's `description:` front matter is derived from its opening sentence, so a pointer
+inserted directly under `## Command` would have become `BasicConcepts.md`'s public
+description — the platform-default duplication of Phase 10, arriving from the other
+direction. Appended, the opening sentence is untouched and the front matter still matches it.
+
+**One more link fault, found on the page this task was editing.** `BasicConcepts.md` carried
+`[query processor](#)` — **a link to nothing**, which reaches a reader as a live link and
+reached `linkcheck.py` as a same-page link with an empty anchor, so the anchor test skipped
+it for having nothing to look up. It is the third thing this tool has walked past in two
+tasks, and the same shape as the other two: *not malformed, therefore not examined*. Now
+`EMPTY TARGET`, and red on the untouched corpus before the fix, which is exactly one
+occurrence — the one on this page. **The rule is worth more than the fix**: an empty link is
+what a half-finished edit leaves behind, and nothing else in this repository would notice.
+
+**`ServiceActivator` is in backticks**, because the Glossary entry it points at defines it as
+*"the assembly name for the Dispatcher component"* — an identifier, which is what `CLAUDE.md`
+says to do and what stops rule 5 firing on a link this task created. Worth noting for
+whoever meets it next: **rule 5 does not read headings**, only prose, so `### ServiceActivator`
+sits in the Glossary unreported. That is defensible — it is the assembly's name — but it is
+unchecked rather than approved.
+
+**Gates after:** linkcheck **144 files, clean**; pagelint 0 errors / **791** warnings / 142
+pages; `--check-shape` 0; `--check-redirects` 0 at 77 entries.
 
 - [ ] **Task 11.2:** P2-1 — normalise the files with no trailing newline — **14**, re-derived
   - Input: the 14 files (measured at `3178d68`; it was 18 of 105 before the Phase 6 splits,

--- a/tools/linkcheck.py
+++ b/tools/linkcheck.py
@@ -1,12 +1,13 @@
 #!/usr/bin/env python3
 """Check internal markdown links across the documentation.
 
-Reports five kinds of breakage:
+Reports six kinds of breakage:
 
   MISSING FILE    the link target file does not exist
   MISSING ANCHOR  the file exists, but no heading in it slugifies to the anchor
   WRONG CASE      the target exists only under different capitalisation
   LEGACY HTML     a link to a `.html` path, which the published site never serves
+  EMPTY TARGET    a link whose target is `#` or empty -- it goes nowhere
   ORPHAN          a published page nothing in SUMMARY.md links to
 
 LEGACY HTML is the fault class this tool used to *create*. Only `.md` targets
@@ -198,6 +199,14 @@ def check(paths):
             target = unquote(raw.strip())
             if target.startswith(('http://', 'https://', 'mailto:')):
                 continue
+            # `[text](#)` is a link that goes nowhere. It reaches a reader as a
+            # live link, and it used to reach this checker as a same-page link
+            # with an empty anchor, which the anchor test below skips because
+            # there is nothing to look up. Nothing about it is malformed; it
+            # simply points at no heading on any page.
+            if not target.strip('#').strip():
+                problems.append(('EMPTY TARGET', rel_src, lineno, raw, label))
+                continue
             if HTML_RE.search(target.split('#')[0]):
                 problems.append(
                     ('LEGACY HTML', rel_src, lineno, raw,
@@ -255,7 +264,8 @@ def main(argv):
         print(f"No broken internal links ({len(paths)} files checked).")
         return 0
 
-    for kind in ('MISSING FILE', 'WRONG CASE', 'MISSING ANCHOR', 'LEGACY HTML'):
+    for kind in ('MISSING FILE', 'WRONG CASE', 'MISSING ANCHOR', 'LEGACY HTML',
+                 'EMPTY TARGET'):
         rows = [p for p in problems if p[0] == kind]
         if not rows:
             continue


### PR DESCRIPTION
**Spec 010, Phase 11, Task 11.1 (D8).** Two published pages change; no URL moves.

All 24 of `BasicConcepts.md`'s terms now link to their `Glossary.md` entry. Every link carries an `#anchor`, which is the point of doing it this way — all 24 are now under `linkcheck.py`'s MISSING ANCHOR check.

### The task presupposed a mapping that did not exist

*"Each of the 24 linked to its matching anchor"* reads as bookkeeping. It is a claim about the Glossary, and it was wrong for nine of them:

| | Terms |
|---|---|
| Matched exactly | 12 |
| Matched under a different spelling | 3 — `Message Mappers`→`Message Mapper`, `Routing Key (Topic)`→`Routing Key`, `Service Activator`→`ServiceActivator` |
| **No entry at all** | **9** — DLQ, CQS, Event Stream, MoM, Message Queue, Nack, Poison Message, Result, Request-Reply |

**`Middleware` is the near-miss worth naming.** A loose match offers it for *Message Oriented Middleware*; the entry reads *"a handler that wraps other handlers"* — pipeline middleware, the opposite end of the system. A linker working from string distance would have pointed the reader at the wrong concept with every check still green.

### The nine, written

Ruled by the maintainer. They are Brighter's own vocabulary — a messaging framework's glossary with no entry for *dead letter queue*, *nack* or *poison message* is missing the words a reader arrives with.

Placed in the categories that already existed (six in *Messaging Terms*, two in *Core Concepts*, `Request-Reply` in *Patterns*), in the house format, and **checked against the Brighter source rather than paraphrased from `BasicConcepts.md`**: `RejectMessageAction`, `DontAckAction` and `DeferMessageAction` are three distinct dispositions in `Paramore.Brighter/Actions/`, and their XML docs are where the DLQ entry's *"when the requeue count is exceeded"* and the Nack entry's per-transport list come from. `RequeueCount` is checked at `Subscription.cs:109`. **81 entries → 90.**

### Placement is load-bearing

The link line goes at the **end** of each section. A page's `description:` is derived from its opening sentence, so a pointer inserted under `## Command` would have become `BasicConcepts.md`'s public description — Phase 10's platform-default duplication, arriving from the other direction.

### A third thing linkcheck walked past

`BasicConcepts.md` carried **`[query processor](#)`** — a link to nothing. It reaches a reader as a live link, and reached the checker as a same-page link with an empty anchor, so the anchor test skipped it for having nothing to look up. Now **EMPTY TARGET**, red on the untouched corpus at exactly one occurrence: the one on this page.

Same shape as the `.html` links and the wrapped links: *not malformed, therefore not examined*. The rule is worth more than the fix — an empty link is what a half-finished edit leaves behind, and nothing else here would notice.

### Gates

linkcheck **144 files, clean**; pagelint **0 errors / 791 warnings / 142 pages**; `--check-shape` **0**; `--check-redirects` **0** at 77 entries; `--changed origin/master` **0** at 5 files, 36 hunks, 2 pages, 0 code blocks strict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)