### PR TITLE
spec: 009 Phase 8 — rung 3's page, Adding a Durable Outbox

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -2,6 +2,7 @@
 
 * [1. Your First Command](/contents/TutorialFirstCommand.md)
 * [2. Your First Message Over a Broker](/contents/TutorialFirstMessage.md)
+* [3. Adding a Durable Outbox](/contents/TutorialDurableOutbox.md)
 * [Why Brighter?](/contents/WhyBrighter.md)
 * [Basic Concepts](/contents/BasicConcepts.md)
 * [Show me the code!](/contents/ShowMeTheCode.md)

--- a/contents/TutorialDurableOutbox.md
+++ b/contents/TutorialDurableOutbox.md
@@ -1,0 +1,658 @@
+---
+description: "Write your business data and the message announcing it in one Postgres transaction, then let the Sweeper deliver the message once that transaction has committed."
+layout:
+  description:
+    visible: false
+---
+
+# Adding a Durable Outbox
+
+> **Tutorial** · Applies to **Brighter V10** · Prerequisites: [Your First Message Over a Broker](/contents/TutorialFirstMessage.md)
+
+Write your business data and the message announcing it in one Postgres transaction, then let
+the [Sweeper](/contents/Glossary.md#sweeper) deliver the message once that transaction has
+committed.
+
+This is the third rung of the ladder. Rung 2's sender called `Post` and hoped: if the process
+had died between writing its data and reaching the broker, the data would exist and the
+announcement would not, permanently. Here the message is written to a database table — the
+[Outbox](/contents/Glossary.md#outbox) — inside the *same transaction* as your own row, so the
+two commit together or not at all. A background service sends it afterwards.
+
+The cost is a delay of a few seconds before the message goes out. What you buy with it is that
+your data and your messages can no longer disagree.
+
+## What You'll Build: A Durable Outbox
+
+Rung 2's three projects, unchanged except for the sender, plus Postgres alongside RabbitMQ:
+
+| What | Change from rung 2 |
+|---|---|
+| `Greetings` | unchanged |
+| `GreetingsReceiver` | unchanged — it does not know or care how the message was sent |
+| `GreetingsSender` | a command and a handler, a Postgres Outbox, a `Greeting` table of its own, and the Sweeper hosted in-process |
+
+The sender prints `Committed.` at once and then keeps running. About ten seconds later the
+receiver prints `Received: Hello from the sender`. **That gap is the whole point:** the send is
+no longer on the request path.
+
+Then you run it again with `--fail`, which throws after both writes and before the commit, and
+find neither of them in the database.
+
+## Before You Start the Durable Outbox
+
+- **Rung 2 complete.** [Your First Message Over a Broker](/contents/TutorialFirstMessage.md)
+  built the three projects this rung starts from, and only the sender changes here. Work in
+  that solution; this page does not rebuild it.
+- **The .NET 9 SDK.** Check with `dotnet --version`.
+- **Docker Desktop**, running, with port **5432** free as well as rung 2's **5672** and
+  **15672**.
+- **A Postgres client.** Everything below uses `psql` inside the container, so you need
+  nothing installed.
+- **About twenty-five minutes**, most of it reading. The machine work measured **9.2 seconds**
+  to add the six package references and **1.3 seconds** to build, starting from a rung 2
+  solution and a NuGet cache holding only rung 2's packages. Pulling the `postgres` image the
+  first time takes longer and depends on your connection.
+
+## Step 1: Start Postgres
+
+Rung 2's `docker-compose.yml` gains a second service. Replace the file with this:
+
+```yaml
+services:
+  rabbitmq:
+    image: rabbitmq:management
+    hostname: rabbitmq-server
+    ports:
+      - "5672:5672"
+      - "15672:15672"
+    environment:
+      RABBITMQ_DEFAULT_USER: guest
+      RABBITMQ_DEFAULT_PASS: guest
+
+  postgres:
+    image: postgres
+    ports:
+      - "5432:5432"
+    environment:
+      POSTGRES_PASSWORD: password
+      POSTGRES_DB: brightertests
+```
+
+```bash
+docker compose up -d
+```
+
+**Expected result:** `docker ps` shows two containers running.
+
+> **Neither service has a healthcheck**, so that command returns before either accepts
+> connections. RabbitMQ is ready when <http://localhost:15672> answers. Postgres is ready when
+> this prints a row:
+>
+> ```bash
+> docker compose exec postgres psql -U postgres -d brightertests -c 'select 1'
+> ```
+
+## Step 2: Add the Packages
+
+All six go to the sender. The receiver and the shared library do not change.
+
+```bash
+dotnet add GreetingsSender package Paramore.Brighter.Outbox.PostgreSql --version 10.7.0
+dotnet add GreetingsSender package Paramore.Brighter.PostgreSql --version 10.7.0
+dotnet add GreetingsSender package Paramore.Brighter.BoxProvisioning --version 10.7.0
+dotnet add GreetingsSender package Paramore.Brighter.BoxProvisioning.PostgreSql --version 10.7.0
+dotnet add GreetingsSender package Paramore.Brighter.Outbox.Hosting --version 10.7.0
+dotnet add GreetingsSender package Npgsql --version 10.0.2
+```
+
+Five of the six are Brighter's. Two are worth pausing on:
+
+- **`Paramore.Brighter.Outbox.Hosting`** is where `UseOutboxSweeper` lives. The Sweeper is the
+  feature this rung is named after, and it ships in its own package rather than in the Outbox
+  one.
+- **`Npgsql`** is not a Brighter package at all. You need it because *you* are about to talk to
+  Postgres directly — the `Greeting` table is yours, and creating it is your code's job. See
+  step 3.
+
+## Step 3: Create the Greeting Table
+
+**Two tables will live in this database and they have different owners.** Brighter's
+provisioning creates the **Outbox** table and nothing else. `Greeting` is your table: your
+schema, your migrations, your problem. A reader who conflates the two goes looking for a
+schema-management feature that Brighter does not have.
+
+Your table is as small as a table gets:
+
+```sql
+create table if not exists Greeting (
+    Id      serial primary key,
+    Message text not null
+)
+```
+
+The sample runs that in plain ADO.NET at the bottom of `Program.cs`, deliberately not through
+Brighter, because it is not Brighter's table. You will see it in the next step.
+
+## Step 4: Configure the Outbox
+
+Replace `GreetingsSender/Program.cs`:
+
+```csharp
+using System;
+using System.Data.Common;
+using System.Linq;
+using System.Threading.Tasks;
+using Greetings;
+using GreetingsSender;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Npgsql;
+using Paramore.Brighter;
+using Paramore.Brighter.BoxProvisioning;
+using Paramore.Brighter.BoxProvisioning.PostgreSql;
+using Paramore.Brighter.Extensions.DependencyInjection;
+using Paramore.Brighter.MessagingGateway.RMQ.Async;
+using Paramore.Brighter.Outbox.Hosting;
+using Paramore.Brighter.Outbox.PostgreSql;
+using Paramore.Brighter.PostgreSql;
+
+const string connectionString =
+    "Host=localhost;Port=5432;Username=postgres;Password=password;Database=brightertests";
+
+// Two tables live in this database and they have different owners. Greeting is yours: your
+// schema, your migrations, your problem, and the line below is the whole of this sample's
+// answer to that. The Outbox table is Brighter's, and UseBoxProvisioning creates it further
+// down. Do not let the two blur — Brighter does not manage your schema.
+await CreateGreetingTableAsync(connectionString);
+
+// The Outbox and the provisioner both need to know where the database is and what the table
+// is called. RelationalDatabaseConfiguration defaults the name to "Outbox".
+var outboxConfiguration = new RelationalDatabaseConfiguration(connectionString);
+
+var rmqConnection = new RmqMessagingGatewayConnection
+{
+    AmpqUri = new AmqpUriSpecification(new Uri("amqp://guest:guest@localhost:5672")),
+    Exchange = new Exchange("paramore.brighter.exchange")
+};
+
+// Unchanged from rung 2: the publication says where GreetingEvent goes. Naming the type here
+// is also what loads the Greetings assembly, which AutoFromAssemblies below needs to have
+// happened already — moving this line beneath the registration is a silent no-op.
+var producerRegistry = new RmqProducerRegistryFactory(
+    rmqConnection,
+    [
+        new RmqPublication<GreetingEvent>
+        {
+            Topic = new RoutingKey("greeting.event"),
+            MakeChannels = OnMissingChannel.Create
+        }
+    ]).Create();
+
+var builder = Host.CreateApplicationBuilder(args);
+
+// The configuration goes into the container as well as into the two calls below, and this
+// line is easy to leave out. TransactionProvider is given as a *type*, so the container
+// activates PostgreSqlTransactionProvider, and its constructor asks for exactly this
+// interface. Without it the host starts, provisions the Outbox and only then fails, on the
+// first attempt to resolve a command processor.
+builder.Services.AddSingleton<IAmARelationalDatabaseConfiguration>(outboxConfiguration);
+
+builder.Services
+    .AddBrighter()
+    .AddProducers(configure =>
+    {
+        configure.ProducerRegistry = producerRegistry;
+
+        // Rung 2 had none of these three lines and got an in-memory Outbox by default: good
+        // enough to make Post work, gone the moment the process is. These three make it
+        // durable. The transaction provider is the important one — it is what lets the
+        // handler hand Brighter a transaction that the handler itself opened.
+        configure.Outbox = new PostgreSqlOutbox(outboxConfiguration);
+        configure.ConnectionProvider = typeof(PostgreSqlConnectionProvider);
+        configure.TransactionProvider = typeof(PostgreSqlTransactionProvider);
+    })
+    .AutoFromAssemblies()
+
+    // Creates and migrates the Outbox table at startup, before anything else runs. It owns
+    // that table and nothing else; the Greeting table above was yours to create. This needs
+    // rights to CREATE TABLE, which the Docker Postgres has and your production database
+    // very likely does not — see the Box Provisioning page for the alternative.
+    .UseBoxProvisioning(options => options.AddPostgreSqlOutbox(outboxConfiguration))
+
+    // The Sweeper: a hosted service that wakes on a timer, finds undispatched messages in the
+    // Outbox and sends them. Both values below are the defaults, spelled out because the
+    // delay they produce is the thing this rung teaches — a message is picked up on the first
+    // tick after it is MinimumMessageAge old, so expect five to ten seconds.
+    .UseOutboxSweeper(options =>
+    {
+        options.TimerInterval = 5;
+        options.MinimumMessageAge = TimeSpan.FromSeconds(5);
+    });
+
+var host = builder.Build();
+
+// StartAsync rather than RunAsync, because we have work to do between starting the host and
+// waiting on it. Starting is what provisions the Outbox table and starts the Sweeper, so it
+// has to happen before the send rather than after.
+await host.StartAsync();
+
+var commandProcessor = host.Services.GetRequiredService<IAmACommandProcessor>();
+var failBeforeCommit = args.Contains("--fail");
+
+// The failing run says something different so you can prove it is absent afterwards rather
+// than counting rows: a table that still holds one greeting is only interesting if you can
+// see which greeting it is.
+var greeting = failBeforeCommit ? "This greeting will not survive" : "Hello from the sender";
+
+try
+{
+    await commandProcessor.SendAsync(new AddGreeting(greeting, failBeforeCommit));
+
+    Console.WriteLine("Committed. The greeting and the message are both in Postgres.");
+    Console.WriteLine("Waiting for the Sweeper to dispatch it. Ctrl+C to stop.");
+}
+catch (Exception e)
+{
+    Console.WriteLine($"Rolled back: {e.Message}");
+    Console.WriteLine("Neither the greeting nor the message was written. Ctrl+C to stop.");
+}
+
+await host.WaitForShutdownAsync();
+
+// Your table, created by your code. Plain ADO.NET: this is deliberately not going through
+// Brighter, because it is not Brighter's table.
+static async Task CreateGreetingTableAsync(string connection)
+{
+    await using var postgres = new NpgsqlConnection(connection);
+    await postgres.OpenAsync();
+
+    await using DbCommand command = postgres.CreateCommand();
+    command.CommandText =
+        """
+        create table if not exists Greeting (
+            Id      serial primary key,
+            Message text not null
+        )
+        """;
+
+    await command.ExecuteNonQueryAsync();
+}
+```
+
+That will not compile yet — `AddGreeting` and its handler arrive in step 5. What is new since
+rung 2:
+
+- **Three lines on `AddProducers`.** Rung 2 set only `ProducerRegistry` and got the default
+  in-memory Outbox: enough to make `Post` work, gone the moment the process is. `Outbox`,
+  `ConnectionProvider` and `TransactionProvider` replace it with Postgres. The transaction
+  provider is the important one — it is what lets your handler hand Brighter a transaction that
+  the *handler* opened.
+- **`AddSingleton<IAmARelationalDatabaseConfiguration>`, which is easy to leave out.**
+  `TransactionProvider` is given as a **type**, not an instance, so the container activates
+  `PostgreSqlTransactionProvider` and its constructor asks for that interface. Without the
+  registration the host starts happily, provisions the Outbox, logs the Sweeper ticking, and
+  only then throws — on the first attempt to resolve a command processor, naming a type your
+  code never mentions.
+- **`UseBoxProvisioning`** creates and migrates the **Outbox** table at startup, which is why
+  there is no migration project and no second terminal here. It needs rights to `CREATE TABLE`
+  and `ALTER TABLE`. The Docker Postgres above has them; a production database very often does
+  not, and [Box Provisioning](/contents/Glossary.md#boxprovisioning) is one of two options for
+  exactly that reason — see *Further Reading*.
+- **`UseOutboxSweeper`** hosts the [Sweeper](/contents/Glossary.md#sweeper) in this process. It
+  is an `IHostedService`, which is why the sender now runs a host instead of building one and
+  throwing it away as rung 2 did.
+- **`StartAsync`, not `RunAsync`.** There is work to do between starting the host and waiting
+  on it, and starting is what provisions the table and starts the Sweeper — so it has to happen
+  before the send rather than after.
+
+Both Sweeper values are the defaults, spelled out because the delay they produce is the thing
+this rung teaches: a message is picked up on the first tick that finds it at least
+`MinimumMessageAge` old.
+
+## Step 5: Write and Deposit in One Transaction
+
+Rung 2's sender called `Post` straight from `Main`. A transaction needs somewhere to live, and
+a [handler](/contents/Glossary.md#handler) is where Brighter puts one — so the work moves
+behind a [command](/contents/Glossary.md#command).
+
+Put this in `GreetingsSender/AddGreeting.cs`:
+
+```csharp
+using Paramore.Brighter;
+
+namespace GreetingsSender;
+
+/// <summary>
+/// The instruction to record a greeting and tell the world about it. Unlike
+/// <see cref="Greetings.GreetingEvent"/> this never leaves the process, so it lives here in
+/// the sender rather than in the shared Greetings library: a command is addressed to one
+/// handler, and that handler is in this assembly.
+/// </summary>
+public class AddGreeting : Command
+{
+    public AddGreeting(string greeting, bool failBeforeCommit = false) : base(Id.Random())
+    {
+        Greeting = greeting;
+        FailBeforeCommit = failBeforeCommit;
+    }
+
+    public string Greeting { get; }
+
+    /// <summary>
+    /// Set by the <c>--fail</c> switch. It exists so the tutorial can run the unhappy path:
+    /// the handler throws after the row and the message are both written and before the
+    /// commit, which is the only interesting moment in the whole sample.
+    /// </summary>
+    public bool FailBeforeCommit { get; }
+}
+```
+
+And this in `GreetingsSender/AddGreetingHandlerAsync.cs`:
+
+```csharp
+using System;
+using System.Data.Common;
+using System.Threading;
+using System.Threading.Tasks;
+using Greetings;
+using Paramore.Brighter;
+
+namespace GreetingsSender;
+
+/// <summary>
+/// The whole point of rung 3. The business row and the outgoing message are written on the
+/// same connection inside the same transaction, so the database commits both or neither.
+/// </summary>
+public class AddGreetingHandlerAsync : RequestHandlerAsync<AddGreeting>
+{
+    private readonly IAmATransactionConnectionProvider _transactionProvider;
+    private readonly IAmACommandProcessor _postBox;
+
+    public AddGreetingHandlerAsync(
+        IAmATransactionConnectionProvider transactionProvider,
+        IAmACommandProcessor postBox)
+    {
+        _transactionProvider = transactionProvider;
+        _postBox = postBox;
+    }
+
+    public override async Task<AddGreeting> HandleAsync(
+        AddGreeting addGreeting,
+        CancellationToken cancellationToken = default)
+    {
+        // Ask the provider for the connection and transaction rather than opening your own.
+        // This is the shared unit of work: the Outbox writes through the same pair, which is
+        // what makes the two writes below one atomic act instead of two hopeful ones.
+        DbConnection connection = await _transactionProvider.GetConnectionAsync(cancellationToken);
+        DbTransaction transaction = await _transactionProvider.GetTransactionAsync(cancellationToken);
+
+        try
+        {
+            // 1. Your write, to your table. Brighter neither knows nor cares what this is.
+            await using (DbCommand command = connection.CreateCommand())
+            {
+                command.Transaction = transaction;
+                command.CommandText = "insert into Greeting (Message) values (@message)";
+
+                DbParameter message = command.CreateParameter();
+                message.ParameterName = "message";
+                message.Value = addGreeting.Greeting;
+                command.Parameters.Add(message);
+
+                await command.ExecuteNonQueryAsync(cancellationToken);
+            }
+
+            // 2. Brighter's write, to the Outbox table, on that same transaction. Nothing has
+            // gone to RabbitMQ yet — DepositPostAsync only stores the message.
+            await _postBox.DepositPostAsync(
+                new GreetingEvent(addGreeting.Greeting),
+                _transactionProvider,
+                cancellationToken: cancellationToken);
+
+            // The deliberate failure the tutorial's last step runs. Both writes are pending
+            // right now; neither is committed. Throwing here is the experiment.
+            if (addGreeting.FailBeforeCommit)
+            {
+                throw new InvalidOperationException(
+                    "Deliberate failure, after both writes and before the commit");
+            }
+
+            // 3. Both, or neither.
+            await _transactionProvider.CommitAsync(cancellationToken);
+        }
+        catch (Exception)
+        {
+            // Rolling back discards your row and the message together. There is no window in
+            // which the greeting exists but the message does not, or the other way round.
+            await _transactionProvider.RollbackAsync(cancellationToken);
+            throw;
+        }
+        finally
+        {
+            _transactionProvider.Close();
+        }
+
+        // Note what is NOT here: ClearOutboxAsync. The message sits in the Outbox until the
+        // Sweeper picks it up, which is the delay this rung exists to show you. Call
+        // ClearOutboxAsync here instead and it dispatches immediately, at the cost of doing
+        // the send on the request thread.
+        return await base.HandleAsync(addGreeting, cancellationToken);
+    }
+}
+```
+
+Read the middle of that handler as three numbered acts, because that is the entire argument of
+this rung:
+
+1. **Your write**, to your table, on a connection and transaction you asked the *provider* for
+   rather than opening yourself.
+2. **Brighter's write**, to the Outbox table, on that same transaction. `DepositPostAsync` only
+   stores the message; nothing has gone to RabbitMQ.
+3. **Commit** — and both land, or the `catch` rolls back and neither does.
+
+There is no window in which the greeting exists and the message does not, or the other way
+round. That is not achieved by retrying, or by being careful; it is achieved by there being
+only one write as far as the database is concerned.
+
+> **The absent call the comment flags — `ClearOutboxAsync` — is what most production code does.**
+> Called after the commit, it dispatches on the spot and the ten-second wait below never
+> happens; the transactional guarantee is unaffected either way, because the row is already
+> committed by then. This page leaves it out so that the Outbox is visible as a thing with
+> contents rather than a formality. See
+> [Transactional Messaging with the Outbox](/contents/TransactionalMessagingWithTheOutbox.md)
+> for the version you would ship.
+
+## Step 6: Run It
+
+Three terminals this time: one for each app, and a third for the database — the sender no
+longer exits, because it is hosting the Sweeper. **The receiver first**, as before; it is
+still the process that declares the queue and the binding:
+
+```bash
+dotnet run --project GreetingsReceiver
+```
+
+```bash
+dotnet run --project GreetingsSender
+```
+
+**Expected result** — the sender, which commits at once and then stays up:
+
+```text
+info: Paramore.Brighter.BoxProvisioning.BoxProvisioningHostedService[0]
+      Provisioning Outbox 'Outbox'...
+info: Paramore.Brighter.BoxProvisioning.BoxProvisioningHostedService[0]
+      Provisioned Outbox 'Outbox' successfully
+info: Microsoft.Hosting.Lifetime[0]
+      Application started. Press Ctrl+C to shut down.
+info: Paramore.Brighter.CommandProcessor[1620710603]
+      Found 0 to clear out of amount 100
+info: Paramore.Brighter.CommandProcessor[1552112121]
+      Save request: Greetings.GreetingEvent 01a03dfa-1542-7196-8db0-3dea053ae393
+Committed. The greeting and the message are both in Postgres.
+Waiting for the Sweeper to dispatch it. Ctrl+C to stop.
+info: Paramore.Brighter.CommandProcessor[1620710603]
+      Found 1 to clear out of amount 100
+info: Paramore.Brighter.CommandProcessor[1310740404]
+      Decoupled invocation of message: Topic:greeting.event Id:01a03dfa-1542-7196-8db0-3dea053ae393
+info: Paramore.Brighter.MessagingGateway.RMQ.Async.RmqMessageProducer[1379693184]
+      Published message: 01a03dfa-1542-7196-8db0-3dea053ae393
+```
+
+And the receiver, about ten seconds later:
+
+```text
+info: Paramore.Brighter.CommandProcessor[258521805]
+      Found 1 pipelines for event: Greetings.GreetingEvent 01a03dfa-1542-7196-8db0-3dea053ae393
+Received: Hello from the sender
+info: Paramore.Brighter.MessagingGateway.RMQ.Async.RmqMessageConsumer[22364147]
+      RmqMessageConsumer: Acknowledging message 01a03dfa-1542-7196-8db0-3dea053ae393 as completed with delivery tag 1
+```
+
+Both listings are trimmed; identifiers and timings differ on every run.
+
+`Found 0 to clear` and then `Found 1 to clear` are the Sweeper's ticks: it woke, looked, found
+nothing old enough, and on a later pass found your message and sent it. Those two lines are the
+only place the delay is visible in the log.
+
+**Ten seconds is a long time for a message.** It is also the only thing you gave up. While you
+wait, look at the two tables:
+
+```bash
+docker compose exec postgres psql -U postgres -d brightertests \
+  -c 'select * from Greeting;' \
+  -c 'select messageid, topic, dispatched from Outbox;'
+```
+
+```text
+ id |        message
+----+-----------------------
+  1 | Hello from the sender
+(1 row)
+
+              messageid               |     topic      | dispatched
+--------------------------------------+----------------+------------
+ 01a03dfa-1542-7196-8db0-3dea053ae393 | greeting.event |
+(1 row)
+```
+
+**`dispatched` is null.** That single column is the durable Outbox doing its job: the message is
+committed, it is not yet sent, and nothing about it depends on this process staying alive. Run
+the same query a few seconds later and it carries a timestamp.
+
+You do not have to time it by hand — the row records both moments:
+
+```bash
+docker compose exec postgres psql -U postgres -d brightertests \
+  -c 'select timestamp, dispatched, dispatched - timestamp as sweep_delay from Outbox;'
+```
+
+```text
+           timestamp           |          dispatched           |   sweep_delay
+-------------------------------+-------------------------------+-----------------
+ 2026-08-26 12:09:54.761362+00 | 2026-08-26 12:10:04.796541+00 | 00:00:10.035179
+(1 row)
+```
+
+`TimerInterval` and `MinimumMessageAge` are five seconds each, so a message waits out its
+minimum age and is then caught by the next tick: **about ten seconds**, give or take where in
+the cycle it arrived.
+
+## Step 7: Make It Fail
+
+This is the step the page exists for. Stop the sender and run it again with `--fail`:
+
+```bash
+dotnet run --project GreetingsSender -- --fail
+```
+
+The handler writes the greeting, deposits the message, and throws before the commit. The
+greeting it writes says something different on purpose, so you can look for its *absence*
+rather than counting rows:
+
+```text
+info: Paramore.Brighter.CommandProcessor[1552112121]
+      Save request: Greetings.GreetingEvent 01a03dfa-a8d6-7398-abe9-0242392c165c
+Rolled back: Deliberate failure, after both writes and before the commit
+Neither the greeting nor the message was written. Ctrl+C to stop.
+```
+
+**`Save request` is in that output, and the message was still not saved.** `DepositPostAsync`
+really did write the Outbox row — inside a transaction that then rolled back. The log records
+what your code asked for; the table records what survived, and only one of the two is the
+authority.
+
+Now query both tables again:
+
+```bash
+docker compose exec postgres psql -U postgres -d brightertests \
+  -c 'select * from Greeting;' \
+  -c 'select messageid, topic, dispatched from Outbox;'
+```
+
+```text
+ id |        message
+----+-----------------------
+  1 | Hello from the sender
+(1 row)
+
+              messageid               |     topic      |          dispatched
+--------------------------------------+----------------+-------------------------------
+ 01a03dfa-1542-7196-8db0-3dea053ae393 | greeting.event | 2026-08-26 12:10:04.796541+00
+(1 row)
+```
+
+**Neither table gained a row.** `This greeting will not survive` is in neither, and the receiver
+stayed silent — no message was ever sent, because no message was ever committed. The two writes
+were never two writes; they were one transaction.
+
+> **`Greeting.Id` skips a number after a failed run.** Postgres allocates from the sequence
+> before the rollback and does not hand it back, so the ids go 1, 3. Nothing was lost — ids are
+> not a count.
+
+Stop both containers when you are done. The `-v` discards the Postgres volume, so the next run
+starts from an empty database:
+
+```bash
+docker compose down -v
+```
+
+## What the Durable Outbox Showed You
+
+Your handler gained a transaction and one extra write. The system gained a guarantee:
+
+- **The Outbox turns two systems into one transaction.** Your data and the message announcing
+  it are written to the same database on the same connection, so the database's own atomicity
+  is what keeps them agreeing. No distributed transaction, no two-phase commit, no compensating
+  logic.
+- **The Sweeper decouples sending from committing.** Once the row is in the Outbox the message
+  will go out — on the next tick, or after a restart, or when the broker comes back. The
+  sending process no longer has to survive for the message to be delivered.
+- **What you get is [at-least-once](/contents/Glossary.md#at-least-once), not exactly-once.** You
+  watched `dispatched` stay null until *after* the message went to RabbitMQ — so a process that
+  dies in that gap leaves a row the next sweep will send again. Combined with rung 2's
+  redelivery-on-failure, that is two reasons your handlers should tolerate seeing the same
+  message twice.
+- **Brighter owns one table and you own the other.** Provisioning creates the Outbox; `Greeting`
+  was yours to create, and your schema stays yours.
+
+The next rung changes the transport rather than the guarantee: Kafka, where messages are
+partitioned, consumers form a group, and ordering is something you get per key rather than
+per topic.
+
+## Further Reading
+
+- [Your First Message Over a Broker](/contents/TutorialFirstMessage.md) — rung 2, if you skipped
+  it
+- [Box Provisioning](/contents/BoxProvisioning.md#when-to-use-box-provisioning) — this page took
+  Option A silently; if your database will not grant `CREATE TABLE`, read the other one
+- [Using the PostgreSQL Outbox](/contents/PostgresOutbox.md) — the DDL, the configuration and
+  the Entity Framework Core variant, in full
+- [Brighter Outbox Support](/contents/BrighterOutboxSupport.md) — every Outbox Brighter ships,
+  the archiver, and how the Sweeper is configured beyond these two options
+- [Outbox Pattern Support](/contents/OutboxPattern.md) — why the pattern exists, without any
+  configuration in the way
+- [Transactional Messaging with the Outbox](/contents/TransactionalMessagingWithTheOutbox.md) —
+  the same idea taken to production, with an Inbox on the consuming side
+- [Glossary](/contents/Glossary.md) — every term this page linked, and the rest

--- a/spec/009-getting_started_tutorials/tasks.md
+++ b/spec/009-getting_started_tutorials/tasks.md
@@ -7,10 +7,13 @@ moved. See § *Re-derive the total* and Task 3.5.
 applied) and `requirements.md` (approved 2026-08-03)
 **Executes against:** a corpus that **Spec 010 moved after this spec was approved** — see §2.
 
-**Total tasks: 39, across 12 phases. 22 done — Phases 1, 2 and 3 complete 2026-08-24;
-Phases 4, 5 and 6 complete 2026-08-25.**
-Re-derived, not incremented: `grep -c '^- \[x\] \*\*Task'` says 22 and `'^- \[ \] \*\*Task'`
-says 17. The phase table's Tasks column still sums to **39** independently.
+**Total tasks: 39, across 12 phases. 28 done — Phases 1, 2 and 3 complete 2026-08-24;
+Phases 4, 5 and 6 complete 2026-08-25; Phases 7 and 8 complete 2026-08-26.**
+Re-derived, not incremented: `grep -c '^- \[x\] \*\*Task'` says 28 and `'^- \[ \] \*\*Task'`
+says 11. The phase table's Tasks column still sums to **39** independently.
+
+**Phase 7's three boxes are ticked here, in Phase 8's PR, and that is the pattern**: a tick is
+a Docs commit, and Phase 7 was a Brighter PR that could not carry one.
 
 ---
 
@@ -1019,8 +1022,10 @@ fetch a file from a repository they have never cloned.
     `apply_banners.py` **preserves** a Prerequisites segment as of `5498cd6` — it used to
     strip them — so a later sweep will not eat it.
   - **As shipped:** the five entries join the existing `## Get Started` section per §2.1, rung 2
-    directly under rung 1. `pagetypes.tsv` goes 144 → **145 rows**, appended rather than
-    re-sorted. Banner carries the *Prerequisites* segment naming rung 1, and `linkcheck.py`
+    directly under rung 1. `pagetypes.tsv` goes 143 → **144 rows** — *corrected 2026-08-26 at
+    Phase 8, which re-derived it from history: 143 data rows at `bbd054a`, 144 at `cc4f9f6`.
+    The figure written here was `PROMPT.md`'s, and `PROMPT.md`'s was the count **after** this
+    task ran* — appended rather than re-sorted. Banner carries the *Prerequisites* segment naming rung 1, and `linkcheck.py`
     checks that link like any other.
 
 - [x] **Task 6.3:** Clean-machine timed run, two terminals (AC1, AC2) — **DONE 2026-08-25**
@@ -1087,7 +1092,7 @@ fetch a file from a repository they have never cloned.
 two transports — plus migration assemblies, telemetry and a README step that hand-edits an
 absolute database path is four forks and a manual step before the first message moves.
 
-- [ ] **Task 7.1:** Build `samples/Tutorials/03-DurableOutbox`
+- [x] **Task 7.1:** Build `samples/Tutorials/03-DurableOutbox`
   - Input: D5; `AddGreetingHandlerAsync.cs` for the transaction shape (design § item 5,
     verified still present §2.8); `OutboxFactory.cs:75` for registration;
     `docker-compose-postgres.yaml`
@@ -1098,12 +1103,12 @@ absolute database path is four forks and a manual step before the first message 
     feature being taught. The `Greeting` table is created by the sample's own startup code;
     `UseBoxProvisioning` owns the Outbox table and nothing else, and the two must not blur.
 
-- [ ] **Task 7.2:** Register the new projects in `Brighter.slnx`
+- [x] **Task 7.2:** Register the new projects in `Brighter.slnx`
   - Input: §2.4
   - Output: the entries, under `/samples/Tutorials/`
   - Notes: as Task 5.2. The check is presence in the solution, not in the directory.
 
-- [ ] **Task 7.3:** Open the PR and confirm CI builds it
+- [x] **Task 7.3:** Open the PR and confirm CI builds it
   - Input: a branch off `origin/master`
   - Output: a merged Brighter PR; CI green, naming the new projects
   - Notes: a reviewer should be able to diff 03 against 02 and see exactly what a durable
@@ -1121,7 +1126,7 @@ configuration trivia; **step 7 is the page**, because the reader queries two tab
 nothing in either. Gates: Phase 2 (two of its glossary anchors), Phase 6 (the Prerequisites
 link), Phase 7 (AC4).
 
-- [ ] **Task 8.1:** Write `contents/TutorialDurableOutbox.md`
+- [x] **Task 8.1:** Write `contents/TutorialDurableOutbox.md`
   - Input: design § D3 (outline, eight code examples); the merged D6 sample
   - Output: `contents/TutorialDurableOutbox.md`, ~300 lines
   - Notes: state plainly that the database user needs `CREATE TABLE` and `ALTER TABLE` rights
@@ -1135,18 +1140,82 @@ link), Phase 7 (AC4).
     are genuinely different targets and both are correct here:
     `BoxProvisioning.md#when-to-use-box-provisioning` is a *page section*,
     `Glossary.md#boxprovisioning` is the *term*.
+  - **As shipped: 658 lines** (`len(text.splitlines())`, re-derived after the last prose edit
+    rather than carried from the draft), against design's ~300. As with rung 2
+    the overshoot is verbatim material and none of it is compressible: three C# blocks totalling
+    **255 lines** carry the whole of `GreetingsSender`, and AC3 requires them byte-identical.
+    Read design's per-page estimates as prose budgets — the prose here is about 300 lines.
+  - **Three C# blocks, and all three asserted byte-identical to the merged sample** at
+    `10351e970`, minus the licence region: `Program.cs` 139, `AddGreeting.cs` 27,
+    `AddGreetingHandlerAsync.cs` 89. Done by extracting the page's ```` ```csharp ```` blocks and
+    diffing each against `git show`, not by reading them side by side — Phase 6 established that
+    reading does not catch it.
+  - **The `Greeting` DDL is a ```` ```sql ```` block, deliberately.** It lives inside a C# raw
+    string literal in the sample, so lifting it as SQL de-indents it; a non-C# block is outside
+    AC3 by construction, which keeps the byte-identity claim above unqualified.
+  - **Step 3 was written before step 4 so the two-owners point lands with the DDL**, not after
+    the whole of `Program.cs` has gone past. The alternative — showing the
+    `CreateGreetingTableAsync` span in step 3 and again inside the full file in step 4 —
+    duplicates twenty lines to say the same thing.
+  - **Links as the task specifies:** `#outbox`, `#sweeper`, `#at-least-once`, `#boxprovisioning`
+    (closed form), plus `#command` and `#handler`; and out to
+    `BoxProvisioning.md#when-to-use-box-provisioning`, `PostgresOutbox.md`,
+    `BrighterOutboxSupport.md`, `OutboxPattern.md`,
+    `TransactionalMessagingWithTheOutbox.md`. **`PostgresOutbox.md` is the addition design's
+    cross-link list does not name and should** — it is the page that answers the
+    `IAmARelationalDatabaseConfiguration` registration, which Phase 7 spent an evening
+    rediscovering. **`OutboxSweeper.md` does not exist**; the Sweeper's own page is
+    `BrighterOutboxSupport.md`, and a first draft linked the imaginary one.
 
-- [ ] **Task 8.2:** `SUMMARY.md` entry, `pagetypes.tsv` row, banner naming rung 2
+- [x] **Task 8.2:** `SUMMARY.md` entry, `pagetypes.tsv` row, banner naming rung 2
   - Input: §2.1's block
   - Output: the entry, the row, the banner
   - Notes: as Task 6.2.
+  - **As shipped:** `* [3. Adding a Durable Outbox](/contents/TutorialDurableOutbox.md)` joins
+    `## Get Started` directly under rung 2, per §2.1. `pagetypes.tsv` goes 144 → **145 rows**,
+    appended rather than re-sorted. The banner's *Prerequisites* segment names rung 2 and
+    `linkcheck.py` checks it like any other link.
+  - **Four of the six gates moved, and by the amounts §2.1 predicts**: linkcheck 147 → **148**,
+    pagelint 145 → **146**, `--check-shape` 144 → **145**, `versioncheck.py` **10 pins across 2
+    pages → 15 across 3**. `--check-redirects` is **unchanged at 77 entries**, which is §2.1's
+    "re-ordering inside a section moves no URL" asserted rather than assumed. **The 790
+    using-directive warnings did not move** — all three C# blocks carry their `using` lines.
 
-- [ ] **Task 8.3:** Clean-machine timed run — **both** paths (AC1, AC2)
+- [x] **Task 8.3:** Clean-machine timed run — **both** paths (AC1, AC2)
   - Input: the page as written
   - Output: verbatim output for the happy path *and* the failure path; a measured duration
   - Notes: the failure path is run, not reasoned about. Query both tables after the throw and
     capture what comes back — a reader who is told "you will find neither" and finds one has
     been misled by the page that was supposed to prove the point.
+  - **Run from the page's own code, not the sample's.** The three `.cs` files were extracted
+    from the *page* and written into the project, so a transcription error would have failed
+    the build rather than shipping. The compose file was extracted from the page the same way.
+  - **The starting point is a reader's, not a clean machine's.** All four NuGet cache locations
+    were redirected and asserted empty, then rung 2's solution was built — which is the state a
+    reader of this page is in. The http-cache went 0 → 127 files building rung 2 and **127 →
+    141** adding rung 3's six packages, which is the positive evidence that the new packages
+    came over the network.
+  - **Measured: 9.2s for the six `dotnet add package` lines, 1.3s to build.** No `NU1605`:
+    `Microsoft.Extensions.Hosting 10.0.10`, inherited from rung 2, satisfies everything rung 3
+    adds. **`Npgsql` is pinned at 10.0.2**, which is what Brighter's own central package
+    management resolves for `net9.0` — 10.0.3 exists but is the `net10.0` row.
+  - **Preconditions asserted before either path ran**: `\dt` returned *Did not find any tables*
+    and `rabbitmq-diagnostics check_running` reported fully booted. That is what makes the
+    results below mean anything.
+  - **Happy path, caught mid-flight.** `Greeting` one row, `Outbox` one row with **`dispatched`
+    NULL** — the page's best single screenshot — then dispatched and received. Sweep delay read
+    off the row's own columns: **10.035179s**, a third observation agreeing with Phase 7's
+    10.06s. Still *"about ten seconds"*; three observations are not a distribution.
+  - **Failure path.** `--fail` throws after both writes and before the commit: **neither table
+    gained a row**, `This greeting will not survive` is in neither, and the receiver stayed
+    silent — asserted by counting `^Received:` in its log, still exactly 1.
+  - **`Greeting.Id` skips a number, confirmed here rather than inherited.** A third run after
+    the failure got id **3**, not 2. Postgres allocates from the sequence before the rollback.
+  - **A finding the sample's README does not carry: `Save request` is logged on the failing
+    run too.** `DepositPostAsync` really did write the Outbox row, inside a transaction that
+    then rolled back, so the log says the message was saved and the table says it was not. The
+    page says so, because a reader comparing the two listings will notice and conclude the
+    page is wrong.
 
 ---
 

--- a/spec/011-authoring_conventions/pagetypes.tsv
+++ b/spec/011-authoring_conventions/pagetypes.tsv
@@ -143,3 +143,4 @@ contents/MigratingToPollyV8.md	How-to	high	"split from PolicyRetryAndCircuitBrea
 contents/ConfiguringOpenTelemetry.md	How-to	high	"split from Telemetry.md (spec 010, Task 9.5); single-mode by construction"	How-to	Brighter V10
 contents/TutorialFirstCommand.md	Tutorial	high	"spec 009 D1, rung 1; tutorial by construction — one path, numbered steps, measured run"	Tutorial	Brighter V10
 contents/TutorialFirstMessage.md	Tutorial	high	"spec 009 D2, rung 2; tutorial by construction — one path, numbered steps, measured two-terminal run"	Tutorial	Brighter V10
+contents/TutorialDurableOutbox.md	Tutorial	high	"spec 009 D3, rung 3; tutorial by construction — one path, numbered steps, measured happy-path and failure-path runs"	Tutorial	Brighter V10


### PR DESCRIPTION
**Spec 009, Phase 8 — D3.** `contents/TutorialDurableOutbox.md`, the third rung of the Get Started ladder. Its sample, `samples/Tutorials/03-DurableOutbox`, merged as [Brighter#4278](https://github.com/BrighterCommand/Brighter/pull/4278) (`10351e970`); this is the page that documents it.

## What it does

Rung 2's message could be lost between the business write and the broker. This rung puts the message in a Postgres Outbox table inside the *same transaction* as the business row, and lets the Sweeper dispatch it afterwards. Step 7 is the point of the page: run with `--fail`, throw after both writes and before the commit, and find neither of them.

658 lines against design's estimated ~300. As at rung 2, the overshoot is entirely verbatim material — three C# blocks totalling **255 lines** carry the whole of `GreetingsSender`, and AC3 requires them byte-identical. The prose is about 300 lines.

## AC3 — asserted, not eyeballed

All three C# blocks were extracted from the page and diffed against `git show 10351e970:…` minus the licence region:

```
Program.cs: IDENTICAL (139 lines)
AddGreeting.cs: IDENTICAL (27 lines)
AddGreetingHandlerAsync.cs: IDENTICAL (89 lines)
```

The `Greeting` DDL is a ` ```sql ` block deliberately: it lives inside a C# raw string literal in the sample, so lifting it as SQL de-indents it. A non-C# block is outside AC3 by construction, which keeps the byte-identity claim above unqualified.

## AC1/AC2 — both paths run, from the page's own code

The three `.cs` files **and** the compose file were extracted from the page and written into a project, so a transcription error would have failed the build rather than shipping.

Starting state is a reader's, not a clean machine's: all four NuGet cache locations redirected and asserted empty, then rung 2's solution built. The http-cache went 0 → 127 files building rung 2 and **127 → 141** adding rung 3's six packages — the positive evidence that the new packages crossed the network.

- **9.2s** for the six `dotnet add package` lines, **1.3s** to build. No `NU1605`: rung 2's `Microsoft.Extensions.Hosting 10.0.10` covers everything rung 3 adds. `Npgsql` pinned at **10.0.2**, which is what Brighter's own central package management resolves for `net9.0`.
- **Preconditions asserted first** — `\dt` returned *Did not find any tables*, `rabbitmq-diagnostics check_running` reported fully booted.
- **Happy path**, caught mid-flight with `dispatched` **NULL**. Sweep delay read off the row's own columns: **10.035179s**, a third observation agreeing with Phase 7's 10.06s. The page says *about* ten seconds — three observations are not a distribution.
- **Failure path**: neither table gained a row, and the receiver's `^Received:` count stayed at exactly 1.
- **`Greeting.Id` skips a number**, confirmed here rather than inherited: a third run after the failure got id **3**.

## One finding the sample's README does not carry

**`Save request` is logged on the failing run too.** `DepositPostAsync` really did write the Outbox row — inside a transaction that then rolled back. The log records what the code asked for; the table records what survived. A reader comparing the two listings would otherwise conclude the page is wrong, so the page says so.

## Two corrections to approved documents

- **Design's D3 cross-link list does not name `PostgresOutbox.md` and should.** It is the page that answers the `IAmARelationalDatabaseConfiguration` registration Phase 7 spent an evening rediscovering. Added to *Further Reading*.
- **Task 6.2's `pagetypes.tsv` figure was off by one.** It recorded 144 → 145; history says **143** data rows at `bbd054a` and **144** at `cc4f9f6`. The number came from `PROMPT.md`, and `PROMPT.md`'s was the count *after* that task ran. Corrected in place with the derivation. "Re-derive a total, never increment" applied to a neighbouring document's figure rather than one's own.

`OutboxSweeper.md` does not exist; a first draft linked it, and `linkcheck.py` is what said so.

## Gates

| Gate | Before | After |
|---|---|---|
| `linkcheck.py` | 147 files | **148**, no broken links |
| `pagelint.py` | 145 pages | **146**, 0 errors, **790 warnings unmoved** |
| `urlmap.py --check-shape` | 144 pages | **145**, 0 failures |
| `urlmap.py --check-redirects` | 77 entries | **77 — unchanged** |
| `versioncheck.py` | 10 pins / 2 pages | **15 pins / 3 pages**, 0 stale |

The redirects row is §2.1's *"re-ordering inside a section moves no URL"* asserted rather than assumed. The 790 warnings not moving means all three C# blocks carry their `using` directives — this page adds no debt.

`pagelint.py --changed origin/master`: **20 code blocks strict, 0 errors** — a non-vacuous run.

## Also in this PR

Phase 7's three boxes are ticked here rather than in its own Brighter PR, which is the pattern: a tick is a Docs commit and a sample phase cannot carry one. **28 of 39 tasks, re-derived** (`grep -c`), not incremented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)