### PR TITLE
spec: 009 Phase 4 — the version gate and the release checklist

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -83,14 +83,23 @@ jobs:
       - run: python3 tools/urlmap.py --check-shape
       - run: python3 tools/urlmap.py --check-redirects
 
-  # Spec 009 D9 adds tools/versioncheck.py, which diffs the versions pinned in
-  # tutorial prose against the latest non-prerelease on NuGet. The job is shaped
-  # now so landing D9 is one file, not a workflow restructure.
+  # Spec 009 D9. tools/versioncheck.py diffs the versions pinned in tutorial
+  # prose against the latest non-prerelease on NuGet, per package.
   #
-  # REMOVE THE GUARD when 009 D9 lands — it exists only to keep the build green
-  # while the tool is absent, and inheriting it would silently un-gate the check.
-  # The bare invocation is deliberate: versioncheck.py exits 2 when it cannot
-  # reach NuGet, and an unreachable authority is an unchecked pin, not a pass.
+  # The `if [ -f tools/versioncheck.py ]` guard that stood here until D9 landed
+  # is GONE, and must stay gone: it existed only to keep the build green while
+  # the tool was absent, and a guard that outlives its tool silently un-gates
+  # the check it was protecting.
+  #
+  # The invocation is bare for the same reason. versioncheck.py exits 2 when it
+  # cannot reach NuGet, and an unreachable authority is an unchecked pin rather
+  # than a pass — so no `|| true`, and no swallowing the exit code in a shell
+  # pipeline.
+  #
+  # This job keeps BOTH triggers. The daily `schedule:` above is not belt and
+  # braces: the event that invalidates a pin is a release in another
+  # repository, so a PR-only trigger would leave a stale pin undetected until
+  # someone happened to touch the docs.
   versions:
     runs-on: ubuntu-latest
     steps:
@@ -98,9 +107,4 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: '3.12'
-      - run: |
-          if [ -f tools/versioncheck.py ]; then
-            python3 tools/versioncheck.py
-          else
-            echo "tools/versioncheck.py not present yet (spec 009 D9) - skipping."
-          fi
+      - run: python3 tools/versioncheck.py

--- a/RELEASE_CHECKLIST.md
+++ b/RELEASE_CHECKLIST.md
@@ -1,0 +1,79 @@
+# Documentation Release Checklist
+
+> **Reference** · Applies to **Brighter V10**
+
+Run this on every Brighter release, before the docs are re-published. It is the maintainer's
+list, not a published page — it is deliberately absent from `SUMMARY.md`.
+
+`tools/versioncheck.py` proves the *numbers* on the tutorial pages are current. Only running
+a tutorial proves the *code* still works. That gap is real: the samples reference Brighter by
+`ProjectReference` into `../../../src/`, so Brighter's CI compiles them against tip-of-tree
+source and never against the released package a reader installs. This checklist is what
+closes it.
+
+## On Every Brighter Release
+
+1. **Run `python3 tools/versioncheck.py`. Expect it to FAIL — that failure is the signal.**
+   It exits 1 and names every file, line and package pinned behind the new release. Exit 2
+   means it could not reach NuGet, which is not a pass: retry, or pass
+   `--release-notes ../Brighter/release_notes.md` to check against a local checkout.
+2. **Update the pinned versions it names**, in both the `dotnet add package` line and the
+   `.csproj` block on each page.
+3. **Run each shipped tutorial end to end on a clean machine** — see the definition below,
+   and record the result in the table.
+4. **Re-time each one.** If the stated duration has drifted, change the page. A tutorial that
+   claims ten minutes and takes forty is a defect a reader meets before anything else.
+5. **Run `python3 tools/linkcheck.py` and `python3 tools/pagelint.py`.**
+
+**What this does not cover.** `versioncheck.py` reads only lines naming a
+`Paramore.Brighter*` package, by design — a broader match would start policing pages that
+quote an old version deliberately. Non-Brighter pins on a tutorial page
+(`Microsoft.Extensions.Hosting`, the .NET SDK version, a Docker image tag) are step 3's job,
+not the gate's: you meet them when you run the tutorial.
+
+## The Clean-Machine Definition
+
+A fresh clone, an empty NuGet cache, and no Docker volumes left from a previous run.
+
+**"Empty NuGet cache" means four locations, not one.** `NUGET_PACKAGES` moves the global
+packages folder and nothing else, so a run that redirects only that variable still reads
+downloaded bytes from the machine's HTTP cache and reports a warm restore as cold. Redirect
+all four, and verify with `dotnet nuget locals all --list` **before** the run:
+
+```bash
+export NUGET_PACKAGES="$SCRATCH/packages"
+export NUGET_HTTP_CACHE_PATH="$SCRATCH/http-cache"
+export NUGET_SCRATCH="$SCRATCH/scratch"
+export NUGET_PLUGINS_CACHE_PATH="$SCRATCH/plugins"
+dotnet nuget locals all --list   # every path must be under $SCRATCH, and empty
+```
+
+**Afterwards, assert the HTTP cache filled.** An isolated cache that is still empty and a
+cache that was bypassed look identical from the outside; files appearing under
+`$NUGET_HTTP_CACHE_PATH` is the only positive evidence that bytes crossed the network.
+
+## The Tutorial Run Table
+
+A blank or stale cell is the honest signal that a tutorial is unverified — which is a worse
+state than not having the tutorial at all. Add a row when a rung ships.
+
+| Rung | Page | Sample | Against | Last run | Machine time |
+|---|---|---|---|---|---|
+| 1 | `contents/TutorialFirstCommand.md` | `samples/CommandProcessor/HelloWorld` | 10.7.0 | 2026-08-25 (`faeac68`) | 11s |
+| 2 | `contents/TutorialFirstMessage.md` | `samples/Tutorials/02-FirstMessage` | — | not yet written | — |
+| 3 | `contents/TutorialDurableOutbox.md` | `samples/Tutorials/03-DurableOutbox` | — | not yet written | — |
+| 4 | `contents/TutorialStreamingWithKafka.md` | `samples/Tutorials/04-Kafka` | — | not yet written | — |
+
+**Machine time is create-restore-build-run**, not the duration the page quotes a reader. The
+page's figure is mostly reading and typing; this column is the part a slow feed or a broken
+sample would move.
+
+## When a Tutorial Fails
+
+**It is a release blocker for the docs, not a backlog item.** A tutorial that does not run is
+worse than no tutorial: it costs a newcomer their first hour and their confidence in
+everything else here.
+
+If it cannot be fixed before the docs are re-published, unlink the rung from
+`contents/GetStarted.md` and ship the prefix of the ladder that still works. A two-rung
+ladder is a coherent published state; a four-rung ladder with a broken third rung is not.

