### PR TITLE
spec: 009 Phase 11 — rung 4's page, and the three things the ladder owed once it shipped

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -4,6 +4,7 @@
 * [1. Your First Command](/contents/TutorialFirstCommand.md)
 * [2. Your First Message Over a Broker](/contents/TutorialFirstMessage.md)
 * [3. Adding a Durable Outbox](/contents/TutorialDurableOutbox.md)
+* [4. Streaming with Kafka](/contents/TutorialStreamingWithKafka.md)
 * [Why Brighter?](/contents/WhyBrighter.md)
 * [Basic Concepts](/contents/BasicConcepts.md)
 * [Show me the code!](/contents/ShowMeTheCode.md)

--- a/contents/GetStarted.md
+++ b/contents/GetStarted.md
@@ -1,5 +1,5 @@
 ---
-description: "Brighter's tutorials are a ladder: three rungs, each one a working application, each one adding a single capability to the rung below it."
+description: "Brighter's tutorials are a ladder: four rungs, each one a working application, each one adding a single capability to the rung below it."
 layout:
   description:
     visible: false
@@ -9,10 +9,10 @@ layout:
 
 > **Tutorial** · Applies to **Brighter V10**
 
-Brighter's tutorials are a ladder: three rungs, each one a working application, each one adding
+Brighter's tutorials are a ladder: four rungs, each one a working application, each one adding
 a single capability to the rung below it. You start with a request dispatched to a handler
-inside one process, and finish with a message written to a database transaction and delivered
-after that transaction commits. Every rung runs, and every rung is code the next one builds on.
+inside one process, and finish with a partitioned Kafka stream shared out across two copies of
+the same consumer. Every rung runs, and every rung is code another one builds on.
 
 ## The Brighter Tutorial Ladder
 
