### PR TITLE
spec: 009 Phase 6 — rung 2, and the pin that rung 1 could not lend it

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -1,6 +1,7 @@
 ## Get Started
 
 * [1. Your First Command](/contents/TutorialFirstCommand.md)
+* [2. Your First Message Over a Broker](/contents/TutorialFirstMessage.md)
 * [Why Brighter?](/contents/WhyBrighter.md)
 * [Basic Concepts](/contents/BasicConcepts.md)
 * [Show me the code!](/contents/ShowMeTheCode.md)

--- a/contents/TutorialFirstMessage.md
+++ b/contents/TutorialFirstMessage.md
@@ -1,0 +1,440 @@
+---
+description: "Send an event from one process, over a RabbitMQ exchange, to a second process that handles it."
+layout:
+  description:
+    visible: false
+---
+
+# Your First Message Over a Broker
+
+> **Tutorial** · Applies to **Brighter V10** · Prerequisites: [Your First Command](/contents/TutorialFirstCommand.md)
+
+Send an [event](/contents/Glossary.md#event) from one process, over a RabbitMQ exchange, to a
+second process that handles it.
+
+This is the second rung of the ladder. Rung 1 sent a request to a handler inside one process.
+Here the handler moves into a *different* process, and the two only ever agree on a name — the
+[routing key](/contents/Glossary.md#routing-key). Your code barely changes; what changes is
+that the two halves can now be deployed, restarted and scaled apart from each other.
+
+## What You'll Build: Your First Message Over a Broker
+
+RabbitMQ in Docker, and a solution with three projects:
+
+| Project | What it is |
+|---|---|
+| `Greetings` | a class library holding `GreetingEvent` — the one type both processes share |
+| `GreetingsSender` | a console app that publishes the event and exits |
+| `GreetingsReceiver` | a console app that runs until you stop it, handling whatever arrives |
+
+The sender prints `Published greeting.event` and exits. The receiver prints
+`Received: Hello from the sender` and keeps running.
+
+The shared library is the only code the two processes have in common. That is deliberate: in a
+real system the sender and the receiver are separately deployed, and often separately owned. A
+shared library is convenient here, not required — what actually couples them is the routing
+key and the shape of the JSON on the wire.
+
+## Before You Start Your First Message
+
+- **Rung 1 complete.** [Your First Command](/contents/TutorialFirstCommand.md) introduced the
+  [Command Processor](/contents/Glossary.md#command-processor), handlers and
+  `AutoFromAssemblies()`. This page assumes all three.
+- **The .NET 9 SDK.** Check with `dotnet --version`.
+- **Docker Desktop**, running, with ports **5672** (AMQP) and **15672** (the management UI)
+  free. If something else is on those ports, RabbitMQ will start and your apps will not
+  connect.
+- **About twenty minutes.** The machine work — create, restore, build — measured **23 seconds**
+  on a clean machine with an empty NuGet package cache. Pulling the `rabbitmq:management`
+  image the first time takes longer and depends on your connection.
+
+## Step 1: Start RabbitMQ
+
+Create `docker-compose.yml` in a new folder:
+
+```yaml
+services:
+  rabbitmq:
+    image: rabbitmq:management
+    hostname: rabbitmq-server
+    ports:
+      - "5672:5672"
+      - "15672:15672"
+    environment:
+      RABBITMQ_DEFAULT_USER: guest
+      RABBITMQ_DEFAULT_PASS: guest
+```
+
+```bash
+docker compose up -d
+```
+
+**Expected result:** `docker ps` shows one container running.
+
+> **That command returns before RabbitMQ accepts connections**, because this compose file has
+> no healthcheck. Wait until <http://localhost:15672> answers — `guest` / `guest` — before you
+> start either app. Starting early prints connection failures until the broker comes up, which
+> looks exactly like a broken sample and is not one.
+
+## Step 2: Define the Greeting Event
+
+```bash
+dotnet new classlib -n Greetings -f net9.0
+dotnet add Greetings package Paramore.Brighter --version 10.7.0
+```
+
+Delete the generated `Class1.cs`, and put this in `Greetings/GreetingEvent.cs`:
+
+```csharp
+using Paramore.Brighter;
+
+namespace Greetings;
+
+/// <summary>
+/// The event both processes share. The sender publishes it; the receiver handles it.
+/// The property has a setter because the message is deserialized into a new instance
+/// by the receiver, which uses the parameterless constructor.
+/// </summary>
+public class GreetingEvent : Event
+{
+    public GreetingEvent() : base(Id.Random()) { }
+
+    public GreetingEvent(string greeting) : base(Id.Random())
+    {
+        Greeting = greeting;
+    }
+
+    public string Greeting { get; set; } = string.Empty;
+}
+```
+
+An **event** derives from `Event`, where rung 1's command derived from `Command`. The
+difference is intent, and it is not cosmetic: a command is addressed to exactly one handler,
+while an event is a statement of fact that any number of subscribers may act on. Crossing a
+broker is what makes that distinction pay.
+
+> **Both the parameterless constructor and the setter are load-bearing.** The receiver does not
+> get your object; it gets bytes, which `System.Text.Json` turns into a *new* instance. Given
+> two constructors and no `[JsonConstructor]`, it picks the parameterless one and then assigns
+> properties — so a get-only `Greeting` would arrive as an empty string, with no error
+> anywhere. If your receiver prints `Received:` and nothing else, this is why.
+
+## Step 3: Build the Sender
+
+```bash
+dotnet new console -n GreetingsSender -f net9.0
+dotnet add GreetingsSender package Paramore.Brighter.Extensions.DependencyInjection --version 10.7.0
+dotnet add GreetingsSender package Paramore.Brighter.MessagingGateway.RMQ.Async --version 10.7.0
+dotnet add GreetingsSender package Microsoft.Extensions.Hosting --version 10.0.10
+dotnet add GreetingsSender reference Greetings
+```
+
+Replace `GreetingsSender/Program.cs`:
+
+```csharp
+using System;
+using Greetings;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Paramore.Brighter;
+using Paramore.Brighter.Extensions.DependencyInjection;
+using Paramore.Brighter.MessagingGateway.RMQ.Async;
+
+var rmqConnection = new RmqMessagingGatewayConnection
+{
+    AmpqUri = new AmqpUriSpecification(new Uri("amqp://guest:guest@localhost:5672")),
+    Exchange = new Exchange("paramore.brighter.exchange")
+};
+
+// A publication tells Brighter where a request type goes: which routing key, on which broker.
+// Naming GreetingEvent here is also what loads the Greetings assembly, which matters below:
+// AutoFromAssemblies scans the assemblies loaded so far, so anything it must find has to have
+// been touched before the call. Reordering this below the registration is a silent no-op.
+var producerRegistry = new RmqProducerRegistryFactory(
+    rmqConnection,
+    [
+        new RmqPublication<GreetingEvent>
+        {
+            Topic = new RoutingKey("greeting.event"),
+            MakeChannels = OnMissingChannel.Create
+        }
+    ]).Create();
+
+var builder = Host.CreateApplicationBuilder(args);
+
+builder.Services
+    .AddBrighter()
+    .AddProducers(configure => configure.ProducerRegistry = producerRegistry)
+    .AutoFromAssemblies();
+
+// The host is built but never run: Post is synchronous, so all we need from it is the
+// container. Rung 3 does run the host, because it hosts the Outbox Sweeper.
+using (var host = builder.Build())
+{
+    var commandProcessor = host.Services.GetRequiredService<IAmACommandProcessor>();
+
+    commandProcessor.Post(new GreetingEvent("Hello from the sender"));
+}
+// Publisher confirms are asynchronous: Post returns once the message is on its way, and the
+// broker's acknowledgement arrives later. Disposing the host waits for it — bounded by
+// RmqPublication.WaitForConfirmsTimeOutInMilliseconds, 500ms by default — which is why this
+// line sits after the brace. Note what it does and does not say: the broker has had its
+// chance to confirm. A nack surfaces as a log line rather than an exception, so this message
+// means "sent", not "accepted".
+Console.WriteLine("Published greeting.event");
+```
+
+Three things are new since rung 1:
+
+- **A [publication](/contents/Glossary.md#publication)** is the outbound half of the
+  arrangement: *this request type goes to this routing key on this broker*.
+  `MakeChannels = OnMissingChannel.Create` tells Brighter to declare the exchange if it is not
+  there, which is what saves you a broker-setup step.
+- **`Post`, not `Send`.** Rung 1's `Send` ran a handler in-process and returned when it
+  finished. `Post` hands the request to the transport. Nothing in this process handles it.
+- **The `using (…) { }` block is deliberate, and so is the line after it.** Publisher confirms
+  are asynchronous: `Post` returns once the message is on its way, and the broker's
+  acknowledgement arrives later. Disposing the host is what waits for it, bounded by
+  `RmqPublication.WaitForConfirmsTimeOutInMilliseconds` — **500 ms** by default. Written as
+  `using var host`, the `Console.WriteLine` would run *before* that wait.
+
+> **`Published greeting.event` means "sent", not "accepted".** A negative acknowledgement from
+> the broker, or a confirm window that lapses, surfaces as a log line rather than an exception —
+> so this message prints either way. Rung 3 is where the message stops depending on this process
+> staying alive to be delivered at all.
+
+## Step 4: Build the Receiver
+
+```bash
+dotnet new console -n GreetingsReceiver -f net9.0
+dotnet add GreetingsReceiver package Paramore.Brighter.ServiceActivator.Extensions.DependencyInjection --version 10.7.0
+dotnet add GreetingsReceiver package Paramore.Brighter.ServiceActivator.Extensions.Hosting --version 10.7.0
+dotnet add GreetingsReceiver package Paramore.Brighter.MessagingGateway.RMQ.Async --version 10.7.0
+dotnet add GreetingsReceiver package Microsoft.Extensions.Hosting --version 10.0.10
+dotnet add GreetingsReceiver reference Greetings
+```
+
+> **The package names say `ServiceActivator` and this page says Dispatcher.** They are the same
+> thing: *Dispatcher* is the V10 name for the component that owns the message pumps, and
+> `ServiceActivator` is the older name, still carried by the assemblies and the
+> `ServiceActivatorHostedService` type so that existing code keeps compiling. You are on the
+> right page. See [Dispatcher](/contents/Glossary.md#dispatcher).
+>
+> This is also why rung 2 pins `Microsoft.Extensions.Hosting` at **10.0.10** rather than rung
+> 1's `9.0.0` — `Paramore.Brighter.ServiceActivator.Extensions.Hosting` requires it, and the
+> older pin fails the build with `NU1605`.
+
+Put this in `GreetingsReceiver/GreetingEventHandler.cs`:
+
+```csharp
+using System;
+using Greetings;
+using Paramore.Brighter;
+
+namespace GreetingsReceiver;
+
+/// <summary>
+/// The pump reads a message from the channel, the mapper turns it back into a
+/// <see cref="GreetingEvent"/>, and Brighter dispatches it here. This is a synchronous
+/// handler because the subscription runs a Reactor pump.
+/// </summary>
+public class GreetingEventHandler : RequestHandler<GreetingEvent>
+{
+    public override GreetingEvent Handle(GreetingEvent @event)
+    {
+        Console.WriteLine($"Received: {@event.Greeting}");
+
+        return base.Handle(@event);
+    }
+}
+```
+
+That is rung 1's handler with a different request type. Nothing about it knows a broker exists,
+which is the point.
+
+Replace `GreetingsReceiver/Program.cs`:
+
+```csharp
+using System;
+using Greetings;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Paramore.Brighter;
+using Paramore.Brighter.MessagingGateway.RMQ.Async;
+using Paramore.Brighter.ServiceActivator.Extensions.DependencyInjection;
+using Paramore.Brighter.ServiceActivator.Extensions.Hosting;
+
+// A subscription is the consuming half of a publication: the queue to read, the routing
+// key bound to it, and how the pump should run. This is also the process that declares
+// the queue and its binding, which is why it has to run first the first time.
+//
+// Naming GreetingEvent here is also what loads the Greetings assembly. AutoFromAssemblies
+// below scans the assemblies loaded so far, so reordering this beneath it is a silent no-op.
+//
+// isDurable defaults to false, so the queue does not survive a broker restart. That is a
+// property of the *queue*, and it is a different question from whether a message survives
+// the *sender* crashing — which is what rung 3's durable Outbox is about.
+var subscriptions = new Subscription[]
+{
+    new RmqSubscription<GreetingEvent>(
+        new SubscriptionName("greeting.subscription"),
+        new ChannelName("greeting.event"),
+        new RoutingKey("greeting.event"),
+        messagePumpType: MessagePumpType.Reactor,
+        makeChannels: OnMissingChannel.Create)
+};
+
+var rmqConnection = new RmqMessagingGatewayConnection
+{
+    AmpqUri = new AmqpUriSpecification(new Uri("amqp://guest:guest@localhost:5672")),
+    Exchange = new Exchange("paramore.brighter.exchange")
+};
+
+var builder = Host.CreateApplicationBuilder(args);
+
+builder.Services
+    .AddConsumers(options =>
+    {
+        options.Subscriptions = subscriptions;
+        options.DefaultChannelFactory = new ChannelFactory(new RmqMessageConsumerFactory(rmqConnection));
+    })
+    .AutoFromAssemblies();
+
+builder.Services.AddHostedService<ServiceActivatorHostedService>();
+
+var host = builder.Build();
+
+await host.RunAsync();
+```
+
+- **A [subscription](/contents/Glossary.md#subscription)** mirrors the publication: the queue to
+  read, the routing key bound to it, and how to run the pump. `"greeting.event"` appears here
+  twice — as the channel (queue) name and as the routing key — and once in the sender. Three
+  bare strings, deliberately not a shared constant: agreeing on a name over the wire *is* the
+  coupling, and hiding it behind a constant would hide the lesson.
+- **`MessagePumpType.Reactor`** runs a single-threaded pump, so your handler can be synchronous
+  and needs no locking. See [Reactor and Proactor](/contents/ReactorAndProactor.md).
+- **`host.RunAsync()`, which rung 1 did not have.** Now there *is* something to host: the
+  Dispatcher runs until you stop it.
+
+## Step 5: Run Both Processes
+
+Two terminals, **the receiver first** — it is the process that declares the queue and binding:
+
+```bash
+dotnet run --project GreetingsReceiver
+```
+
+```bash
+dotnet run --project GreetingsSender
+```
+
+**Expected result** — the receiver, ending at the greeting and then waiting:
+
+```text
+info: Paramore.Brighter.ServiceActivator.Extensions.Hosting.ServiceActivatorHostedService[0]
+      Starting hosted service dispatcher
+info: Paramore.Brighter.ServiceActivator.Dispatcher[2014651798]
+      Dispatcher: Creating consumer number 1 for subscription: greeting.subscription
+info: Microsoft.Hosting.Lifetime[0]
+      Application started. Press Ctrl+C to shut down.
+info: Paramore.Brighter.MessagingGateway.RMQ.Async.RmqMessageConsumer[784437019]
+      RmqMessageConsumer: Created consumer for queue greeting.event with routing key greeting.event via exchange paramore.brighter.exchange on subscription amqp://*****@localhost:5672/
+info: Paramore.Brighter.CommandProcessor[258521805]
+      Found 1 pipelines for event: Greetings.GreetingEvent 01a03a64-1e77-7c06-b3d7-7d73826a9fa5
+Received: Hello from the sender
+info: Paramore.Brighter.MessagingGateway.RMQ.Async.RmqMessageConsumer[22364147]
+      RmqMessageConsumer: Acknowledging message 01a03a64-1e77-7c06-b3d7-7d73826a9fa5 as completed with delivery tag 1
+```
+
+And the sender, which exits:
+
+```text
+info: Paramore.Brighter.CommandProcessor[1310740404]
+      Decoupled invocation of message: Topic:greeting.event Id:01a03a64-1e77-7c06-b3d7-7d73826a9fa5
+info: Paramore.Brighter.MessagingGateway.RMQ.Async.RmqMessageProducer[1379693184]
+      Published message: 01a03a64-1e77-7c06-b3d7-7d73826a9fa5
+Published greeting.event
+```
+
+Both listings are trimmed: each process also logs the whole serialized message on one very long
+line, and the receiver logs its hosting environment and content root. Identifiers and
+timestamps differ on every run.
+
+The decoded body is worth seeing once, because you never wrote any code to produce it:
+
+```json
+{"greeting":"Hello from the sender","correlationId":null,"id":"01a03a64-1e77-7c06-b3d7-7d73826a9fa5"}
+```
+
+Brighter serialized your event with its default mapper, `JsonMessageMapper<T>`, and
+deserialized it on the other side. Registering a mapper by hand is something you do when the
+wire format has to match someone else's contract, not to get started.
+
+> **If you ran the sender first, on a brand-new broker, nothing arrives.** The sender declares
+> the *exchange*; the receiver declares the *queue* and the binding. With no queue bound,
+> RabbitMQ discards the message — and the publish still succeeds, so the sender prints
+> `Published greeting.event` and exits `0`. Start the receiver, then run the sender again.
+>
+> **Order only matters that first time.** The queue is declared with `autoDelete: false`, so
+> once the receiver has run, the queue and its binding outlive it and survive until the broker
+> restarts. After that you can run the sender with nothing listening, and the message waits in
+> the queue until the receiver comes back.
+
+## Step 6: See It in RabbitMQ
+
+Open <http://localhost:15672> and log in with `guest` / `guest`. Under **Exchanges** and
+**Queues** you will find what your two processes declared:
+
+| | Name | Notable |
+|---|---|---|
+| Exchange | `paramore.brighter.exchange` | type `direct` — the routing key must match exactly |
+| Queue | `greeting.event` | `0` messages once the receiver has drained it, `1` consumer |
+| Binding | exchange → queue | on routing key `greeting.event` |
+
+If the queue is missing, the receiver has not run. If it is there with messages piling up, the
+receiver has stopped but its queue survived — which is the `autoDelete: false` behaviour above.
+
+Both are declared **non-durable**, so a broker restart removes them. That is a property of the
+*queue*, and a different question from whether a message survives the *sender* crashing — which
+is rung 3's subject.
+
+Stop the broker when you are done:
+
+```bash
+docker compose down
+```
+
+## What Your First Message Showed You
+
+The handler did not change in any way that matters, and it now runs in another process:
+
+- **A publication and a subscription are two halves of one agreement**, and the agreement is a
+  string. The sender knows a routing key; the receiver knows the same routing key. Neither
+  knows the other exists.
+- **The Dispatcher is the consuming counterpart of the Command Processor.** It owns the pump
+  that reads the queue, hands each message to Brighter, and acknowledges it once your handler
+  returns. You configure it; you never call it.
+- **Acknowledgement happens after your handler returns**, which is why a crash mid-handler
+  redelivers rather than loses. That is at-least-once delivery, and it means your handler
+  should tolerate seeing the same message twice.
+
+What you still do not have is durability. The message existed only in RabbitMQ: if the sender
+had crashed between writing its data and publishing, the two would have disagreed permanently.
+The next rung puts an Outbox in the same transaction as your business data, so the message is
+either stored with it or not at all.
+
+## Further Reading
+
+- [Your First Command](/contents/TutorialFirstCommand.md) — rung 1, if you skipped it
+- [RabbitMQ Configuration](/contents/RabbitMQConfiguration.md) — every option on the
+  connection, publication and subscription used above
+- [Reactor and Proactor](/contents/ReactorAndProactor.md) — what `MessagePumpType.Reactor`
+  chose, and when to choose the other one
+- [How the Dispatcher Works](/contents/HowServiceActivatorWorks.md) — pumps, performers and
+  channels underneath the subscription
+- [Dispatching Requests](/contents/DispatchingARequest.md) — `Send`, `Publish` and `Post`
+  compared
+- [Basic Configuration](/contents/BrighterBasicConfiguration.md) — what `AddBrighter()` and
+  `AddConsumers()` accept beyond these defaults
+- [Glossary](/contents/Glossary.md) — every term this page linked, and the rest

--- a/spec/009-getting_started_tutorials/tasks.md
+++ b/spec/009-getting_started_tutorials/tasks.md
@@ -7,10 +7,10 @@ moved. See § *Re-derive the total* and Task 3.5.
 applied) and `requirements.md` (approved 2026-08-03)
 **Executes against:** a corpus that **Spec 010 moved after this spec was approved** — see §2.
 
-**Total tasks: 39, across 12 phases. 16 done — Phases 1, 2 and 3 complete 2026-08-24;
-Phase 4 complete 2026-08-25.**
-Re-derived, not incremented: `grep -c '^- \[x\] \*\*Task'` says 16 and `'^- \[ \] \*\*Task'`
-says 23. The phase table's Tasks column still sums to **39** independently.
+**Total tasks: 39, across 12 phases. 22 done — Phases 1, 2 and 3 complete 2026-08-24;
+Phases 4, 5 and 6 complete 2026-08-25.**
+Re-derived, not incremented: `grep -c '^- \[x\] \*\*Task'` says 22 and `'^- \[ \] \*\*Task'`
+says 17. The phase table's Tasks column still sums to **39** independently.
 
 ---
 
@@ -936,7 +936,7 @@ The extras being dropped — Serilog, `CustomPublicationFinder`, the second even
 explicit scheduler — are *why that sample exists*; removing them there would destroy its
 teaching purpose, which is the whole argument for a new sample rather than an edit in place.
 
-- [ ] **Task 5.1:** Build `samples/Tutorials/02-FirstMessage`
+- [x] **Task 5.1:** Build `samples/Tutorials/02-FirstMessage` — **DONE 2026-08-25**
   - Input: `../Brighter/samples/TaskQueue/RMQTaskQueue/`; `docker-compose-rmq.yaml`
   - Output: a sender, a receiver console, and the shared event type, under
     `samples/Tutorials/02-FirstMessage/`
@@ -944,14 +944,14 @@ teaching purpose, which is the whole argument for a new sample rather than an ed
     `ProjectReference` into `../../../src/` like every other sample, and no `Version`
     attributes on third-party references — central package management (requirements § Q1).
 
-- [ ] **Task 5.2:** Register the new projects in `Brighter.slnx`
+- [x] **Task 5.2:** Register the new projects in `Brighter.slnx` — **DONE 2026-08-25**
   - Input: §2.4; the existing `<Folder Name="/samples/…">` structure
   - Output: a `<Project Path="samples/Tutorials/02-FirstMessage/…" />` entry per project,
     under a `/samples/Tutorials/` folder
   - Notes: **this is the step that makes AC4 true.** Without it the sample is in `samples/`
     and not in the build, which is the state `TodoApi` is in today.
 
-- [ ] **Task 5.3:** Open the PR and confirm CI builds the new projects
+- [x] **Task 5.3:** Open the PR and confirm CI builds the new projects — **DONE 2026-08-25**
   - Input: a branch off `origin/master` (§2.6)
   - Output: a merged Brighter PR; the CI log naming the new projects
   - Notes: AC4 is *merged*, not *opened*. If it stalls beyond a couple of weeks, **say so on
@@ -960,6 +960,21 @@ teaching purpose, which is the whole argument for a new sample rather than an ed
     reasons that are not yours** — it was on 2026-08-24, on one `net10.0` test in
     `Paramore.Brighter.Transforms.Adaptors.Tests` — so read *which* check failed before
     concluding anything about your sample.
+  - **Merged 2026-08-25 as [Brighter#4275](https://github.com/BrighterCommand/Brighter/pull/4275)**,
+    squashed to `0e617177c` on Brighter `master` — matching how that repository's recent content
+    PRs land. **AC4 is therefore satisfied on its own terms: merged, not opened.** At the merge
+    the PR stood at **24 checks passing, 1 failing, 2 skipped**, and the one failure was read
+    rather than counted: `aws-ci`, **190 `TopicLimitExceededException` lines**, an SNS quota in
+    the test account that no pull request can fix. **`rabbitmq-async-ci` and `rabbitmq-sync-ci`
+    both passed**, which is the transport this rung actually uses.
+  - **The squash was verified by content, not assumed.** A squash leaves the four branch commits
+    non-ancestors of `master`, so `git log origin/master..<branch>` still lists them and looks
+    like an unmerged branch. The check that settles it is
+    `git diff origin/master <branch> -- samples/Tutorials Brighter.slnx`, which returned **0
+    lines**. Only then were the branch and its worktree removed.
+  - **All three projects are named in `Brighter.slnx` on `master`** — `Greetings`,
+    `GreetingsSender`, `GreetingsReceiver`, under a `/samples/Tutorials/02-FirstMessage/` folder
+    alongside the README.
 
 ---
 
@@ -970,7 +985,7 @@ teaching purpose, which is the whole argument for a new sample rather than an ed
 **This phase must not:** ship before Phase 5 merges (AC4), and must not tell the reader to
 fetch a file from a repository they have never cloned.
 
-- [ ] **Task 6.1:** Write `contents/TutorialFirstMessage.md`
+- [x] **Task 6.1:** Write `contents/TutorialFirstMessage.md` — **DONE 2026-08-25**
   - Input: design § D2 (outline, six code examples); the merged D5 sample
   - Output: `contents/TutorialFirstMessage.md`, ~260 lines
   - Notes: **the compose file is inlined in the page** (~12 lines, `rabbitmq:management`, the
@@ -979,20 +994,88 @@ fetch a file from a repository they have never cloned.
     the `using` block: prose says Dispatcher, the API says `ServiceActivator`, and a beginner
     who meets the mismatch unexplained concludes they are on the wrong page. Link
     `#dispatcher` — unblocked, see §2.2.
+  - **As shipped: 440 lines, against design's estimated ~260** — measured with
+    `wc -l`, after a first note in this very file guessed "293" and was corrected by running it.
+    The overshoot is all verbatim material rather than prose: the four code blocks reproduce the
+    sample in full (AC3), and two `text` blocks carry both terminals' output (AC2). Neither is
+    compressible without breaking the acceptance criterion that requires it. **Rungs 3 and 4
+    should expect the same overshoot**, and design's per-page line estimates should be read as
+    prose budgets, not page lengths. Compose file inlined at 10 lines as design requires; the
+    `ServiceActivator` sentence sits at the receiver's package block, where a reader meets the
+    name for the first time — in the `dotnet add package` lines, which is *earlier* than the
+    `using` block design anticipated, because the package names carry the old name too.
+  - **The four C# blocks are byte-identical to the four sample files** minus the licence region
+    (AC3's documented elision), asserted mechanically by extracting the page's ```` ```csharp ````
+    blocks and diffing each against the file that ran — not by eye. A first draft had trimmed
+    three of the sample's comments into prose, which would have broken the promise
+    `samples/Tutorials/02-FirstMessage/README.md` makes explicitly: *"Every code block on the page
+    is this code."* The diff is what caught it.
 
-- [ ] **Task 6.2:** `SUMMARY.md` entry, `pagetypes.tsv` row, banner with its *Prerequisites*
-      segment
+- [x] **Task 6.2:** `SUMMARY.md` entry, `pagetypes.tsv` row, banner with its *Prerequisites*
+      segment — **DONE 2026-08-25**
   - Input: §2.1's block
   - Output: the entry, the row, and a banner naming rung 1
   - Notes: the *Prerequisites* link is an ordinary internal link and `linkcheck.py` checks it.
     `apply_banners.py` **preserves** a Prerequisites segment as of `5498cd6` — it used to
     strip them — so a later sweep will not eat it.
+  - **As shipped:** the five entries join the existing `## Get Started` section per §2.1, rung 2
+    directly under rung 1. `pagetypes.tsv` goes 144 → **145 rows**, appended rather than
+    re-sorted. Banner carries the *Prerequisites* segment naming rung 1, and `linkcheck.py`
+    checks that link like any other.
 
-- [ ] **Task 6.3:** Clean-machine timed run, two terminals (AC1, AC2)
+- [x] **Task 6.3:** Clean-machine timed run, two terminals (AC1, AC2) — **DONE 2026-08-25**
   - Input: the page as written
   - Output: both terminals' output captured **verbatim** into the page; a measured duration
   - Notes: also walk step 6 — the exchange and queue visible at `localhost:15672` — since a
     reader who cannot see them has diverged and needs to know it there.
+  - **Run as a reader would run it**, against **released 10.7.0 packages** rather than the
+    `ProjectReference` the sample uses — which is the point of this task, and the third of the
+    three partial guarantees in requirements § Q1. All four NuGet cache locations were
+    redirected and **asserted empty by `dotnet nuget locals all --list` before the run**;
+    afterwards the HTTP cache held **144 files / 45 MB**, which is the positive evidence that
+    bytes crossed the network rather than a directory merely being extracted into.
+  - **Measured: 20.4s to create the three projects and add the packages, 2.3s to build both
+    apps — 23s of machine work.** Docker image pull is excluded and stated as excluded on the
+    page, because it depends on the reader's connection.
+  - **Step 6 was walked against the management API, not eyeballed**: exchange
+    `paramore.brighter.exchange` is type **`direct`**, queue `greeting.event` is
+    `durable: false`, `auto_delete: false`, and the binding carries routing key
+    `greeting.event`. The `direct` type is why the page says the routing key must match exactly.
+  - **The wire format independently re-confirms the defect behind Brighter#4277**, this time on
+    a *released* package rather than tip-of-tree source: the body is
+    `{"greeting":…,"correlationId":null,"id":…}` with `mediaType: application/json` — plain JSON
+    from `JsonMessageMapper<T>`, **not** a CloudEvents envelope, which is what 13 XML
+    doc-comment lines in `src/` still claim.
+
+> **Phase 6's durable results, so nobody re-derives them.**
+>
+> **`Microsoft.Extensions.Hosting 9.0.0` — rung 1's pin — does not build on rung 2.**
+> `Paramore.Brighter.ServiceActivator.Extensions.Hosting 10.7.0` depends on
+> `Microsoft.Extensions.Hosting (>= 10.0.10)`, so the receiver fails restore with
+> **`error NU1605: Detected package downgrade`**. This was found by *running the page's own
+> commands*, not by reading them: the pin was copied forward from rung 1 on the reasonable
+> assumption that a host package is a host package. **Rung 2 pins `10.0.10` in both projects**
+> — uniform across the two rather than only where it is forced, so a reader is never asked why
+> two sibling apps disagree — and the page says why in one sentence. **Rungs 3 and 4 inherit
+> this**: they also reference the Dispatcher's hosting package.
+>
+> **A queue-depth probe run too early reports the wrong number, and the wrong number is 0.**
+> Verifying *"stop the receiver, send anyway, the message waits"*, the queue read
+> `messages: 0, consumers: 1` immediately after the receiver was killed and **still 0** right
+> after the send — which reads as *the message was lost*, the opposite of the truth. RabbitMQ
+> had handed it to the not-yet-reaped consumer as unacknowledged; five seconds later it was
+> requeued and the depth was **1**. This is the programme's *"wait on the value you want, never
+> on the absence of the one you don't"* in a new place, and the tell was that `consumers` still
+> said 1 for a process that had already exited. **Re-read a broker's counters after the
+> connection is actually gone.**
+>
+> **All three legs of the ordering warning were re-measured here rather than inherited**, on a
+> genuinely fresh broker (`docker compose down -v`): sender-first prints
+> `Published greeting.event` and exits **0** with no queue in existence and the message
+> discarded; the receiver then starts and creates the queue at **0 messages** having received
+> nothing; a second sender run delivers. The page carries **both halves** — that order matters
+> the first time, and that it stops mattering afterwards, because `autoDelete: false` keeps the
+> queue alive once the receiver has run once.
 
 ---
 

--- a/spec/011-authoring_conventions/pagetypes.tsv
+++ b/spec/011-authoring_conventions/pagetypes.tsv
@@ -142,3 +142,4 @@ contents/AgreementDispatcherRouting.md	Explanation	high	"split from AgreementDis
 contents/MigratingToPollyV8.md	How-to	high	"split from PolicyRetryAndCircuitBreaker.md (spec 010, Task 9.4); single-mode by construction"	How-to	Brighter V10
 contents/ConfiguringOpenTelemetry.md	How-to	high	"split from Telemetry.md (spec 010, Task 9.5); single-mode by construction"	How-to	Brighter V10
 contents/TutorialFirstCommand.md	Tutorial	high	"spec 009 D1, rung 1; tutorial by construction — one path, numbered steps, measured run"	Tutorial	Brighter V10
+contents/TutorialFirstMessage.md	Tutorial	high	"spec 009 D2, rung 2; tutorial by construction — one path, numbered steps, measured two-terminal run"	Tutorial	Brighter V10


### PR DESCRIPTION
**D2 ships.** `contents/TutorialFirstMessage.md` — an event leaves one process, crosses a RabbitMQ exchange, and is handled in another. It will publish at `get-started/tutorialfirstmessage`.

**Phase 5's boxes are ticked here**, not in a Docs PR of their own: a tick is a Docs commit and Phase 5 was a Brighter PR. [Brighter#4275](https://github.com/BrighterCommand/Brighter/pull/4275) merged as `0e617177c`.

## What is in the PR

| File | Change |
|---|---|
| `contents/TutorialFirstMessage.md` | new, 440 lines |
| `SUMMARY.md` | rung 2 joins the existing `## Get Started` section, under rung 1 |
| `spec/011-authoring_conventions/pagetypes.tsv` | 144 → 145 rows, appended |
| `spec/009-.../tasks.md` | Tasks 5.1–5.3 and 6.1–6.3 ticked; Phase 6's durable results |

## Two findings that only a run produces

- **`Microsoft.Extensions.Hosting 9.0.0` — rung 1's pin — does not build on rung 2.** `Paramore.Brighter.ServiceActivator.Extensions.Hosting 10.7.0` requires `>= 10.0.10`, so the receiver fails restore with **NU1605**. The pin had been copied forward on the reasonable assumption that a host package is a host package. Rung 2 pins `10.0.10` in *both* projects, so a reader is never asked why two sibling apps disagree — and rungs 3 and 4 inherit this.
- **A queue-depth probe run too early reports 0 where the answer is 1.** Verifying *"stop the receiver, send anyway, the message waits"*, the depth read 0 immediately after the send — which reads as *the message was lost*, the opposite of the truth. RabbitMQ had handed it to a consumer it had not yet reaped; five seconds later the depth was 1. The tell was that `consumers` still said 1 for a process that had already exited.

## Verification

- **The four C# blocks are byte-identical to the four sample files** minus the licence region, asserted by extracting the page's ```csharp blocks and diffing each against the file that ran. A first draft had trimmed three of the sample's comments into prose, which would have broken the promise that sample's README makes explicitly. The diff caught it; reading it did not.
- **The ordering warning's three legs were re-measured on a fresh broker**, not inherited: sender-first prints `Published greeting.event` and exits **0** with no queue and the message discarded; the receiver then creates the queue at 0 messages having received nothing; a second send delivers. The page carries *both* halves — that order matters the first time, and that `autoDelete: false` stops it mattering afterwards.
- **Timed against released 10.7.0 packages**, not the sample's `ProjectReference` — the third of requirements § Q1's three partial guarantees. All four NuGet caches redirected and asserted empty first; afterwards the HTTP cache held **144 files / 45 MB**, the positive evidence bytes crossed the network. 20.4s create + restore, 2.3s build.
- **Step 6 walked against the management API**: exchange `paramore.brighter.exchange` is type `direct`, queue `greeting.event` is `durable: false` / `auto_delete: false`, binding on routing key `greeting.event`.

Incidentally, the wire format re-confirms [Brighter#4277](https://github.com/BrighterCommand/Brighter/issues/4277) on a *released* package: plain JSON from `JsonMessageMapper<T>`, not a CloudEvents envelope.

## Gates

```text
linkcheck.py    No broken internal links (147 files checked).
pagelint.py     0 errors, 790 warnings, 145 pages
pagelint.py --changed origin/master
                4 file(s), 13 hunk(s); 1 page(s), 15 code block(s) strict — 0 errors
urlmap.py --check-shape      0 — 144 pages, 12 sections, deepest 4, widest 10
urlmap.py --check-redirects  0 — 77 entries, 7858 bytes, printable ASCII
versioncheck.py              0 stale pins of 10 examined across 2 page(s)
```

The using-directive debt is **unchanged at 790** — this page adds none.

🤖 Generated with [Claude Code](https://claude.com/claude-code)