--- a/spec/009-getting_started_tutorials/README.md
+++ b/spec/009-getting_started_tutorials/README.md
@@ -154,11 +154,13 @@ parallel** with the others. Agreed order across the programme is
 
 ## Next Steps
 
-**Spent 2026-08-24 — the next step is `tasks.md` Phase 2.** All three items below were
-resolved during requirements and design and the list was never updated; the checklist above
-is the current state. Kept rather than deleted because it records what this spec did not yet
-know on 2026-08-03. Note item 2 says *three* tutorials: the ladder is **four** rungs, settled
-at design.
+**Spent 2026-08-24 — for the current position read `tasks.md`'s phase table, not this
+section.** It named Phase 2 and was stale by Phase 3; a pointer at one phase rots every time
+a phase lands, and `tasks.md` re-derives its own tally rather than incrementing it. All three
+items below were resolved during requirements and design and the list was never updated; the
+checklist above is the current state. Kept rather than deleted because it records what this
+spec did not yet know on 2026-08-03. Note item 2 says *three* tutorials: the ladder is
+**four** rungs, settled at design.
 
 1. Resolve the tutorial-code hosting question above
 2. Confirm the three-tutorial ladder is the right shape and ordering

--- a/spec/009-getting_started_tutorials/design.md
+++ b/spec/009-getting_started_tutorials/design.md
@@ -477,6 +477,15 @@ source: the pin's job is to match what `dotnet add package` gives the reader, an
 is what answers that command — `release_notes.md` is Brighter's record of it, one step
 removed.
 
+**Settled 2026-08-25 at Phase 4 — it is queried once per *package*, not once.** *"The
+package the tutorials pin"* was written when no tutorial page existed; rung 1 pins **two**
+(`Paramore.Brighter` and `Paramore.Brighter.Extensions.DependencyInjection`), so the phrase
+has no referent. Per-package is what the paragraph above already asks for, since
+`dotnet add package` resolves against the id it is given. The two are not interchangeable:
+the ids list **123** and **111** versions respectively, and twelve 7.x/8.x versions exist
+only for the first. They agree at the tip today, which is precisely the state in which a
+single-id query looks correct indefinitely. See `tasks.md` Task 4.1.
+
 `--release-notes PATH` remains as an **offline fallback**, reading the latest release
 heading from a local `release_notes.md`, so the tool still runs on a train. When both
 are available the NuGet answer wins; a disagreement is reported, not silently resolved,

