### PR TITLE
spec: 009 Phase 9 — the ladder's landing page

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -1,5 +1,6 @@
 ## Get Started
 
+* [Get Started with Brighter](/contents/GetStarted.md)
 * [1. Your First Command](/contents/TutorialFirstCommand.md)
 * [2. Your First Message Over a Broker](/contents/TutorialFirstMessage.md)
 * [3. Adding a Durable Outbox](/contents/TutorialDurableOutbox.md)

--- a/contents/GetStarted.md
+++ b/contents/GetStarted.md
@@ -1,0 +1,95 @@
+---
+description: "Brighter's tutorials are a ladder: three rungs, each one a working application, each one adding a single capability to the rung below it."
+layout:
+  description:
+    visible: false
+---
+
+# Get Started with Brighter
+
+> **Tutorial** · Applies to **Brighter V10**
+
+Brighter's tutorials are a ladder: three rungs, each one a working application, each one adding
+a single capability to the rung below it. You start with a request dispatched to a handler
+inside one process, and finish with a message written to a database transaction and delivered
+after that transaction commits. Every rung runs, and every rung is code the next one builds on.
+
+## The Brighter Tutorial Ladder
+
+| Rung | What you add | About | Needs Docker |
+|---|---|---|---|
+| [1. Your First Command](/contents/TutorialFirstCommand.md) | a [command](/contents/Glossary.md#command), a [handler](/contents/Glossary.md#handler), and the [Command Processor](/contents/Glossary.md#command-processor) that connects them | 10 minutes | no |
+| [2. Your First Message Over a Broker](/contents/TutorialFirstMessage.md) | a second process, RabbitMQ between the two, and an [event](/contents/Glossary.md#event) that crosses it | 20 minutes | RabbitMQ |
+| [3. Adding a Durable Outbox](/contents/TutorialDurableOutbox.md) | Postgres, one transaction covering your data *and* the message, and the [Sweeper](/contents/Glossary.md#sweeper) that dispatches it afterwards | 25 minutes | RabbitMQ and Postgres |
+
+Those times are mostly reading and typing. The machine work — creating projects, restoring
+packages, building — was measured on a clean machine with an empty NuGet package cache at
+**11 seconds** for rung 1, **23 seconds** for rung 2, and **9.2 seconds** to add rung 3's
+packages plus **1.3 seconds** to build. Pulling the Docker images the first time takes longer
+and depends on your connection.
+
+The rungs join up like this:
+
+- **Rung 1 stands alone.** One console project, no broker, nothing to install but the SDK.
+- **Rung 2 starts a fresh solution** of three projects: a shared class library, a sender and a
+  receiver.
+- **Rung 3 keeps rung 2's solution** and changes only the sender. If you intend to do rung 3,
+  do not delete rung 2's work.
+
+Start at rung 1. If you already know how a request reaches a handler, rung 2 is the first one
+with a broker in it — but it assumes rung 1's vocabulary rather than repeating it.
+
+## What You Need Installed for the Ladder
+
+- **The .NET 9 SDK.** Check with `dotnet --version`.
+- **Docker Desktop**, for rungs 2 and 3 only. Rung 1 is deliberately in-process.
+- **Free ports**: **5672** and **15672** for RabbitMQ on rung 2, and **5432** for Postgres on
+  rung 3. If something else is already listening, the container starts and your application
+  does not connect.
+
+Every `Paramore.Brighter*` package these pages install is pinned to the same version, so every
+`dotnet add package` line you will meet has this shape:
+
+```bash
+dotnet add package Paramore.Brighter --version 10.7.0
+```
+
+Those pins are checked against NuGet on every pull request and once a day, so the versions
+these pages name are versions that still exist. Each rung also repeats what it needs in its own *Before You Start*
+section — nothing here has to be remembered.
+
+## Just Want to See Brighter Code?
+
+There are two front doors, and they answer different questions.
+[Show me the code!](/contents/ShowMeTheCode.md) is the two-minute look at what Brighter and
+Darker code reads like: types, attributes and calls, with nothing to install. The ladder is
+for building something that runs. If you are evaluating Brighter, start with *Show me the
+code!*; if you have decided to use it, start at rung 1.
+
+## Where to Go After the Ladder
+
+The ladder teaches by building, and it deliberately takes the shortest path through every
+choice. When you want the choices themselves:
+
+- **Configure it properly.** [Basic Configuration](/contents/BrighterBasicConfiguration.md)
+  covers what `AddBrighter()`, `AddProducers()` and `AddConsumers()` accept beyond the
+  defaults these pages used, and each transport has its own reference page —
+  [RabbitMQ](/contents/RabbitMQConfiguration.md) is the one rung 2 configured.
+- **Understand why it works that way.** [The Task Queue Pattern](/contents/TaskQueuePattern.md)
+  and [Outbox Pattern Support](/contents/OutboxPattern.md) explain the two patterns rungs 2
+  and 3 built, and [Reactor and Proactor](/contents/ReactorAndProactor.md) explains the
+  concurrency model behind the [message pump](/contents/Glossary.md#message-pump).
+- **Take it to production.** [Brighter Outbox Support](/contents/BrighterOutboxSupport.md) and
+  [Transactional Messaging with the Outbox](/contents/TransactionalMessagingWithTheOutbox.md)
+  pick up where rung 3 stops, with an Inbox on the consuming side.
+- **Query the other side.** Darker is Brighter's query half —
+  [CQRS with Brighter and Darker](/contents/CQRSWithBrighterAndDarker.md) is where that story
+  starts.
+
+## Further Reading
+
+- [Why Brighter?](/contents/WhyBrighter.md) — the case for the framework, before any code
+- [Basic Concepts](/contents/BasicConcepts.md) — commands, events and requests, defined in one
+  place
+- [Glossary](/contents/Glossary.md) — every term these tutorials link, and the rest
+- [FAQ](/contents/FAQ.md) — the questions that come up once the ladder is behind you

--- a/contents/TutorialFirstCommand.md
+++ b/contents/TutorialFirstCommand.md
@@ -207,7 +207,8 @@ did that work, and all three scale up unchanged:
   handler — and runs it. Attributes decide what goes into it.
 
 What you have not got yet is durability or another process. Nothing left this application,
-so nothing survived it. That is the next rung, which sends the same shape of request over
+so nothing survived it. That is
+[the next rung](/contents/TutorialFirstMessage.md), which sends the same shape of request over
 RabbitMQ to a consumer running separately.
 
 ## Further Reading

--- a/contents/TutorialFirstMessage.md
+++ b/contents/TutorialFirstMessage.md
@@ -421,8 +421,8 @@ The handler did not change in any way that matters, and it now runs in another p
 
 What you still do not have is durability. The message existed only in RabbitMQ: if the sender
 had crashed between writing its data and publishing, the two would have disagreed permanently.
-The next rung puts an Outbox in the same transaction as your business data, so the message is
-either stored with it or not at all.
+[The next rung](/contents/TutorialDurableOutbox.md) puts an Outbox in the same transaction as
+your business data, so the message is either stored with it or not at all.
 
 ## Further Reading
 

--- a/spec/009-getting_started_tutorials/tasks.md
+++ b/spec/009-getting_started_tutorials/tasks.md
@@ -7,13 +7,14 @@ moved. See § *Re-derive the total* and Task 3.5.
 applied) and `requirements.md` (approved 2026-08-03)
 **Executes against:** a corpus that **Spec 010 moved after this spec was approved** — see §2.
 
-**Total tasks: 39, across 12 phases. 28 done — Phases 1, 2 and 3 complete 2026-08-24;
-Phases 4, 5 and 6 complete 2026-08-25; Phases 7 and 8 complete 2026-08-26.**
-Re-derived, not incremented: `grep -c '^- \[x\] \*\*Task'` says 28 and `'^- \[ \] \*\*Task'`
-says 11. The phase table's Tasks column still sums to **39** independently.
+**Total tasks: 39, across 12 phases. 30 done — Phases 1, 2 and 3 complete 2026-08-24;
+Phases 4, 5 and 6 complete 2026-08-25; Phases 7, 8 and 9 complete 2026-08-26.**
+Re-derived, not incremented: `grep -c '^- \[x\] \*\*Task'` says 30 and `'^- \[ \] \*\*Task'`
+says 9. The phase table's Tasks column still sums to **39** independently.
 
-**Phase 7's three boxes are ticked here, in Phase 8's PR, and that is the pattern**: a tick is
-a Docs commit, and Phase 7 was a Brighter PR that could not carry one.
+**Phase 7's three boxes were ticked in Phase 8's PR, and that is the pattern**: a tick is
+a Docs commit, and Phase 7 was a Brighter PR that could not carry one. **Phase 10's will be
+ticked in Phase 11's**, for the same reason.
 
 ---
 
@@ -1227,7 +1228,7 @@ link), Phase 7 (AC4).
 exists; if Kafka slips, it lists three rungs and the ladder still stands, which is why the
 numbering lives in the display text and not in the file names.
 
-- [ ] **Task 9.1:** Write `contents/GetStarted.md`
+- [x] **Task 9.1:** Write `contents/GetStarted.md` — **DONE 2026-08-26**
   - Input: design § D10 outline
   - Output: `contents/GetStarted.md`, ~90 lines
   - Notes: the four sections are *The Ladder* (rung, what you add, time, needs Docker), *What
@@ -1236,13 +1237,69 @@ numbering lives in the display text and not in the file names.
     sentence** lives in the third: the ladder is for building something,
     `ShowMeTheCode.md` is the two-minute look at what Brighter code reads like. Times come
     from the measured runs of Tasks 3.4, 6.3 and 8.3 — not from design's estimates.
+  - **As shipped: 95 lines, four sections plus *Further Reading*, three rungs.** The first
+    estimate in this spec that did not overshoot — rungs 2 and 3 overshot because AC3 obliges
+    them to carry a sample verbatim, and this page carries no sample.
+  - **The times come from the three pages, which is where the measurements landed**, not from
+    this document: 10 / 20 / 25 minutes reader-facing, and **11s, 23s, 9.2s + 1.3s** of machine
+    work, each quoted from the rung's own *Before You Start*. So the landing page and the rung
+    cannot disagree without one of them being edited.
+  - **Port 9092 is not listed, and that is this phase's must-not being honoured rather than an
+    omission.** The task note above was written when four rungs were assumed; 9092 is Kafka's
+    port and Kafka has not shipped. *What You Need Installed* names **5672/15672** (rung 2) and
+    **5432** (rung 3), and Docker for **rungs 2 and 3**, not 2–4.
+  - **The page pins a version, and it has to.** `versioncheck.py`'s `TUTORIAL_PAGES` lists
+    `contents/GetStarted.md` (Phase 4 put it there), and **a listed page that exists and pins
+    nothing is exit 1** — so a landing page with no `dotnet add package` line would have gone
+    red the moment it was created. Found by reading the tool before writing the page rather
+    than by the gate afterwards. It carries one line,
+    `dotnet add package Paramore.Brighter --version 10.7.0`, presented as the shape every
+    `Paramore.Brighter*` line on the ladder takes — which is true and is worth a reader
+    knowing. **The pin was re-derived at writing time**, not carried: NuGet's highest
+    non-prerelease for `paramore.brighter` is **10.7.0** (123 versions), and
+    `…extensions.dependencyinjection` agrees.
+  - **Design's `## Just Want to See the Code?` shipped as `## Just Want to See Brighter
+    Code?`** — the outline's heading is unique but unattributable in a retrieval chunk, which
+    is exactly what heading qualification exists to prevent. The other three are
+    `## The Brighter Tutorial Ladder`, `## What You Need Installed for the Ladder` and
+    `## Where to Go After the Ladder`.
+  - **The upward links Phase 3 deferred to this phase are in.** Rung 1's closing paragraph now
+    links *the next rung* to `TutorialFirstMessage.md`, and rung 2's to
+    `TutorialDurableOutbox.md`. **Rung 3's closing paragraph still names Kafka without linking
+    it**, because rung 4 does not exist — the same rule pointing the same way, and Phase 11
+    inherits that one link.
+  - **The page type is `Tutorial`, per approved design, and the confidence in `pagetypes.tsv`
+    is `medium` rather than `high`.** It is a front door rather than something you build, and
+    `Reference` is arguable; it is typed with the ladder it opens. Recorded here so the
+    judgement is visible rather than implied by a green build.
 
-- [ ] **Task 9.2:** Execute §2.1's `SUMMARY.md` block and append the row
+- [x] **Task 9.2:** Execute §2.1's `SUMMARY.md` block and append the row — **DONE 2026-08-26**
   - Input: §2.1
   - Output: `## Get Started` holding the ladder above the three orientation pages; one
     appended `pagetypes.tsv` row
   - Notes: re-ordering inside a section moves no URL (§2.1), so `--check-redirects` should be
     unchanged at 77 entries — assert that rather than assuming it. S2 goes 3 → 8 of 12.
+  - **One entry was added, not five.** §2.1's block is the finished section; rungs 1, 2 and 3
+    joined it in Phases 3, 6 and 8, so this task contributed
+    `* [Get Started with Brighter](/contents/GetStarted.md)` at the top and nothing else. Rung
+    4's line is Task 11.2's.
+  - **S2 goes 6 → 7 of 12, not 3 → 8**, and both figures are right about different moments:
+    §2.1 measured the section before Phase 3 and counted the finished ladder including Kafka.
+    The widest section is still **10 of 12** and unchanged. *(This is the programme's "a total
+    needs a ref" arriving in the smallest possible way — §2.1's 3 is stamped 2026-08-23.)*
+  - **`--check-redirects` is unchanged at 77 entries and 7858 bytes**, asserted rather than
+    assumed, which is §2.1's "re-ordering inside a section moves no URL" holding for a fourth
+    time.
+  - **`pagetypes.tsv` goes 145 → 146 rows, appended rather than re-sorted.** `PROMPT.md` says
+    144; it is stamped before rung 3 shipped and is right about that moment. Re-derived here
+    with `awk 'NR>1' | wc -l` rather than incremented.
+  - **Four gates moved and two did not.** linkcheck 148 → **149 files**, pagelint 146 → **147
+    pages**, `--check-shape` 145 → **146 pages**, `versioncheck.py` **15 pins across 3 pages →
+    16 across 4**. Unmoved: `--check-redirects` at 77, and the **790 using-directive warnings**
+    — the page's one fenced block is `bash`, so it adds no debt. `--changed origin/master`
+    reports **5 files, 5 hunks, 3 pages, 1 code block strict**: non-vacuous, and exit 0.
+  - **Predicted publication path, with the tool rather than by guessing:**
+    `get-started/getstarted`.
 
 ---
 

--- a/spec/011-authoring_conventions/pagetypes.tsv
+++ b/spec/011-authoring_conventions/pagetypes.tsv
@@ -144,3 +144,4 @@ contents/ConfiguringOpenTelemetry.md	How-to	high	"split from Telemetry.md (spec 
 contents/TutorialFirstCommand.md	Tutorial	high	"spec 009 D1, rung 1; tutorial by construction — one path, numbered steps, measured run"	Tutorial	Brighter V10
 contents/TutorialFirstMessage.md	Tutorial	high	"spec 009 D2, rung 2; tutorial by construction — one path, numbered steps, measured two-terminal run"	Tutorial	Brighter V10
 contents/TutorialDurableOutbox.md	Tutorial	high	"spec 009 D3, rung 3; tutorial by construction — one path, numbered steps, measured happy-path and failure-path runs"	Tutorial	Brighter V10
+contents/GetStarted.md	Tutorial	medium	"spec 009 D10, the ladder's landing page; not itself a build, but the entry point to the three tutorials and typed with them"	Tutorial	Brighter V10


### PR DESCRIPTION
**Spec 009, Phase 9 — D10.** `contents/GetStarted.md`, the front door to the tutorial ladder. A Docs-only PR; nothing was written to `../Brighter`.

## What is here

- **`contents/GetStarted.md`, 95 lines** — *The Brighter Tutorial Ladder* (a table of rung / what you add / time / needs Docker), *What You Need Installed for the Ladder*, *Just Want to See Brighter Code?* (the two-front-doors sentence), *Where to Go After the Ladder*, and *Further Reading*.
- **One `SUMMARY.md` entry** at the top of the existing `## Get Started` section, per tasks §2.1. Rungs 1–3 joined that section in Phases 3, 6 and 8; rung 4's line belongs to Task 11.2.
- **One appended `pagetypes.tsv` row**, `Tutorial` / `medium`.
- **The upward links Phase 3 deferred to this phase**: rung 1's closing paragraph now links rung 2, and rung 2's links rung 3.

## Three things worth reading the diff for

**It lists three rungs, and port 9092 is absent.** Task 9.1's note names Docker for "rungs 2–4" and ports "5672/15672, 5432, 9092" — written when four rungs were assumed. The phase's own must-not is *do not list a rung that has not shipped*, so the page names Docker for rungs 2 and 3, and 5672/15672 and 5432.

**The page had to carry a version pin, and the tool is why.** `versioncheck.py`'s `TUTORIAL_PAGES` has listed `contents/GetStarted.md` since Phase 4, and a listed page that exists and pins nothing is **exit 1** — a landing page with no `dotnet add package` line would have gone red the moment it was created. Found by reading the tool before writing the page rather than by the gate afterwards. It carries one line, presented as the shape every `Paramore.Brighter*` line on the ladder takes. **10.7.0 was re-derived from NuGet at writing time**, not carried from a neighbouring page.

**The times come from the pages, not from design.** 10 / 20 / 25 minutes reader-facing and **11s, 23s, 9.2s + 1.3s** of machine work, each quoted from that rung's own *Before You Start* — the measured runs of Tasks 3.4, 6.3 and 8.3. Landing page and rung page cannot drift without one of them being edited.

## Gates

| Gate | Before | After |
|---|---|---|
| `linkcheck.py` | 148 files | **149 files**, no broken links |
| `pagelint.py` | 146 pages | **147 pages**, 0 errors, **790 warnings — unmoved** |
| `pagelint.py --changed origin/master` | — | 5 files, 5 hunks, 3 pages, **1 code block strict**, exit 0 |
| `urlmap.py --check-shape` | 145 pages | **146 pages**, widest still 10 of 12 |
| `urlmap.py --check-redirects` | 77 entries | **77 entries — unchanged** |
| `versioncheck.py` | 15 pins / 3 pages | **16 pins / 4 pages**, 0 stale |

The unchanged redirects figure is §2.1's *"re-ordering inside a section moves no URL"* asserted rather than assumed, for the fourth time. The unchanged warning count is because the page's one fenced block is `bash`: it adds nothing to the using-directive debt.

**Predicted publication path, with `urlmap.py` rather than by guessing:** `get-started/getstarted`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)