@@ -21,12 +21,14 @@ after that transaction commits. Every rung runs, and every rung is code the next
 | [1. Your First Command](/contents/TutorialFirstCommand.md) | a [command](/contents/Glossary.md#command), a [handler](/contents/Glossary.md#handler), and the [Command Processor](/contents/Glossary.md#command-processor) that connects them | 10 minutes | no |
 | [2. Your First Message Over a Broker](/contents/TutorialFirstMessage.md) | a second process, RabbitMQ between the two, and an [event](/contents/Glossary.md#event) that crosses it | 20 minutes | RabbitMQ |
 | [3. Adding a Durable Outbox](/contents/TutorialDurableOutbox.md) | Postgres, one transaction covering your data *and* the message, and the [Sweeper](/contents/Glossary.md#sweeper) that dispatches it afterwards | 25 minutes | RabbitMQ and Postgres |
+| [4. Streaming with Kafka](/contents/TutorialStreamingWithKafka.md) | Kafka in place of RabbitMQ, a topic split into [partitions](/contents/Glossary.md#partition), and a [consumer group](/contents/Glossary.md#consumer-group) that divides them between two processes | 30 minutes | Kafka |
 
 Those times are mostly reading and typing. The machine work — creating projects, restoring
 packages, building — was measured on a clean machine with an empty NuGet package cache at
-**11 seconds** for rung 1, **23 seconds** for rung 2, and **9.2 seconds** to add rung 3's
-packages plus **1.3 seconds** to build. Pulling the Docker images the first time takes longer
-and depends on your connection.
+**11 seconds** for rung 1, **23 seconds** for rung 2, **9.2 seconds** to add rung 3's packages
+plus **1.3 seconds** to build, and **5.2 seconds** to swap rung 4's package plus **3.1 seconds**
+to build. Pulling the Docker images the first time takes longer and depends on your
+connection.
 
 The rungs join up like this:
 
@@ -35,17 +37,22 @@ The rungs join up like this:
   receiver.
 - **Rung 3 keeps rung 2's solution** and changes only the sender. If you intend to do rung 3,
   do not delete rung 2's work.
+- **Rung 4 branches from rung 2 as well, not from rung 3.** A durable Outbox and a partitioned
+  transport are independent choices, so rung 4 swaps rung 2's broker and leaves its plain `Post`
+  alone. Because rung 3 edits rung 2's sender in place, copy that solution aside before you
+  start rung 4 — or rebuild its three projects.
 
 Start at rung 1. If you already know how a request reaches a handler, rung 2 is the first one
-with a broker in it — but it assumes rung 1's vocabulary rather than repeating it.
+with a broker in it — but it assumes rung 1's vocabulary rather than repeating it. Rungs 3 and 4
+can be taken in either order.
 
 ## What You Need Installed for the Ladder
 
 - **The .NET 9 SDK.** Check with `dotnet --version`.
-- **Docker Desktop**, for rungs 2 and 3 only. Rung 1 is deliberately in-process.
-- **Free ports**: **5672** and **15672** for RabbitMQ on rung 2, and **5432** for Postgres on
-  rung 3. If something else is already listening, the container starts and your application
-  does not connect.
+- **Docker Desktop**, for rungs 2, 3 and 4. Rung 1 is deliberately in-process.
+- **Free ports**: **5672** and **15672** for RabbitMQ on rungs 2 and 3, **5432** for Postgres on
+  rung 3, and **9092** for Kafka on rung 4. If something else is already listening, the
+  container starts and your application does not connect.
 
 Every `Paramore.Brighter*` package these pages install is pinned to the same version, so every
 `dotnet add package` line you will meet has this shape:
@@ -74,11 +81,13 @@ choice. When you want the choices themselves:
 - **Configure it properly.** [Basic Configuration](/contents/BrighterBasicConfiguration.md)
   covers what `AddBrighter()`, `AddProducers()` and `AddConsumers()` accept beyond the
   defaults these pages used, and each transport has its own reference page —
-  [RabbitMQ](/contents/RabbitMQConfiguration.md) is the one rung 2 configured.
+  [RabbitMQ](/contents/RabbitMQConfiguration.md) and
+  [Kafka](/contents/KafkaConfiguration.md) are the two the ladder configured.
 - **Understand why it works that way.** [The Task Queue Pattern](/contents/TaskQueuePattern.md)
   and [Outbox Pattern Support](/contents/OutboxPattern.md) explain the two patterns rungs 2
   and 3 built, and [Reactor and Proactor](/contents/ReactorAndProactor.md) explains the
-  concurrency model behind the [message pump](/contents/Glossary.md#message-pump).
+  concurrency model behind the [message pump](/contents/Glossary.md#message-pump) that rung 4
+  leans on for its ordering.
 - **Take it to production.** [Brighter Outbox Support](/contents/BrighterOutboxSupport.md) and
   [Transactional Messaging with the Outbox](/contents/TransactionalMessagingWithTheOutbox.md)
   pick up where rung 3 stops, with an Inbox on the consuming side.

--- a/contents/TutorialDurableOutbox.md
+++ b/contents/TutorialDurableOutbox.md
@@ -637,7 +637,8 @@ Your handler gained a transaction and one extra write. The system gained a guara
 - **Brighter owns one table and you own the other.** Provisioning creates the Outbox; `Greeting`
   was yours to create, and your schema stays yours.
 
-The next rung changes the transport rather than the guarantee: Kafka, where messages are
+The next rung changes the transport rather than the guarantee:
+[Streaming with Kafka](/contents/TutorialStreamingWithKafka.md), where messages are
 partitioned, consumers form a group, and ordering is something you get per key rather than
 per topic.
 

--- a/contents/TutorialStreamingWithKafka.md
+++ b/contents/TutorialStreamingWithKafka.md
@@ -1,0 +1,587 @@
+---
+description: "Send the same greeting over a three-partition Kafka topic, then start a second copy of the receiver and watch Kafka hand it half the partitions."
+layout:
+  description:
+    visible: false
+---
+
+# Streaming with Kafka
+
+> **Tutorial** · Applies to **Brighter V10** · Prerequisites: [Your First Message Over a Broker](/contents/TutorialFirstMessage.md), [Adding a Durable Outbox](/contents/TutorialDurableOutbox.md)
+
+Send the same greeting over a three-partition Kafka topic, then start a second copy of the
+receiver and watch Kafka hand it half the [partitions](/contents/Glossary.md#partition).
+
+This is the fourth and last rung of the ladder. Rungs 2 and 3 kept one queue and one reader.
+Kafka splits a topic into partitions, and a group of readers divides those partitions between
+them — so scaling out is starting the same process again, changing nothing. What you give up is
+a single global order, and what you get back is order *per key*, which is usually the order you
+actually wanted.
+
+**Rung 4 branches from rung 2, not from rung 3.** The durable Outbox and the Kafka transport are
+independent choices, and this rung changes the transport while keeping rung 2's plain `Post`.
+
+## What You'll Build: A Partitioned Kafka Stream
+
+Rung 2's three projects with the transport swapped, and nothing else moved:
+
+| What | Change from rung 2 |
+|---|---|
+| `Greetings` | unchanged |
+| `GreetingsReceiver` | the [subscription](/contents/Glossary.md#subscription) becomes a `KafkaSubscription`, with a group id. The [handler](/contents/Glossary.md#handler) is untouched |
+| `GreetingsSender` | the [publication](/contents/Glossary.md#publication) becomes a `KafkaPublication` with three partitions, and each greeting carries a [partition key](/contents/Glossary.md#partition-key) |
+
+The sender publishes nine greetings — three each for `alice`, `grace` and `mia`, interleaved.
+The receiver prints them **grouped by recipient rather than in the order they were sent.** Then
+you start a second receiver, watch the group rebalance, and send the nine again to see each
+recipient's greetings stay in sequence on whichever consumer now owns them.
+
+## Before You Start Streaming with Kafka
+
+- **Rungs 2 and 3 complete.** [Your First Message Over a
+  Broker](/contents/TutorialFirstMessage.md) builds the three projects, and [Adding a Durable
+  Outbox](/contents/TutorialDurableOutbox.md) is the guarantee this rung leaves alone.
+- **Start from a copy of rung 2.** Rung 3 changed rung 2's sender in place, so if you worked
+  through it in the same folder, copy your rung 2 solution aside — or rebuild those three
+  projects — before making the changes below. Nothing here builds on rung 3's Outbox.
+- **The .NET 9 SDK.** Check with `dotnet --version`.
+- **Docker Desktop**, running, with port **9092** free. RabbitMQ and Postgres are not needed;
+  you can stop them.
+- **About thirty minutes**, most of it reading and waiting for a rebalance. The machine work
+  measured **5.2 seconds** to swap the package on both projects and **3.1 seconds** to build,
+  starting from a rung 2 solution and a NuGet cache holding only rung 2's packages. Pulling the
+  Kafka image the first time takes longer and depends on your connection.
+
+## Step 1: Start Kafka
+
+Put this in `docker-compose-kafka.yml` beside your solution:
+
+```yaml
+services:
+  kafka:
+    image: apache/kafka:4.0.2
+    hostname: kafka
+    container_name: kafka
+    ports:
+      - "9092:9092"
+    environment:
+      KAFKA_NODE_ID: 1
+      KAFKA_PROCESS_ROLES: broker,controller
+      KAFKA_CONTROLLER_QUORUM_VOTERS: 1@kafka:29093
+      CLUSTER_ID: 'MkU3OEVBNTcwNTJENDM2Qk'
+      KAFKA_LISTENERS: PLAINTEXT://0.0.0.0:29092,PLAINTEXT_HOST://0.0.0.0:9092,CONTROLLER://0.0.0.0:29093
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:29092,PLAINTEXT_HOST://localhost:9092
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT,CONTROLLER:PLAINTEXT
+      KAFKA_CONTROLLER_LISTENER_NAMES: CONTROLLER
+      KAFKA_AUTO_CREATE_TOPICS_ENABLE: "false"
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+      KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
+```
+
+```bash
+docker compose -f docker-compose-kafka.yml up -d
+```
+
+This is a single broker running in **KRaft** mode — no ZooKeeper. One broker is enough to learn
+partitions and consumer groups on, because both are properties of a *topic* rather than of the
+cluster.
+
+`KAFKA_AUTO_CREATE_TOPICS_ENABLE: "false"` is deliberate. With it on, a typo in a topic name
+silently creates a new topic with the broker's default partition count, and you spend an
+afternoon wondering why nothing arrives.
+
+As in rung 2, the command returns before the broker is accepting connections. It is ready when
+this stops failing:
+
+```bash
+docker exec kafka /opt/kafka/bin/kafka-broker-api-versions.sh --bootstrap-server localhost:9092
+```
+
+## Step 2: Swap the Transport
+
+Both processes talk to the broker, so both change. Remove RabbitMQ and add Kafka:
+
+```bash
+dotnet remove GreetingsSender package Paramore.Brighter.MessagingGateway.RMQ.Async
+dotnet remove GreetingsReceiver package Paramore.Brighter.MessagingGateway.RMQ.Async
+dotnet add GreetingsSender package Paramore.Brighter.MessagingGateway.Kafka --version 10.7.0
+dotnet add GreetingsReceiver package Paramore.Brighter.MessagingGateway.Kafka --version 10.7.0
+```
+
+That is the entire package change. `Paramore.Brighter`,
+`Paramore.Brighter.Extensions.DependencyInjection` and the two
+`Paramore.Brighter.ServiceActivator.*` packages are rung 2's and stay exactly as they were —
+which is the point worth noticing: **a transport is a package, not an architecture.** The
+[Command Processor](/contents/Glossary.md#command-processor), the handler and the event do not
+know which broker they are running over.
+
+Your `.csproj` files show `PackageReference` with a pinned version. The sample in the Brighter
+repository uses `ProjectReference` into the source tree instead, which is the one place page and
+sample differ on purpose.
+
+## Step 3: Send with a Partition Key
+
+Replace `GreetingsSender/Program.cs` with this:
+
+```csharp
+using System;
+using Greetings;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Paramore.Brighter;
+using Paramore.Brighter.Extensions.DependencyInjection;
+using Paramore.Brighter.MessagingGateway.Kafka;
+
+// Kafka is reached through a bootstrap server list rather than a single connection string.
+// The client asks any broker in the list for the cluster's real topology, so one entry is
+// enough to learn on; a production cluster names several so that startup survives one being
+// down.
+var kafkaConfiguration = new KafkaMessagingGatewayConfiguration
+{
+    Name = "greetings.sender",
+    BootStrapServers = ["localhost:9092"]
+};
+
+// A publication tells Brighter where a request type goes: which topic, on which broker.
+// NumPartitions is the delta from rung 2. A RabbitMQ queue is one ordered stream; a Kafka
+// topic is NumPartitions of them, and that is what gives a consumer group something to
+// share out. OnMissingChannel.Create means the sender creates the topic if it is missing, with
+// this many partitions.
+//
+// Two defaults are doing quiet work here, and the ordering this rung teaches depends on both:
+// EnableIdempotence is true and MaxInFlightRequestsPerConnection is 1. Without them a retry
+// could reorder messages *within* a partition, and no amount of careful keying would help.
+// Acquiring the idempotence id is also what logs "Failed to acquire idempotence PID ...
+// retrying" if you start the sender before the broker has finished booting.
+//
+// Naming GreetingEvent here is also what loads the Greetings assembly, which matters below:
+// AutoFromAssemblies scans the assemblies loaded so far, so anything it must find has to have
+// been touched before the call. Reordering this below the registration is a silent no-op.
+var producerRegistry = new KafkaProducerRegistryFactory(
+    kafkaConfiguration,
+    [
+        new KafkaPublication<GreetingEvent>
+        {
+            Topic = new RoutingKey("greeting.event"),
+            NumPartitions = 3,
+            MakeChannels = OnMissingChannel.Create
+        }
+    ]).Create();
+
+var builder = Host.CreateApplicationBuilder(args);
+
+builder.Services
+    .AddBrighter()
+    .AddProducers(configure => configure.ProducerRegistry = producerRegistry)
+    .AutoFromAssemblies();
+
+// Three recipients, three greetings each, sent round-robin so that the three streams are
+// interleaved on the wire.
+//
+// These three names are not arbitrary. Kafka picks the partition by hashing the key, so you
+// do not get to choose it, and with three keys over three partitions there is only a 2-in-9
+// chance that they land one apiece. The first three names this sample tried, "alice", "bob"
+// and "carol", all hashed to the same partition — which a single consumer hides completely,
+// because it drains all three partitions and everything still arrives in order.
+//
+// These three were checked against the broker rather than calculated. The hash is
+// crc32(key) % partition-count for librdkafka, which the Confluent .NET client wraps; the
+// Java client uses murmur2 and would scatter the same three names differently. So the 2/0/1
+// mapping below holds for this client at exactly three partitions and nowhere else.
+string[] recipients = ["alice", "grace", "mia"];
+const int greetingsPerRecipient = 3;
+
+// The host is built but never run: Post is synchronous, so all we need from it is the
+// container. Rung 3 does run the host, because it hosts the Outbox Sweeper.
+using (var host = builder.Build())
+{
+    var commandProcessor = host.Services.GetRequiredService<IAmACommandProcessor>();
+
+    for (var i = 1; i <= greetingsPerRecipient; i++)
+    {
+        foreach (var recipient in recipients)
+        {
+            // The partition key is how you choose a partition, and the partition is the only
+            // thing Kafka orders. Keying on the recipient sends every one of alice's greetings
+            // to the same partition, so they arrive in the order they were sent — while grace's
+            // and mia's are free to be handled on other partitions.
+            //
+            // No message mapper is needed for this. JsonMessageMapper<T> is Brighter's
+            // registered default for both the sync and the async path, and it already reads
+            // the key out of the request context onto the message header.
+            var context = new RequestContext();
+            context.Bag[RequestContextBagNames.PartitionKey] = recipient;
+
+            commandProcessor.Post(new GreetingEvent($"Hello {recipient} #{i}"), context);
+        }
+    }
+}
+// Delivery to Kafka is asynchronous: Post hands the message to the producer's send queue and
+// returns, and the broker's acknowledgement arrives on a delivery report later. Disposing the
+// host flushes that queue and waits for the reports, which is why this line sits after the
+// brace rather than inside the loop.
+Console.WriteLine($"Published {recipients.Length * greetingsPerRecipient} greetings to greeting.event");
+```
+
+Three things changed from rung 2's sender, and one thing deliberately did not.
+
+**`NumPartitions = 3`.** A RabbitMQ queue is a single ordered stream. A Kafka topic is
+`NumPartitions` of them, and that is what gives a group of consumers something to divide. The
+topic is created with this many partitions the first time a process reaches a broker that does
+not have it.
+
+**A partition key on every message.** Kafka orders messages *within* a partition and promises
+nothing across partitions, so the key is how you decide what shares an order with what. Keying
+on the recipient means all of alice's greetings go to one partition and stay in sequence, while
+grace's and mia's are free to be handled elsewhere.
+
+**No message mapper.** `KafkaTaskQueue`, Brighter's reference Kafka sample, writes one in order
+to set the partition key — but it does not have to. `JsonMessageMapper<T>` is the registered
+default for both the synchronous and the asynchronous path, and it already reads the key out of
+the request context onto the message header. Setting
+`context.Bag[RequestContextBagNames.PartitionKey]` and passing the context to `Post` is all it
+takes. [Dispatching a Request](/contents/DispatchingARequest.md) covers the request context
+properly.
+
+**`Post` is unchanged.** No Outbox, no transaction — rung 3's guarantee is orthogonal to this
+one, and combining them is a decision you make per service rather than a step on this ladder.
+
+## Step 4: Consume as a Reactor
+
+Replace `GreetingsReceiver/Program.cs` with this:
+
+```csharp
+using Greetings;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Paramore.Brighter;
+using Paramore.Brighter.MessagingGateway.Kafka;
+using Paramore.Brighter.ServiceActivator.Extensions.DependencyInjection;
+using Paramore.Brighter.ServiceActivator.Extensions.Hosting;
+
+var kafkaConfiguration = new KafkaMessagingGatewayConfiguration
+{
+    Name = "greetings.receiver",
+    BootStrapServers = ["localhost:9092"]
+};
+
+// groupId is the delta from rung 2, and it is what makes a second copy of this process
+// interesting rather than redundant. Every instance sharing a group id is one member of one
+// consumer group, and Kafka gives each member a disjoint set of partitions: run one instance
+// and it holds all three, start a second and Kafka rebalances the group so they hold roughly
+// half each. Two instances with *different* group ids would each get all three and both would
+// see every greeting.
+//
+// messagePumpType is KafkaSubscription<T>'s own default — note the generic; the non-generic
+// KafkaSubscription defaults to MessagePumpType.Unknown. It is written out anyway, because it
+// is the point of this rung.
+// A Reactor pump is a single thread per performer, and noOfPerformers defaults to 1 — so one
+// instance is one member with one thread, draining its partitions in turn. That single thread
+// is why per-key ordering holds; it is not that Brighter runs a pump per partition.
+//
+// numOfPartitions matches the publication so that whichever process reaches an empty broker
+// first creates the same three-partition topic. Keep the two in step if you change either:
+// when the topic already exists and does not match, Brighter logs "topic is misconfigured =>
+// NumPartitions should be ..." as a *warning* and carries on, so raising one side alone gives
+// you a puzzling half-working sample rather than an error.
+var subscriptions = new Subscription[]
+{
+    new KafkaSubscription<GreetingEvent>(
+        new SubscriptionName("greeting.subscription"),
+        new ChannelName("greeting.event"),
+        new RoutingKey("greeting.event"),
+        groupId: "greeting.readers",
+        numOfPartitions: 3,
+        messagePumpType: MessagePumpType.Reactor,
+        makeChannels: OnMissingChannel.Create)
+};
+
+var builder = Host.CreateApplicationBuilder(args);
+
+builder.Services
+    .AddConsumers(options =>
+    {
+        options.Subscriptions = subscriptions;
+        options.DefaultChannelFactory = new ChannelFactory(new KafkaMessageConsumerFactory(kafkaConfiguration));
+    })
+    .AutoFromAssemblies();
+
+builder.Services.AddHostedService<ServiceActivatorHostedService>();
+
+var host = builder.Build();
+
+await host.RunAsync();
+```
+
+**`groupId` is the delta that matters.** Every instance sharing a group id is one member of one
+[consumer group](/contents/Glossary.md#consumer-group), and Kafka guarantees each member a
+disjoint set of partitions. That is what makes starting a second copy of this process
+*useful* rather than duplicative — two instances with different group ids would each receive
+every greeting.
+
+**The pump runs as a [Reactor](/contents/Glossary.md#reactor)**, which is
+`KafkaSubscription<T>`'s own default and is written out because it is this rung's point. A
+Reactor is a single thread per performer, and `noOfPerformers` defaults to 1 — so one running
+process is one group member with one thread, draining its partitions in turn.
+
+**That single thread is why per-key ordering holds.** It is not that Brighter runs a
+[message pump](/contents/Glossary.md#message-pump) per partition; it runs one per performer,
+and Kafka gives that member whatever partitions the group's split assigns it.
+[Reactor and Proactor](/contents/ReactorAndProactor.md) covers the choice properly, including
+what changes if you raise `noOfPerformers`.
+
+**`GreetingEventHandler.cs` does not change at all** — it is rung 2's file, byte for byte. A
+handler does not know what transport delivered its message, and that is the whole benefit of
+having one.
+
+## Step 5: Watch One Consumer Take All Three Partitions
+
+Start the receiver:
+
+```bash
+dotnet run --project GreetingsReceiver
+```
+
+Among its startup logging, one line is the one to watch:
+
+```text
+Partition Added greeting.event : 0,greeting.event : 1,greeting.event : 2
+```
+
+**One member gets every partition.** The group has one instance, so the split is trivial — but
+it is the same mechanism that will divide them in step 6.
+
+Now, in a second terminal:
+
+```bash
+dotnet run --project GreetingsSender
+```
+
+```text
+Published 9 greetings to greeting.event
+```
+
+And the receiver prints:
+
+```text
+Received: Hello alice #1
+Received: Hello alice #2
+Received: Hello alice #3
+Received: Hello grace #1
+Received: Hello grace #2
+Received: Hello grace #3
+Received: Hello mia #1
+Received: Hello mia #2
+Received: Hello mia #3
+```
+
+**Read that carefully, because it is not the order they were sent.** The sender interleaved the
+recipients — alice #1, grace #1, mia #1, alice #2, and so on — and they came back grouped. One
+consumer, one thread, and still the order changed.
+
+That is partitions doing exactly what they promise. The single thread drains one partition at a
+time, and each partition holds one recipient's greetings. **There is no global order to
+preserve, and Kafka never claimed there was.** What survived is each recipient's own sequence.
+
+You can see where the keys landed by reading the topic directly:
+
+```bash
+docker exec kafka /opt/kafka/bin/kafka-console-consumer.sh \
+  --bootstrap-server localhost:9092 --topic greeting.event --from-beginning \
+  --max-messages 9 --property print.partition=true --property print.key=true \
+  --property print.value=false --timeout-ms 15000
+```
+
+```text
+Partition:0	grace
+Partition:0	grace
+Partition:0	grace
+Partition:1	mia
+Partition:1	mia
+Partition:1	mia
+Partition:2	alice
+Partition:2	alice
+Partition:2	alice
+```
+
+**Those three names were chosen, and the reason is a trap worth knowing about.** Kafka picks the
+partition by hashing the key, so you choose the key and the hash chooses the partition. With
+three keys over three partitions there is only a 2-in-9 chance they land one apiece — and the
+first three names this tutorial used, `alice`, `bob` and `carol`, all hashed to partition 2.
+Nothing looked wrong: one consumer holds every partition anyway, so all nine greetings arrived
+in perfect order and the code appeared to work while demonstrating nothing at all. Running the
+command above is what exposed it.
+
+## Step 6: Start a Second Instance
+
+Leave everything running and start the receiver again, in a third terminal, with no arguments
+and no configuration change:
+
+```bash
+dotnet run --project GreetingsReceiver
+```
+
+The **first** receiver logs that its partitions were taken away and which it got back:
+
+```text
+Partitions for consumer revoked greeting.event : [0],greeting.event : [1],greeting.event : [2]
+Partition Added greeting.event : 0,greeting.event : 2
+```
+
+The **second** logs what it was given:
+
+```text
+Partition Added greeting.event : 1
+```
+
+**That is a rebalance.** Kafka revoked the whole assignment and redistributed it, and the two
+sets are disjoint and cover all three partitions between them. Which instance gets which is
+Kafka's decision, not yours — run this twice and you may well see the split the other way
+round.
+
+Nothing was configured to make this happen. Scaling a Kafka consumer out is starting the process
+again; scaling it in is stopping one. The group id is the only thing that had to agree.
+
+## Step 7: Ordering Holds Per Key
+
+With both receivers running, send the nine greetings again:
+
+```bash
+dotnet run --project GreetingsSender
+```
+
+The instance holding partitions 0 and 2 prints grace's and alice's:
+
+```text
+Received: Hello grace #1
+Received: Hello grace #2
+Received: Hello grace #3
+Received: Hello alice #1
+Received: Hello alice #2
+Received: Hello alice #3
+```
+
+The instance holding partition 1 prints mia's:
+
+```text
+Received: Hello mia #1
+Received: Hello mia #2
+Received: Hello mia #3
+```
+
+**The work divided and every recipient's sequence survived.** No greeting was handled twice, no
+recipient's greetings were split across the two processes, and each one's `#1`, `#2`, `#3`
+arrived in that order on whichever consumer owned its partition.
+
+**Which recipient's block prints first may differ on your machine, and that is the point rather
+than a flaw.** The instance holding two partitions drains them in whatever order it polls them,
+so grace and alice can swap places between runs — this page has seen both. What never varies is
+the run *inside* each block. The order you are promised is the one you asked for with a key.
+
+This is the guarantee Kafka actually offers, and it is worth stating exactly: **ordering is per
+partition, and therefore per key.** If you need two events to be processed in order, give them
+the same key. If they do not share a key, you have not asked for an order and you will not get
+one — no matter how few consumers are running.
+
+Two defaults are quietly making the per-key half true, and they are worth knowing before you
+tune anything: `KafkaPublication` sets `EnableIdempotence = true` and
+`MaxInFlightRequestsPerConnection = 1`. Without them, a producer retrying a failed send could
+reorder messages within a partition, and careful keying would not save you.
+
+## Step 8: Offsets and What a Rebalance Costs You
+
+An [offset](/contents/Glossary.md#offset) is a consumer group's bookmark in a partition. Ask
+Kafka where this group has got to:
+
+```bash
+docker exec kafka /opt/kafka/bin/kafka-consumer-groups.sh \
+  --bootstrap-server localhost:9092 --describe --group greeting.readers
+```
+
+Run that immediately after the greetings are handled and the answer is surprising:
+
+```text
+TOPIC           PARTITION  CURRENT-OFFSET  LOG-END-OFFSET  LAG
+greeting.event  0          -               3               -
+greeting.event  1          -               3               -
+greeting.event  2          -               3               -
+```
+
+**Nothing is committed, although every message was handled.** Handling a message *stores* an
+offset; it does not commit one. Brighter commits on two paths, and at nine messages neither has
+run yet:
+
+- **`commitBatchSize`**, default **10** — offsets are committed in batches, and nine is not ten.
+- **`sweepUncommittedOffsetsInterval`**, default **30 seconds** — a timer that commits whatever
+  is still outstanding.
+
+Wait half a minute and ask again:
+
+```text
+greeting.event  0          2               3               1
+greeting.event  1          2               3               1
+greeting.event  2          2               3               1
+```
+
+The sweeper has committed, and each partition is left **one short**. That residual `LAG 1` is a
+Brighter defect rather than Kafka semantics, tracked as
+[#4281](https://github.com/BrighterCommand/Brighter/issues/4281); a group that has handled
+everything ought to reach `LAG 0`.
+
+**Whatever is uncommitted when a rebalance happens gets handled again.** Look back at step 6: as
+well as logging the new assignment, each receiver handled one greeting a second time — the one
+sitting at the uncommitted offset on each partition it picked up. Three greetings, one per
+partition, already handled by the instance that had them before.
+
+That is **[at-least-once](/contents/Glossary.md#at-least-once) delivery**, and it is the honest
+statement about every broker on this ladder. Rung 3's Outbox gave you at-least-once on the
+sending side; this is the same promise on the receiving side. **Nothing is lost. Some things
+arrive twice. A handler that does real work — charging a card, sending an email — has to
+tolerate seeing the same message again.**
+
+Tuning the two options above changes *how many* duplicates a rebalance costs, and cannot take it
+to zero: a rebalance can always arrive between handling a message and committing its offset.
+[Kafka Configuration](/contents/KafkaConfiguration.md) documents both, along with everything
+else `KafkaSubscription` and `KafkaPublication` expose.
+
+When you are finished:
+
+```bash
+docker compose -f docker-compose-kafka.yml down -v
+```
+
+## What Streaming with Kafka Showed You
+
+You swapped one package and gained a scaling model:
+
+- **A transport is a package.** The event, the handler and the Command Processor never learned
+  which broker they were running over. Only the publication and the subscription changed, and
+  the handler file is rung 2's byte for byte.
+- **Partitions are the unit of parallelism, and the key chooses one.** You do not pick a
+  partition; you pick a key and Kafka hashes it. Everything sharing a key shares an order.
+- **A consumer group scales by starting the process again.** Two instances, one group id, and
+  Kafka divided the partitions without either process being told about the other.
+- **Ordering is per key, not per topic — and the single-threaded Reactor pump is what delivers
+  it.** One pump per performer, one performer by default, so one member drains its partitions in
+  turn. It is not a pump per partition.
+- **Delivery is at-least-once, and a rebalance is when you notice.** Offsets commit in batches
+  or on a timer, so anything uncommitted when partitions move is handled again.
+
+That is the ladder. You have built a command and a handler, sent a message between two
+processes, made the send survive a crash, and scaled the receiving side across a partitioned
+stream. Everything after this is configuration, middleware and the shape of your own domain —
+and the rest of this documentation is organised around exactly those.
+
+## Further Reading
+
+- [Adding a Durable Outbox](/contents/TutorialDurableOutbox.md) — rung 3, if you skipped it;
+  its guarantee composes with this one
+- [Kafka Configuration](/contents/KafkaConfiguration.md) — every option on `KafkaSubscription`
+  and `KafkaPublication`, including `commitBatchSize`, the sweep interval and security
+- [Reactor and Proactor](/contents/ReactorAndProactor.md) — why the pump is single-threaded,
+  and what changes when you raise `noOfPerformers`
+- [Dispatching a Request](/contents/DispatchingARequest.md) — the request context, and the other
+  well-known keys besides the partition key
+- [Get Started with Brighter](/contents/GetStarted.md) — the ladder's front door, and where to
+  go next
+- [Glossary](/contents/Glossary.md) — every term this page linked, and the rest

--- a/spec/009-getting_started_tutorials/tasks.md
+++ b/spec/009-getting_started_tutorials/tasks.md
@@ -7,14 +7,18 @@ moved. See § *Re-derive the total* and Task 3.5.
 applied) and `requirements.md` (approved 2026-08-03)
 **Executes against:** a corpus that **Spec 010 moved after this spec was approved** — see §2.
 
-**Total tasks: 39, across 12 phases. 30 done — Phases 1, 2 and 3 complete 2026-08-24;
-Phases 4, 5 and 6 complete 2026-08-25; Phases 7, 8 and 9 complete 2026-08-26.**
-Re-derived, not incremented: `grep -c '^- \[x\] \*\*Task'` says 30 and `'^- \[ \] \*\*Task'`
-says 9. The phase table's Tasks column still sums to **39** independently.
+**Total tasks: 39, across 12 phases. 36 done — Phases 1, 2 and 3 complete 2026-08-24;
+Phases 4, 5 and 6 complete 2026-08-25; Phases 7, 8, 9, 10 and 11 complete 2026-08-26.**
+Re-derived, not incremented: `grep -c '^- \[x\] \*\*Task'` says 36 and `'^- \[ \] \*\*Task'`
+says 3. The phase table's Tasks column still sums to **39** independently.
+
+**Only Phase 12 remains** — the acceptance pass and the close.
 
 **Phase 7's three boxes were ticked in Phase 8's PR, and that is the pattern**: a tick is
-a Docs commit, and Phase 7 was a Brighter PR that could not carry one. **Phase 10's will be
-ticked in Phase 11's**, for the same reason.
+a Docs commit, and Phase 7 was a Brighter PR that could not carry one. **Phase 10's were ticked
+in Phase 11's**, for the same reason — so the six boxes in this document's Phases 10 and 11 all
+landed in one Docs commit, and the pattern is now spent: no phase after this one is a Brighter
+PR.
 
 ---
 
@@ -1107,7 +1111,10 @@ absolute database path is four forks and a manual step before the first message 
 - [x] **Task 7.2:** Register the new projects in `Brighter.slnx`
   - Input: §2.4
   - Output: the entries, under `/samples/Tutorials/`
-  - Notes: as Task 5.2. The check is presence in the solution, not in the directory.
+  - Notes: as Task 5.2.
+  - **Checked with `git ls-files`, never `find`** (§2.4): 252 tracked `.csproj`, 251 named in
+    the solution, and the single unregistered project is the pre-existing #4272 `TodoApi` —
+    a control, not a finding. The check is presence in the solution, not in the directory.
 
 - [x] **Task 7.3:** Open the PR and confirm CI builds it
   - Input: a branch off `origin/master`
@@ -1311,7 +1318,7 @@ numbering lives in the display text and not in the file names.
 which obliges **synchronous** equivalents; `KafkaTaskQueue` supplies only the `…Async` pair,
 and that widened delta is the argument for a separate sample.
 
-- [ ] **Task 10.1:** Build `samples/Tutorials/04-Kafka`
+- [x] **Task 10.1:** Build `samples/Tutorials/04-Kafka` — **DONE 2026-08-26**
   - Input: D5; `../Brighter/samples/TaskQueue/KafkaTaskQueue/`; `docker-compose-kafka.yaml`
   - Output: the sample — transport → Kafka, 3-partition topic, `PartitionKey` set on the
     producer, `groupId` on the subscription, `MessagePumpType.Reactor`, sync handler and
@@ -1319,16 +1326,45 @@ and that widened delta is the argument for a separate sample.
   - Notes: `KafkaSubscription` already defaults to `MessagePumpType.Reactor`
     (`:298`, re-verified §2.8), so the default is the teaching point rather than an override
     to explain.
+  - **As shipped: no message mapper at all, and design's D7 row is wrong about this.** The row
+    says "async handler/mapper → **sync**", a delta measured against `KafkaTaskQueue` — but D7
+    is derived from **D5**, which has neither. `JsonMessageMapper<T>` is the registered default
+    for *both* the sync and the async path
+    (`ServiceCollectionMessageMapperRegistryBuilder.cs:47-50`) and already sets
+    `partitionKey: Context.GetPartitionKey()` (`JsonMessageMapper.cs:50`), so the sender sets
+    `context.Bag[RequestContextBagNames.PartitionKey]` and passes the context to `Post`.
+    **`contents/DispatchingARequest.md:89` and `:162` already documented this route** — the
+    corpus had the answer before the sample was written, again.
+  - **Three plausible partition keys collided, and one consumer hid it completely.** `alice`,
+    `bob` and `carol` all hash to partition 2 (`crc32(key) % 3`, librdkafka's
+    `ConsistentRandom`), so all nine greetings arrived in send order and the sample looked
+    perfect while demonstrating nothing. Exposed only by asking the broker with
+    `kafka-console-consumer.sh --property print.partition=true`. **`alice`, `grace`, `mia` land
+    on 2, 0, 1**, checked against the broker rather than calculated.
+  - **Three of seven files are byte-identical to rung 2's**, asserted with `cmp`:
+    `GreetingEvent.cs`, `Greetings.csproj`, `GreetingEventHandler.cs`. **Rung 4 changes both
+    ends** where rung 3 changed only the sender.
 
-- [ ] **Task 10.2:** Register the new projects in `Brighter.slnx`
+- [x] **Task 10.2:** Register the new projects in `Brighter.slnx` — **DONE 2026-08-26**
   - Input: §2.4
   - Output: the entries, under `/samples/Tutorials/`
   - Notes: as Task 5.2.
 
-- [ ] **Task 10.3:** Open the PR and confirm CI builds it
+- [x] **Task 10.3:** Open the PR and confirm CI builds it — **DONE 2026-08-26**
   - Input: a branch off `origin/master`
   - Output: a merged Brighter PR; CI green
   - Notes: as Task 5.3.
+  - **[Brighter#4280](https://github.com/BrighterCommand/Brighter/pull/4280), squashed to
+    `b100bffd5`.** Four commits and **three review rounds**; content verified by
+    `git diff origin/master <branch> -- samples/Tutorials Brighter.slnx` → **0 lines**.
+  - **`build` went pass / fail / fail / pass on this one PR**, every failure identical and
+    every one diagnosed rather than assumed: #4276's `JustSayingPropertySerializationTests`
+    on `net9.0` while `net10.0` passed 30/30. **`postgres-ci` went red once and green on the
+    re-run** against an identical Postgres surface — a *third* flake, newly recorded. `aws-ci`
+    is the standing SNS quota failure, red on master too (`TopicLimitExceededException` ×190).
+  - **The stable `LAG 1` found here went up as
+    [Brighter#4281](https://github.com/BrighterCommand/Brighter/issues/4281)**, re-searched
+    immediately before filing. Not a 009 deliverable.
 
 ---
 
@@ -1344,7 +1380,7 @@ pump per performer, hence per group member** — `noOfPerformers` defaults to 1
 which its single thread drains sequentially. Nor may it run the `noOfPerformers = 3`
 experiment in the body: that is a fork, and it belongs to `ReactorAndProactor.md`.
 
-- [ ] **Task 11.1:** Write `contents/TutorialStreamingWithKafka.md`
+- [x] **Task 11.1:** Write `contents/TutorialStreamingWithKafka.md` — **DONE 2026-08-26**
   - Input: design § D8 (eight steps); the merged D7 sample; §2.8's verified offset numbers
   - Output: `contents/TutorialStreamingWithKafka.md`, ~320 lines
   - Notes: step 8 is the honest at-least-once statement — offsets batch at `commitBatchSize`
@@ -1352,21 +1388,60 @@ experiment in the body: that is a fork, and it belongs to `ReactorAndProactor.md
     silently lose position, but a crash redelivers up to a batch. Ordering holds *per key*,
     because the key selects the partition. Link `#partition`, `#consumer-group`, `#offset`,
     `#partition-key`, `#reactor`.
+  - **As shipped: 587 lines against design's ~320**, the same shape of overshoot as rungs 2 and
+    3 and for the same reason — two C# blocks totalling **157 lines** carry both `Program.cs`
+    files and AC3 requires them verbatim. **Design's per-page estimates are prose budgets.**
+  - **Step 8 says both halves, and design's step-8 note only has one.** Verification item 2 is
+    right that offsets are committed for revoked partitions so position is not *lost* — and the
+    natural inference that nothing is *redelivered* is false. Measured: **nothing at all is
+    committed** immediately after nine messages (`CURRENT-OFFSET -`), because
+    `commitBatchSize` is 10; the **30-second `sweepUncommittedOffsetsInterval`** commits, and
+    leaves `LAG 1` per partition **stably**. A rebalance then redelivers **one message per
+    partition**.
+  - **Ordering is demonstrated at step 5, before the second instance exists.** The receiver
+    prints the nine greetings *grouped by recipient* rather than in send order, so the absence
+    of a global order and the presence of a per-key one are both visible with one consumer.
+    Design put ordering at step 7; it arrives earlier and for free.
+  - **`DispatchingARequest.md` is missing from design's D8 cross-link list and is now in
+    *Further Reading*** — it is the page that documents the request-context partition key.
 
-- [ ] **Task 11.2:** `SUMMARY.md` entry, `pagetypes.tsv` row, banner naming **both** rungs
+- [x] **Task 11.2:** `SUMMARY.md` entry, `pagetypes.tsv` row, banner naming **both** rungs — **DONE 2026-08-26**
   - Input: §2.1's block; design § Reading order
   - Output: the entry, the row, and a banner whose *Prerequisites* segment names rungs 2
     **and** 3
   - Notes: banner, *Before You Start* and the ladder diagram must all say the same two rungs.
     An earlier draft of design said it three different ways, which a reader reads as a mistake
     in the ladder itself.
+  - **`pagetypes.tsv` goes 146 → 147 rows**, appended rather than re-sorted, re-derived with
+    `awk 'NR>1' | wc -l` at this commit rather than incremented from a neighbouring document.
+  - **Three things this task did not list and the phase owed anyway.** `GetStarted.md` said
+    *"three rungs"* in eight places including its `description:` front matter — Phase 9 wrote it
+    that way deliberately, because rung 4 had not shipped, and shipping it is what makes the
+    landing page stale. Rung 3's closing paragraph **named Kafka without linking it**, the one
+    upward link Phase 9 deferred here. And the ladder now needs port **9092** listed, which
+    Task 9.1's note asked for and Phase 9 correctly refused.
 
-- [ ] **Task 11.3:** Clean-machine timed run, including the rebalance (AC1, AC2)
+- [x] **Task 11.3:** Clean-machine timed run, including the rebalance (AC1, AC2) — **DONE 2026-08-26**
   - Input: the page as written
   - Output: both terminals' rebalance output captured verbatim; a measured duration
   - Notes: the second consumer instance is a second copy of the app, not a second broker
     (Q2). This is the run most likely to overshoot its estimate; adjust the page to the
     measurement.
+  - **Measured on a genuinely cold cache** — all four NuGet locations redirected and asserted
+    empty first. Baseline is a reader's: rung 2 built from packages, http-cache 0 → **127
+    files**, which independently reproduces Phase 8's figure. Then rung 4's package swap
+    **127 → 149** (22 new files, the positive evidence that bytes crossed the network):
+    **5.2s** to swap the package on both projects, **3.1s** to build.
+  - **The page's own fences were extracted and run, not the sample's** — Phase 8's method.
+    Both `Program.cs` blocks are `cmp`-identical to the merged sample below its licence region,
+    the ```` ```yaml ```` compose block passes `docker compose config`, and every quoted output
+    was captured from running exactly those files: the assignment line, the nine grouped
+    receipts, the partition/key listing, both offset tables, both rebalance logs and the
+    two-consumer step 7.
+  - **Step 7's block order is not deterministic, and the page now says so.** The instance
+    holding two partitions drains them in whatever order it polls, so grace's block and alice's
+    block swap between runs — observed both ways. What never varies is the order *within* a
+    block, which is the only thing the page claims.
 
 ---
 

--- a/spec/011-authoring_conventions/pagetypes.tsv
+++ b/spec/011-authoring_conventions/pagetypes.tsv
@@ -145,3 +145,4 @@ contents/TutorialFirstCommand.md	Tutorial	high	"spec 009 D1, rung 1; tutorial by
 contents/TutorialFirstMessage.md	Tutorial	high	"spec 009 D2, rung 2; tutorial by construction — one path, numbered steps, measured two-terminal run"	Tutorial	Brighter V10
 contents/TutorialDurableOutbox.md	Tutorial	high	"spec 009 D3, rung 3; tutorial by construction — one path, numbered steps, measured happy-path and failure-path runs"	Tutorial	Brighter V10
 contents/GetStarted.md	Tutorial	medium	"spec 009 D10, the ladder's landing page; not itself a build, but the entry point to the three tutorials and typed with them"	Tutorial	Brighter V10
+contents/TutorialStreamingWithKafka.md	Tutorial	high	"spec 009 D8, rung 4; tutorial by construction — one path, numbered steps, measured single-consumer and rebalanced two-consumer runs"	Tutorial	Brighter V10


### PR DESCRIPTION
**D8 — the last page of the *Get Started* ladder.** `contents/TutorialStreamingWithKafka.md`, the companion to [Brighter#4280](https://github.com/BrighterCommand/Brighter/pull/4280), which merged first as AC4 requires.

587 lines against design's estimated ~320 — the same overshoot as rungs 2 and 3, and for the same reason: two C# blocks carrying 157 lines of `Program.cs` that AC3 requires verbatim. **Design's per-page estimates are prose budgets.**

## Written from Phase 10's measurements, not from design § D8

Three of design's D8 facts did not survive a running system, and the page reflects what was measured:

- **No message mapper.** Design's D7 row says *"async handler/mapper → sync"*, a delta measured against `KafkaTaskQueue` — but D7 derives from **D5**, which has neither. `JsonMessageMapper<T>` is the registered default for *both* paths and already reads the partition key from the request context. **`contents/DispatchingARequest.md:89` documented that route before the sample was written**, and it is now in *Further Reading*, where design's cross-link list should have had it.
- **Partition keys collide, and one consumer hides it perfectly.** `alice`, `bob` and `carol` all hash to partition 2. Step 5 makes the reader run `kafka-console-consumer.sh --property print.partition=true` and see where the keys actually landed, because the failure mode is a sample that looks flawless while demonstrating nothing.
- **Step 8 states both halves of at-least-once.** Verification item 2 is right that offsets are committed for revoked partitions so position is not *lost*; the inference that nothing is *redelivered* is false. Measured: **nothing is committed at all** at nine messages (`commitBatchSize` is 10), the **30s sweeper** commits and leaves `LAG 1` per partition *stably*, and a rebalance then redelivers one per partition. That residual `LAG 1` is [Brighter#4281](https://github.com/BrighterCommand/Brighter/issues/4281) and the page says so.

**Ordering is demonstrated at step 5, before a second consumer exists.** Nine greetings arrive *grouped by recipient* rather than in send order, so the absence of a global order and the presence of a per-key one are both visible with one process. Design put that at step 7; it arrives earlier and for free.

## Three things the phase owed that Task 11.2 does not list

- **`GetStarted.md` said "three rungs" in eight places**, including its `description:` front matter. Phase 9 wrote it that way deliberately because rung 4 had not shipped — *shipping it* is what made the landing page stale. It now lists four rungs, port **9092**, Docker for rungs 2–4, and rung 4's measured **5.2s + 3.1s**.
- **`TutorialDurableOutbox.md` named Kafka without linking it** — the one upward link Phase 9 deferred to this phase.
- **Phase 10's three boxes are ticked here**, the established pattern: a tick is a Docs commit and Phase 10 was a Brighter PR. That pattern is now spent — no later phase is a Brighter PR.

## Verified by running the page's own fences

Phase 8's method, which is stronger than diffing after the fact:

- both `Program.cs` blocks are **`cmp`-identical** to `samples/Tutorials/04-Kafka` below its licence region, and the ```` ```yaml ```` compose block passes `docker compose config`
- extracted into a fresh **package-referenced** solution, built clean, then run against the page's own compose file with preconditions asserted first — **zero topics, zero receiver processes**
- **every quoted output is from that run**: the assignment line, the nine grouped receipts, the partition/key listing, both offset tables, both rebalance logs, and the two-consumer step 7
- clean-machine timing with **all four** NuGet caches redirected and asserted empty. http-cache 0 → **127** building rung 2, which independently reproduces Phase 8's recorded figure, then **127 → 149** adding Kafka — the positive evidence that bytes crossed the network

**Step 7's two output blocks can swap order between runs** — the instance holding two partitions drains them in whatever order it polls, and this was observed both ways — so the page says so rather than presenting one run as what the reader will see.

## Gates

```text
linkcheck.py                149 → 150 files, no broken internal links
pagelint.py                 147 → 148 pages, 0 errors, 790 warnings UNMOVED
pagelint.py --changed       6 files, 25 hunks, 3 pages, 23 code blocks strict — 0 errors
urlmap.py --check-shape     146 → 147 pages, 12 sections, deepest 4, widest 10
urlmap.py --check-redirects unmoved at 77 entries, 7858 bytes
versioncheck.py             16 pins across 4 pages → 18 across 5, 0 stale
pagetypes.tsv               146 → 147 rows, appended never re-sorted
```

The **790 warnings did not move**, which is the check that matters here: every C# block on the page carries its `using` directives, so the page adds nothing to the debt. **23 code blocks strict is this spec's least vacuous `--changed` run** — rung 1's was 7.

Predicted publication path, with `urlmap.py` rather than by guessing: **`get-started/tutorialstreamingwithkafka`**.

## What remains

**Phase 12 only** — the acceptance pass and the close. Task counts re-derived rather than incremented: **36 done, 3 open, 39 total.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0146UueHL6H3zGBGTYwz7GtL