--- a/spec/009-getting_started_tutorials/redproof_versioncheck.py
+++ b/spec/009-getting_started_tutorials/redproof_versioncheck.py
@@ -1,0 +1,172 @@
+#!/usr/bin/env python3
+"""Task 4.2 -- force tools/versioncheck.py red, one branch at a time.
+
+The discipline this probe is written to, from spec 010's rule-7 red-proofs:
+
+  * print a BASELINE first, and require it green. A probe that starts at its
+    first mutation cannot tell a rule that fires from a tool that is broken.
+  * assert the mutation produced *the input the branch rejects*, not merely
+    that the text changed. Three of 010's rule-7 proofs reported SILENT and all
+    three were the probe's fault.
+  * restore from a copy taken aside, never `git checkout --`, and assert the
+    restored file is byte-identical.
+  * when an assertion disagrees with the exit code, the assertion is the
+    suspect.
+"""
+import contextlib
+import hashlib
+import io
+import os
+import shutil
+import sys
+import tempfile
+
+# Derived from __file__, never hard-coded: urlmap.py shipped a `parents[2]`
+# that was correct where it was written and silently wrong one directory later.
+# This file lives at spec/009-getting_started_tutorials/, so the repo is two up.
+REPO = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+sys.path.insert(0, os.path.join(REPO, 'tools'))
+import versioncheck  # noqa: E402
+
+PAGE = os.path.join(REPO, 'contents/TutorialFirstCommand.md')
+REL = 'contents/TutorialFirstCommand.md'
+
+results = []
+
+
+def run(argv):
+    """Run main() capturing stdout, returning (exit code, output)."""
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        code = versioncheck.main(argv)
+    return code, buf.getvalue()
+
+
+def report(name, expected, code, out, assertion):
+    verdict = 'FIRED' if code == expected else 'SILENT'
+    results.append((verdict, name, expected, code))
+    print(f'\n----- {name}')
+    print(f'  precondition asserted: {assertion}')
+    print(out.rstrip())
+    print(f'  exit={code} expected={expected}  -> {verdict}')
+
+
+def digest(path):
+    with open(path, 'rb') as handle:
+        return hashlib.sha256(handle.read()).hexdigest()
+
+
+def main():
+    original = digest(PAGE)
+    keep = os.path.join(tempfile.mkdtemp(), 'TutorialFirstCommand.md')
+    shutil.copy2(PAGE, keep)
+    assert digest(keep) == original, 'the copy aside is not the file'
+    print(f'copy taken aside at {keep}')
+    print(f'sha256 {original}')
+
+    # ---------------------------------------------------------------- BASELINE
+    found = versioncheck.pins(REL)
+    assert found, 'baseline precondition: the page must pin something'
+    code, out = run([])
+    report('BASELINE (unmutated tree)', 0, code, out,
+           f'{len(found)} pin(s) present: '
+           + ', '.join(f'{p}@{v} line {n}' for n, p, v in found))
+    if code != 0:
+        print('\nBASELINE IS RED -- stop. Every result below is untrustworthy.')
+        return 1
+
+    text = open(PAGE, encoding='utf-8').read()
+
+    # -------------------------------------------------------------- 1. STALE PIN
+    try:
+        open(PAGE, 'w', encoding='utf-8').write(
+            text.replace('--version 10.7.0', '--version 9.0.0'))
+        # The branch rejects a pin whose version differs from the current one.
+        # Assert that is what now exists -- not merely that the file changed.
+        found = versioncheck.pins(REL)
+        current, why = versioncheck.nuget_latest('Paramore.Brighter')
+        assert current, f'cannot establish the current version: {why}'
+        behind = [(n, p, v) for n, p, v in found if v != current]
+        assert behind, ('mutation did not land: no pin differs from '
+                        f'{current}')
+        code, out = run([])
+        report('1. STALE PIN', 1, code, out,
+               f'{len(behind)} pin(s) now behind {current}: '
+               + ', '.join(f'line {n} {p}@{v}' for n, p, v in behind))
+    finally:
+        shutil.copy2(keep, PAGE)
+        assert digest(PAGE) == original, 'restore after 1 was not byte-identical'
+
+    # ------------------------------------------------------------- 2. NO PINS
+    try:
+        stripped = text.replace('--version 10.7.0', '')
+        stripped = stripped.replace(' Version="10.7.0"', '')
+        open(PAGE, 'w', encoding='utf-8').write(stripped)
+        # The branch rejects a page that EXISTS and pins NOTHING. Both halves
+        # have to hold, and the file-exists half is the one a careless probe
+        # would break by deleting the page instead.
+        assert os.path.isfile(PAGE), 'mutation deleted the page; wrong branch'
+        found = versioncheck.pins(REL)
+        assert found == [], f'mutation did not land: {len(found)} pin(s) remain'
+        code, out = run([])
+        report('2. PAGE EXISTS, PINS NOTHING', 1, code, out,
+               'page present on disk and pins() returns []')
+    finally:
+        shutil.copy2(keep, PAGE)
+        assert digest(PAGE) == original, 'restore after 2 was not byte-identical'
+
+    # ------------------------------------------- 3. AUTHORITY UNREACHABLE (no fallback)
+    # The tree is untouched here; what is mutated is the authority's address,
+    # so urlopen and every error path below it are the shipped ones.
+    good_url = versioncheck.NUGET_INDEX
+    try:
+        versioncheck.NUGET_INDEX = (
+            'https://nuget.invalid.localhost.example/{id}/index.json')
+        version, why = versioncheck.nuget_latest('Paramore.Brighter')
+        assert version is None, ('mutation did not land: the authority is '
+                                 'still answering')
+        assert versioncheck.pins(REL), ('precondition: there must be a pin to '
+                                        'go and check, or the run never asks')
+        code, out = run([])
+        report('3. AUTHORITY UNREACHABLE, no --release-notes', 2, code, out,
+               f'nuget_latest() returns None ({why})')
+
+        # ------------------------------- 4. same, WITH the offline fallback
+        notes = os.path.join(os.path.dirname(keep), 'release_notes.md')
+        open(notes, 'w', encoding='utf-8').write('## Master\n\n## 10.7.0\n')
+        parsed, why = versioncheck.release_notes_latest(notes)
+        assert parsed == '10.7.0', f'fixture did not parse: {parsed} / {why}'
+        code, out = run(['--release-notes', notes])
+        report('4. AUTHORITY UNREACHABLE, --release-notes supplies 10.7.0',
+               0, code, out,
+               'NuGet still unreachable AND the fallback parses as 10.7.0')
+
+        # ------------------------- 5. fallback disagrees -> reported, not resolved
+        open(notes, 'w', encoding='utf-8').write('## Master\n\n## 10.6.0\n')
+        parsed, _ = versioncheck.release_notes_latest(notes)
+        assert parsed == '10.6.0', f'fixture did not parse: {parsed}'
+        versioncheck.NUGET_INDEX = good_url
+        current, _ = versioncheck.nuget_latest('Paramore.Brighter')
+        assert current != parsed, ('precondition: the two authorities must '
+                                   'actually disagree')
+        code, out = run(['--release-notes', notes])
+        report('5. AUTHORITIES DISAGREE (NuGet reachable)', 0, code, out,
+               f'NuGet says {current}, the fixture says {parsed}')
+        assert 'AUTHORITIES DISAGREE' in out, (
+            'exit 0 is only correct if the disagreement was REPORTED')
+    finally:
+        versioncheck.NUGET_INDEX = good_url
+
+    assert digest(PAGE) == original, 'the page did not survive the probe'
+    print(f'\npage restored byte-identical: sha256 {digest(PAGE)}')
+
+    print('\n===== SUMMARY =====')
+    for verdict, name, expected, code in results:
+        print(f'  {verdict:6}  expected {expected}, got {code}  {name}')
+    silent = [r for r in results if r[0] == 'SILENT']
+    print(f'\n{len(results) - len(silent)}/{len(results)} branches fired.')
+    return 1 if silent else 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/spec/009-getting_started_tutorials/tasks.md
+++ b/spec/009-getting_started_tutorials/tasks.md
@@ -7,10 +7,10 @@ moved. See § *Re-derive the total* and Task 3.5.
 applied) and `requirements.md` (approved 2026-08-03)
 **Executes against:** a corpus that **Spec 010 moved after this spec was approved** — see §2.
 
-**Total tasks: 39, across 12 phases. 15 done — Phases 1, 2 and 3 complete 2026-08-24; Phase
-4's first four 2026-08-25, with Task 4.5 open until its CI run is read.**
-Re-derived, not incremented: `grep -c '^- \[x\] \*\*Task'` says 15 and `'^- \[ \] \*\*Task'`
-says 24. The phase table's Tasks column still sums to **39** independently.
+**Total tasks: 39, across 12 phases. 16 done — Phases 1, 2 and 3 complete 2026-08-24;
+Phase 4 complete 2026-08-25.**
+Re-derived, not incremented: `grep -c '^- \[x\] \*\*Task'` says 16 and `'^- \[ \] \*\*Task'`
+says 23. The phase table's Tasks column still sums to **39** independently.
 
 ---
 
@@ -888,12 +888,42 @@ which is the same shape of defect as the gate itself.
     does not fire. *When an assertion disagrees with the tool, the assertion is the suspect* —
     Task 4.2's own note, earned twice in one phase.
 
-- [ ] **Task 4.5:** Confirm the gate's first CI run is not vacuous
+- [x] **Task 4.5:** Confirm the gate's first CI run is not vacuous — **DONE 2026-08-25, PR
+      #117. It scanned a real page and examined four real pins.**
   - Input: the PR's own checks
   - Output: evidence that the run scanned `TutorialFirstCommand.md` and examined ≥1 pin
   - Notes: `gh pr checks` lists a `push` row and a `pull_request` row per commit and they
     legitimately disagree. **Read the whole output**, and re-check with
     `gh run list --json conclusion` *after* merging, not only before.
+  - **Six checks, all six read, none truncated**: two GitBook, `check` ×2 and `versions` ×2 —
+    one of each per event. All pass. The `tail -3` that merged a red build in session 23 is
+    the reason the whole list is quoted rather than the last lines of it.
+  - **The evidence is the step's own output, taken from the job log** — identical on both the
+    `push` and `pull_request` rows, so the two events agree here rather than legitimately
+    disagreeing as they do for `pagelint --changed`:
+
+    ```text
+    5 page(s) listed, 1 found, 4 not written yet, 4 pin(s) examined.
+      skipped (does not exist yet): contents/TutorialFirstMessage.md
+      skipped (does not exist yet): contents/TutorialDurableOutbox.md
+      skipped (does not exist yet): contents/TutorialStreamingWithKafka.md
+      skipped (does not exist yet): contents/GetStarted.md
+      NuGet (Paramore.Brighter): 10.7.0
+      NuGet (Paramore.Brighter.Extensions.DependencyInjection): 10.7.0
+
+    0 stale pins of 4 examined across 1 page(s).
+    ```
+
+    **`1 found` and `4 pin(s) examined` are the two figures that make the pass mean
+    something**, and they are why §2.9 moved D9 from design's step 6 to here: landed before
+    rung 1, the identical green would have read `0 found, 0 pin(s) examined`. §2.7's rule
+    that those two runs must not print the same line is doing its job on its first CI run.
+  - **NuGet is reachable from a GitHub Actions runner** — an assumption design made and
+    nothing had tested, and the failure mode would have been a daily exit 2. Both queries
+    resolved on the runner, so the per-package fetch is not a CI liability.
+  - **The step fails the build on a non-zero exit**, not merely reports one: the log shows
+    `shell: /usr/bin/bash -e {0}`, and the invocation is bare, so exit 1 and exit 2 both
+    reach the runner.
 
 ---
 

--- a/spec/009-getting_started_tutorials/tasks.md
+++ b/spec/009-getting_started_tutorials/tasks.md
@@ -7,9 +7,10 @@ moved. See § *Re-derive the total* and Task 3.5.
 applied) and `requirements.md` (approved 2026-08-03)
 **Executes against:** a corpus that **Spec 010 moved after this spec was approved** — see §2.
 
-**Total tasks: 39, across 12 phases. 11 done — Phases 1, 2 and 3 complete, 2026-08-24.**
-Re-derived, not incremented: `grep -c '^- \[x\] \*\*Task'` says 11 and `'^- \[ \] \*\*Task'`
-says 28. The phase table's Tasks column still sums to **39** independently.
+**Total tasks: 39, across 12 phases. 15 done — Phases 1, 2 and 3 complete 2026-08-24; Phase
+4's first four 2026-08-25, with Task 4.5 open until its CI run is read.**
+Re-derived, not incremented: `grep -c '^- \[x\] \*\*Task'` says 15 and `'^- \[ \] \*\*Task'`
+says 24. The phase table's Tasks column still sums to **39** independently.
 
 ---
 
@@ -757,7 +758,7 @@ which Spec 011 owns and which already carries the slot. And it must not leave th
 `if [ -f tools/versioncheck.py ]` guard in place — inheriting it silently un-gates the check,
 which is the same shape of defect as the gate itself.
 
-- [ ] **Task 4.1:** Write `tools/versioncheck.py`
+- [x] **Task 4.1:** Write `tools/versioncheck.py` — **DONE 2026-08-25**
   - Input: design § D9 — patterns, NuGet authority, `--release-notes` fallback, exit codes;
     §2.7 for the vacuity contract; `tools/linkcheck.py` for house shape
   - Output: `tools/versioncheck.py`
@@ -766,8 +767,34 @@ which is the same shape of defect as the gate itself.
     deliberately. Prints scope before verdict; missing page skipped and announced; existing
     page with zero pins is exit 1; exit 2 is not a pass. When both authorities are available
     and disagree, report it rather than resolving it.
+  - **As shipped: 352 lines, stdlib only**, `TUTORIAL_PAGES` holding all five pages of the
+    ladder including `GetStarted.md`. On the tree today: *5 page(s) listed, 1 found, 4 not
+    written yet, 4 pin(s) examined* → `0 stale pins of 4 examined across 1 page(s)`. §2.7's
+    contract is met on every clause, and the four absent rungs are named individually rather
+    than counted.
+  - **It resolves per package, not once for `paramore.brighter` — and this is a settlement of
+    something design left under-determined, not a reversal of it.** Design § D9 says the
+    authority is *"NuGet, queried once for the package the tutorials pin"*, written on
+    2026-08-03 when no tutorial page existed. Rung 1 pins **two** packages, so "the package"
+    has no referent. Per-package is what design's own stated rationale asks for — *"the pin's
+    job is to match what `dotnet add package` gives the reader"*, and that command resolves
+    against the id it is given.
+  - **Measured rather than assumed, because the two ids are not interchangeable.**
+    `Paramore.Brighter` lists **123** versions and
+    `Paramore.Brighter.Extensions.DependencyInjection` **111**; twelve 7.x/8.x versions
+    (7.1.0 … 8.1.1399) exist only for the first and four 1.x/2.x only for the second. They
+    agree at the tip today, at 10.7.0, which is exactly the state in which a single-id query
+    looks correct forever. Each id is fetched once however many times it is pinned.
+  - **`Microsoft.Extensions.Hosting 9.0.0` is left alone, and that is now demonstrated rather
+    than predicted.** Task 3.2 flagged rung 1 as D9's first real test of the
+    `Paramore.Brighter`-only restriction. The page carries **six** version-shaped strings
+    across lines 47–62; the tool examines **four**, skipping `--version 9.0.0` at line 49 and
+    `Version="9.0.0"` at line 60. The match is scoped to a *line*, because both pin forms
+    carry the id and the number together — a page-wide match would attribute a version to
+    whichever package name happened to sit nearest it.
 
-- [ ] **Task 4.2:** Prove it red before trusting it green
+- [x] **Task 4.2:** Prove it red before trusting it green — **DONE 2026-08-25. 6/6 branches
+      fired, and the probe found a defect the exit codes could not.**
   - Input: Task 4.1's tool; `TutorialFirstCommand.md` as a real, non-empty input
   - Output: a red-proof recorded here — a stale pin, a page with no pins, and an unreachable
     authority, each forced separately
@@ -776,15 +803,56 @@ which is the same shape of defect as the gate itself.
     rule-7 red-proofs reported SILENT and all three were the probe's fault. Restore from a
     copy taken aside, never `git checkout --`, and assert byte-identity afterwards. When an
     assertion disagrees with the exit code, the assertion is the suspect.
+  - **Kept as `spec/009-getting_started_tutorials/redproof_versioncheck.py`**, re-runnable,
+    the same precedent as 010's `noloss.py`. Its `REPO` is derived from `__file__` rather
+    than hard-coded — `urlmap.py` shipped a `parents[2]` that was right where it was written
+    and silently wrong one directory later.
 
-- [ ] **Task 4.3:** Remove the guard and wire the gate in
+    | # | Branch forced | Precondition asserted before the run | Expect | Got |
+    |---|---|---|---:|---:|
+    | — | BASELINE, tree unmutated | `pins()` returns 4 pins | 0 | **0** |
+    | 1 | stale pin | 2 pins now read 9.0.0 against a live NuGet 10.7.0 | 1 | **1** |
+    | 2 | page exists, pins nothing | page still on disk **and** `pins() == []` | 1 | **1** |
+    | 3 | authority unreachable, no fallback | `nuget_latest()` returns `None` | 2 | **2** |
+    | 4 | unreachable **with** `--release-notes` | NuGet still down, fixture parses 10.7.0 | 0 | **0** |
+    | 5 | both authorities, disagreeing | NuGet 10.7.0 vs fixture 10.6.0 | 0 | **0** |
+
+  - **Branch 2 is where a careless probe fails**, and the assertion says so in two parts: the
+    branch rejects a page that **exists** and pins **nothing**, so deleting the page would
+    have exercised the *skip* path instead and reported a rule broken that is not.
+  - **Branch 5 asserts on the output, not only the exit code.** Exit 0 is the correct verdict
+    — the pins do match the authority that governs them — but it is only *defensible* if the
+    disagreement was reported, so the probe requires the literal `AUTHORITIES DISAGREE` in
+    stdout. A silent 0 there would be the tool resolving what design says it must report.
+  - **The defect the probe found is not one any exit code could show.** All six branches
+    already fired; reading branch 3's *output* showed **four** `could not reach NuGet` lines
+    for **two** packages. The memo keyed on `latest`, which an unreachable package never
+    enters, so each id was re-queried once per **pin** rather than once per package — on a
+    real outage that is N HTTP timeouts at 20s each, not one. Fixed with a separate `asked`
+    set; re-run prints two lines for two packages. **This is *read the whole output* arriving
+    from a new direction**: the programme has been caught by truncating output and by
+    trusting a green check, but not before by a probe that was green on every assertion it
+    made and wrong about something it had not thought to assert.
+  - **The page survived**: `sha256 de759052…95b92` before, and byte-identical after all five
+    mutations, restored from the copy aside each time.
+
+- [x] **Task 4.3:** Remove the guard and wire the gate in — **DONE 2026-08-25**
   - Input: `.github/workflows/docs.yml`, `versions:` job at line 94, guard at 102–106
   - Output: the job runs `python3 tools/versioncheck.py` unconditionally
   - Notes: the job keeps **both** triggers — pull request and the daily `schedule:` — because
     the event this catches happens in another repository. A PR-only trigger leaves a stale
     pin undetected until someone happens to touch the docs.
+  - **The guard is gone and the comment that replaces it says why it must stay gone**, so the
+    next person to meet a red `versions` job does not reintroduce it. No second workflow was
+    created: still one file, still two jobs.
+  - **Verified by parsing the file, not by reading it** — malformed YAML disables things
+    silently in this repository's experience. `yaml.safe_load` gives jobs `['check',
+    'versions']`, triggers `['push', 'pull_request', 'schedule']` with `cron: '17 6 * * *'`
+    intact, and `versions`' steps as `checkout@v4`, `setup-python@v5`,
+    `'python3 tools/versioncheck.py'` — a bare command, no `|| true`, no shell pipeline to
+    swallow exit 2.
 
-- [ ] **Task 4.4:** Write `RELEASE_CHECKLIST.md`
+- [x] **Task 4.4:** Write `RELEASE_CHECKLIST.md` — **DONE 2026-08-25**
   - Input: design § D11 outline
   - Output: `RELEASE_CHECKLIST.md` at the repository root, ~50 lines
   - Notes: the run table carries a **date column**, so *"when was rung 3 last actually run?"*
@@ -792,6 +860,33 @@ which is the same shape of defect as the gate itself.
     it is a maintainer document, deliberately absent from `SUMMARY.md`. **Confirm
     `linkcheck.py`'s orphan check does not object** — it covers `contents/` only. If it does
     object, the file moves; the check is not loosened.
+  - **As shipped: 79 lines**, following design's four-section outline. Longer than the ~50
+    estimated, and the excess is one section: the clean-machine definition carries the
+    four-cache procedure below, which is the difference between a measurement and a warm run
+    reported as cold.
+  - **The run table has two columns design's sketch did not**: *Against*, naming the Brighter
+    release the run was made against, and the rungs not yet written are listed as rows rather
+    than omitted. A missing row and an unverified rung look identical; a row reading *not yet
+    written* cannot be mistaken for either.
+  - **Rung 1's row is filled from Phase 3's evidence, not re-run**: 10.7.0, 2026-08-25
+    (`faeac68`), 11s of machine time. The column is create-restore-build-run, deliberately not
+    the ten minutes the page quotes a reader — the page's figure is mostly reading, and this
+    one is the part a slow feed or a broken sample moves.
+  - **The four-cache lesson now lives in the repository instead of in a session's notes.**
+    `NUGET_PACKAGES` moves the global packages folder only; the bytes come from a separate
+    HTTP cache the variable does not touch. All four of `NUGET_PACKAGES`,
+    `NUGET_HTTP_CACHE_PATH`, `NUGET_SCRATCH`, `NUGET_PLUGINS_CACHE_PATH` are redirected,
+    verified empty with `dotnet nuget locals all --list` **before** the run, and the HTTP
+    cache is asserted to have **filled** afterwards — an isolated cache that stayed empty and
+    a bypassed cache are indistinguishable from the outside.
+  - **The orphan check was confirmed by reading its scope, not by inferring it from a green
+    run**, and the first attempt at that got it backwards: `'RELEASE_CHECKLIST.md' in
+    md_files()` returned `False`, which looks like a finding and is a bug in the assertion —
+    `md_files()` yields **absolute** paths. Corrected, both halves hold: the file **is**
+    link-checked (146 files, up from 145) and `orphans()` skips it by construction, at
+    `if os.path.dirname(rel) != 'contents': continue`. It stays at root; design's contingency
+    does not fire. *When an assertion disagrees with the tool, the assertion is the suspect* —
+    Task 4.2's own note, earned twice in one phase.
 
 - [ ] **Task 4.5:** Confirm the gate's first CI run is not vacuous
   - Input: the PR's own checks

--- a/tools/versioncheck.py
+++ b/tools/versioncheck.py
@@ -1,0 +1,352 @@
+#!/usr/bin/env python3
+"""Check the package versions pinned in tutorial prose against NuGet.
+
+A tutorial tells the reader to run `dotnet add package Paramore.Brighter
+--version 10.7.0`, and that number is a promise the reader can check in one
+command. It goes stale because of an event in *another* repository -- a
+Brighter release -- so nothing in this repository's history marks the moment it
+stops being true. That is why this is a gate and not a checklist line, and why
+the workflow runs it on a daily schedule as well as on pull requests.
+
+What it scans
+-------------
+Only the pages named in TUTORIAL_PAGES, listed explicitly and never globbed. A
+glob would silently start policing pages that quote an old version on purpose
+-- V10MigrationGuide.md exists to show V9 code.
+
+In each page, every match of:
+
+    --version 10.7.0                                 (a dotnet add package line)
+    Version="10.7.0"                                 (a PackageReference)
+
+restricted to lines that also name a `Paramore.Brighter*` package. Anything
+else on the page is left alone.
+
+What it compares against
+------------------------
+NuGet, per package: the highest non-prerelease in
+
+    https://api.nuget.org/v3-flatcontainer/<id>/index.json
+
+Per package rather than once for `paramore.brighter`, because that is the
+question `dotnet add package` actually asks. The two are not interchangeable:
+`Paramore.Brighter` has shipped twelve 7.x/8.x versions that
+`Paramore.Brighter.Extensions.DependencyInjection` never shipped, so the
+package lines have diverged before even though they agree at the tip today.
+Each id is fetched once however many times it is pinned.
+
+`--release-notes PATH` reads the latest released heading from a local
+release_notes.md instead, so the tool still runs with no network. When both
+authorities are available they are compared and a disagreement is *reported*,
+not resolved: it means a release shipped without notes, or notes shipped
+without a release, and either is a fact about Brighter that a docs tool should
+not paper over.
+
+Vacuity
+-------
+The failure this tool is most likely to have is passing without looking at
+anything, so:
+
+  * a listed page that does not exist is skipped, and the skip is printed --
+    the ladder ships one rung at a time, so absence is expected but never
+    silent;
+  * a page that exists and contributes no pins is an error, because a tutorial
+    whose prose pins no version is one the reader cannot reproduce;
+  * the scope -- pages listed, found, skipped, and pins examined -- is printed
+    before the verdict, so `0 stale pins` out of 0 and out of 7 do not print
+    the same line.
+
+Usage:
+    python3 tools/versioncheck.py
+    python3 tools/versioncheck.py --release-notes ../Brighter/release_notes.md
+    python3 tools/versioncheck.py contents/TutorialFirstCommand.md
+
+Exit code is 0 when every pin is current, 1 when a pin is stale or a listed
+page that exists pins nothing, and 2 when the current version could not be
+determined. **2 is not a pass**: an unreachable authority is an unchecked pin,
+so CI must treat it as a failure.
+"""
+import json
+import os
+import re
+import sys
+import urllib.error
+import urllib.request
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+# Listed, never globbed. A page joins this list when its rung ships; a page
+# that is not here yet is reported as skipped rather than passing invisibly.
+TUTORIAL_PAGES = [
+    'contents/TutorialFirstCommand.md',
+    'contents/TutorialFirstMessage.md',
+    'contents/TutorialDurableOutbox.md',
+    'contents/TutorialStreamingWithKafka.md',
+    'contents/GetStarted.md',
+]
+
+NUGET_INDEX = 'https://api.nuget.org/v3-flatcontainer/{id}/index.json'
+
+TIMEOUT = 20
+
+# The package whose version a line pins. Both forms below carry the id on the
+# same line as the number, which is what makes a line-scoped match safe:
+#
+#   dotnet add package Paramore.Brighter.Extensions.DependencyInjection --version 10.7.0
+#   <PackageReference Include="Paramore.Brighter" Version="10.7.0" />
+#
+# The trailing (?![.\w]) stops `Paramore.Brighter` matching the prefix of a
+# longer id and reporting the wrong package.
+PACKAGE_RE = re.compile(r'\bParamore\.Brighter(?:\.[A-Za-z0-9]+)*(?![.\w])')
+
+PIN_RES = (
+    re.compile(r'--version\s+(\d+\.\d+\.\d+)'),
+    re.compile(r'Version="(\d+\.\d+\.\d+)"'),
+)
+
+# `## Master` is the unreleased section and `## Release 9.X` is not a version,
+# so the latest *release* is the first heading carrying three numbers.
+RELEASE_HEADING_RE = re.compile(r'^##\s+(?:Release\s+)?(\d+)\.(\d+)\.(\d+)\s*$')
+
+
+def parse_version(text):
+    """('10.7.0') -> (10, 7, 0), or None if it is not three integers."""
+    parts = text.split('.')
+    if len(parts) != 3:
+        return None
+    try:
+        return tuple(int(p) for p in parts)
+    except ValueError:
+        return None
+
+
+def latest_stable(versions):
+    """Highest non-prerelease in a NuGet versions[] array.
+
+    Prereleases carry a `-` suffix (10.8.0-beta.1) and are dropped: the pin's
+    job is to match what `dotnet add package` gives a reader by default, and
+    that is the highest stable.
+    """
+    stable = []
+    for raw in versions:
+        if '-' in raw or '+' in raw:
+            continue
+        parsed = parse_version(raw)
+        if parsed:
+            stable.append((parsed, raw))
+    if not stable:
+        return None
+    return max(stable)[1]
+
+
+def nuget_latest(package_id):
+    """Highest non-prerelease of one package, or a reason it is unknown."""
+    url = NUGET_INDEX.format(id=package_id.lower())
+    try:
+        with urllib.request.urlopen(url, timeout=TIMEOUT) as response:
+            payload = json.load(response)
+    except urllib.error.HTTPError as exc:
+        if exc.code == 404:
+            return None, f'NuGet has no package {package_id}'
+        return None, f'NuGet returned HTTP {exc.code} for {package_id}'
+    except (urllib.error.URLError, TimeoutError, OSError) as exc:
+        return None, f'could not reach NuGet for {package_id}: {exc}'
+    except json.JSONDecodeError as exc:
+        return None, f'NuGet returned unreadable JSON for {package_id}: {exc}'
+
+    version = latest_stable(payload.get('versions') or [])
+    if not version:
+        return None, f'NuGet lists no stable version of {package_id}'
+    return version, None
+
+
+def release_notes_latest(path):
+    """Latest released version from a local release_notes.md."""
+    try:
+        with open(path, encoding='utf-8') as handle:
+            text = handle.read()
+    except OSError as exc:
+        return None, f'could not read {path}: {exc}'
+    for line in text.splitlines():
+        match = RELEASE_HEADING_RE.match(line)
+        if match:
+            return '.'.join(match.groups()), None
+    return None, f'no release heading in {path}'
+
+
+def pins(path):
+    """Every (lineno, package, version) a page pins.
+
+    Scoped to a line, because both pin forms carry the package id and the
+    number together. A page-wide match would attribute a version to whichever
+    package name happened to appear nearest it.
+    """
+    with open(os.path.join(ROOT, path), encoding='utf-8') as handle:
+        lines = handle.read().splitlines()
+
+    found = []
+    for lineno, line in enumerate(lines, 1):
+        package = PACKAGE_RE.search(line)
+        if not package:
+            continue
+        for pattern in PIN_RES:
+            for match in pattern.finditer(line):
+                found.append((lineno, package.group(0), match.group(1)))
+    return found
+
+
+def main(argv):
+    release_notes = None
+    paths = []
+    args = list(argv)
+    while args:
+        arg = args.pop(0)
+        if arg == '--release-notes':
+            if not args:
+                print('--release-notes needs a path, e.g. --release-notes '
+                      '../Brighter/release_notes.md', file=sys.stderr)
+                return 2
+            release_notes = args.pop(0)
+        elif arg.startswith('-'):
+            print(f'unknown option: {arg}', file=sys.stderr)
+            return 2
+        else:
+            paths.append(arg)
+
+    if paths:
+        listed = []
+        for raw in paths:
+            rel = os.path.relpath(os.path.abspath(raw), ROOT)
+            if rel not in TUTORIAL_PAGES:
+                print(f'not a tutorial page: {raw}\n'
+                      f'add it to TUTORIAL_PAGES in {__file__} if it should be '
+                      f'checked', file=sys.stderr)
+                return 2
+            listed.append(rel)
+    else:
+        listed = list(TUTORIAL_PAGES)
+
+    present, absent = [], []
+    for rel in listed:
+        (present if os.path.isfile(os.path.join(ROOT, rel)) else absent).append(rel)
+
+    examined = []
+    empty = []
+    for rel in present:
+        found = pins(rel)
+        if found:
+            examined += [(rel,) + pin for pin in found]
+        else:
+            empty.append(rel)
+
+    # Scope before verdict. A run that examined nothing must not be able to
+    # print the same summary as one that examined seven pins.
+    print(f'{len(listed)} page(s) listed, {len(present)} found, '
+          f'{len(absent)} not written yet, {len(examined)} pin(s) examined.')
+    for rel in absent:
+        print(f'  skipped (does not exist yet): {rel}')
+
+    notes_version = None
+    if release_notes:
+        notes_version, reason = release_notes_latest(release_notes)
+        if notes_version:
+            print(f'  release notes ({release_notes}): {notes_version}')
+        else:
+            print(f'  release notes unusable: {reason}')
+
+    # A page that exists and pins nothing is a defect in the page, and it is
+    # reported before any network call so it stands on its own.
+    if empty:
+        print()
+        print(f'===== NO PINS ({len(empty)}) =====')
+        for rel in empty:
+            print(f'{rel}: exists but pins no Paramore.Brighter version; a '
+                  f'reader cannot reproduce it')
+        print(f'\n{len(empty)} tutorial page(s) pin nothing.')
+        return 1
+
+    if not examined:
+        print('\nNo pins to check: no listed tutorial page exists yet.')
+        return 0
+
+    latest = {}
+    unreachable = []
+    # `asked`, not `latest`, is what stops a second query: a package that could
+    # not be reached never lands in `latest`, so keying on that would re-ask
+    # once per *pin* rather than once per package -- N timeouts on a genuine
+    # outage, and N copies of the same line. The red-proof printed four of them
+    # for two packages, which is how this was found.
+    asked = set()
+    for _, _, package, _ in examined:
+        if package in asked:
+            continue
+        asked.add(package)
+        version, reason = nuget_latest(package)
+        if version:
+            latest[package] = version
+            print(f'  NuGet ({package}): {version}')
+        else:
+            unreachable.append(reason)
+
+    if unreachable:
+        if notes_version:
+            # The fallback is what makes the tool runnable offline. It answers
+            # for Brighter as a whole rather than per package, which is the
+            # cost of not asking NuGet.
+            for _, _, package, _ in examined:
+                latest.setdefault(package, notes_version)
+            print()
+            for reason in unreachable:
+                print(f'  {reason}')
+            print(f'  falling back to {release_notes} for the rest')
+        else:
+            print()
+            print('===== AUTHORITY UNREACHABLE =====')
+            for reason in unreachable:
+                print(f'  {reason}')
+            print('\nCould not determine the current version. This is not a '
+                  'pass: an unchecked pin is not a current pin. Retry, or pass '
+                  '--release-notes PATH to check against a local '
+                  'release_notes.md.')
+            return 2
+
+    # Both authorities available: report a disagreement, never resolve it.
+    disagreements = []
+    if notes_version:
+        for package, version in sorted(latest.items()):
+            if version != notes_version:
+                disagreements.append(
+                    f'{package}: NuGet says {version}, {release_notes} says '
+                    f'{notes_version}')
+
+    stale = []
+    for rel, lineno, package, version in examined:
+        expected = latest[package]
+        if version != expected:
+            stale.append((rel, lineno, package, version, expected))
+
+    if disagreements:
+        print()
+        print(f'===== AUTHORITIES DISAGREE ({len(disagreements)}) =====')
+        print('reported, not resolved -- a release shipped without notes, or '
+              'notes without a release:')
+        for row in disagreements:
+            print(f'  {row}')
+
+    if stale:
+        print()
+        print(f'===== STALE PIN ({len(stale)}) =====')
+        for rel, lineno, package, version, expected in stale:
+            print(f'{rel}:{lineno}  {package} pinned at {version}, '
+                  f'current is {expected}')
+        print(f'\n{len(stale)} stale pin(s) of {len(examined)} examined across '
+              f'{len(present)} page(s).')
+        return 1
+
+    print(f'\n0 stale pins of {len(examined)} examined across '
+          f'{len(present)} page(s).')
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main(sys.argv[1:]))


### PR DESCRIPTION
**Spec 009, Phase 4 — D9 and D11.** The two halves of making a pinned version hold. No page under `contents/` is touched, so nothing here changes the published site; what changes is the build gate.

### `tools/versioncheck.py` (D9)

Reads the versions pinned in tutorial prose and diffs them against NuGet. On the tree today:

```
5 page(s) listed, 1 found, 4 not written yet, 4 pin(s) examined.
  skipped (does not exist yet): contents/TutorialFirstMessage.md
  ...
  NuGet (Paramore.Brighter): 10.7.0
  NuGet (Paramore.Brighter.Extensions.DependencyInjection): 10.7.0

0 stale pins of 4 examined across 1 page(s).
```

**It resolves per package, not once for `paramore.brighter`.** Design says *"queried once for the package the tutorials pin"*, written on 2026-08-03 when no tutorial page existed — rung 1 pins **two**, so the phrase has no referent. Per-package is what design's own rationale asks for, since `dotnet add package` resolves against the id it is given. Measured rather than assumed: the two ids list **123** and **111** versions, twelve 7.x/8.x releases exist only for the first, and they agree at the tip today — which is exactly the state in which a single-id query looks correct indefinitely.

`Microsoft.Extensions.Hosting 9.0.0` is left alone, as design requires. Rung 1 carries six version-shaped strings; the tool examines four.

**`tasks.md` §2.7's vacuity contract is implemented and asserted.** A listed page that does not exist is skipped *and the skip is printed*; a page that exists and pins nothing is exit 1; scope prints before verdict; exit 2 is not a pass.

### Proved red before being trusted green

Six branches, each with its precondition asserted **before** the run — that the mutation produced *the input the branch rejects*, not merely that the text changed. Kept as `spec/009-getting_started_tutorials/redproof_versioncheck.py`.

| # | Branch | Precondition asserted | Expect | Got |
|---|---|---|---:|---:|
| — | baseline, tree unmutated | `pins()` returns 4 | 0 | **0** |
| 1 | stale pin | 2 pins read 9.0.0 against a live 10.7.0 | 1 | **1** |
| 2 | page exists, pins nothing | page on disk **and** `pins() == []` | 1 | **1** |
| 3 | authority unreachable | `nuget_latest()` returns `None` | 2 | **2** |
| 4 | unreachable + `--release-notes` | NuGet down, fixture parses 10.7.0 | 0 | **0** |
| 5 | authorities disagree | NuGet 10.7.0 vs fixture 10.6.0 | 0 | **0** |

Page restored byte-identical from a copy taken aside, not `git checkout --`.

**Reading branch 3's output — not its exit code — found a real defect.** Four `could not reach NuGet` lines for two packages: the memo keyed on a dict an unreachable package never enters, so each id was re-queried once per *pin*. On a genuine outage that is N HTTP timeouts at 20s each. Fixed; the re-run prints two lines for two packages.

### The guard is gone (D9 wiring)

`if [ -f tools/versioncheck.py ]` is removed from `.github/workflows/docs.yml`, and the comment replacing it says why it must stay gone — a guard that outlives its tool silently un-gates the check. Verified by parsing rather than reading: two jobs, three triggers, `cron: '17 6 * * *'` intact, and a bare command with no `|| true` to swallow exit 2. No second workflow.

### `RELEASE_CHECKLIST.md` (D11)

79 lines at the repository root, deliberately absent from `SUMMARY.md`. Its clean-machine definition carries the four-cache procedure — `NUGET_PACKAGES` moves the global packages folder only, so a run redirecting just that variable reports a warm restore as cold. The run table gains an *Against* column naming the release each run was made against, and lists unwritten rungs as rows: a missing row and an unverified rung otherwise look identical.

**The orphan check was confirmed by reading its scope**, not inferred from a green run — and the first assertion got it backwards, because `md_files()` yields absolute paths. Both halves hold: the file **is** link-checked (146 files, up from 145) and `orphans()` skips it at `if os.path.dirname(rel) != 'contents': continue`. It stays at root.

### Gates

```
linkcheck.py      No broken internal links (146 files checked).
pagelint.py       0 errors, 790 warnings (790 blocks across 117 pages) across 144 pages.
pagelint --changed  7 files, 14 hunks; 0 pages, 0 code blocks strict — vacuous, and it says so
urlmap --check-shape      0 — 143 pages, 12 sections, deepest 4, widest 10
urlmap --check-redirects  0 — 77 entries, 7858 bytes, printable ASCII
versioncheck.py   0 stale pins of 4 examined across 1 page(s).
```

`--changed` being vacuous is correct here and is not being glossed: this phase creates no page under `contents/`, so no code block can overlap the diff. The pagelint and warning figures are unmoved from `master`.

Task 4.5 — reading this PR's own `versions` run to confirm it is not vacuous — stays open until the checks land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)