### PR TITLE
tools: raise S2 to 20 — the second rule to move, and for S3's reason

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -65,7 +65,7 @@ jobs:
       # to ignore red builds.
       #
       # --check-shape asserts design §4's S1/S2/S3 — at least 2 pages per section, at
-      # most 12 top-level entries, at most 4 URL segments — plus that no SUMMARY.md
+      # most 20 top-level entries, at most 4 URL segments — plus that no SUMMARY.md
       # heading carries leading whitespace. It was red on the 19-section tree this
       # spec replaced (6 singleton sections, 2 sections over 12 entries, and the
       # leading space at SUMMARY.md:154), which is how it proved it was not vacuous.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -106,6 +106,56 @@ from any rule in the [ledger](#the-ledger); it records why these pages look diff
 
 **Orphaned Files:** Never create documentation files that aren't linked from SUMMARY.md
 
+### The two kinds of nesting
+
+`SUMMARY.md` nesting does two different jobs, and only one of them absorbs growth. The
+distinction matters because **nesting a page changes its published URL** — GitBook derives
+the path from the tree, so a page moved under a parent gains a segment and its old URL has
+to be redirected.
+
+**Sub-topic nesting** puts detail under the page it elaborates:
+
+```markdown
+* [RabbitMQ Configuration](/contents/RabbitMQConfiguration.md)
+  * [RabbitMQ Durability: Quorum Queues and Persistence](/contents/RabbitMQDurability.md)
+```
+
+It absorbs *detail*. It does nothing about the number of transports.
+
+**Family nesting** puts peers under an overview page for the family:
+
+```markdown
+* [Outbox Support](/contents/BrighterOutboxSupport.md)
+  * [MSSQL Outbox](/contents/MSSQLOutbox.md)
+  * [MySQL Outbox](/contents/MySQLOutbox.md)
+```
+
+It absorbs *peers*, and it is the only thing that does. It is why *Outbox and Inbox*
+carries **39 pages behind 9 top-level entries** while *Transports* carries 12 pages behind
+7 — the outbox family has three parent pages and the transports have none.
+
+**So, for a section that will keep growing:**
+
+1. **Create the family parent page before the family gets big.** Retrofitting one moves a
+   URL per page and needs a `.gitbook.yaml` redirect for each. Cheap at zero pages,
+   expensive at ten.
+2. **A parent must be a real page, not a stub.** A middle navigation layer needs something
+   to hang it from; a placeholder that says "choose a transport below" wastes a click on
+   every visit.
+3. **Do not nest peers a reader chooses between exactly once.** Someone picks one transport
+   and never reads the other nine. Nesting those behind a parent adds a click to every
+   visit to buy tidiness in a sidebar. That is why the ten transports stay flat and why
+   `MAX_TOP_LEVEL_ENTRIES` was raised rather than the family being re-parented.
+
+**`MAX_TOP_LEVEL_ENTRIES` (S2, `tools/urlmap.py`) is an editorial budget, not a platform
+limit, and nothing has ever established otherwise.** It was 12 on the stated grounds that
+*"this is the number the navigation shows"*; measured 2026-08-27, GitBook's own 182-page
+documentation has a widest section of **10**, and its 55-page *create-content* section
+holds those 55 behind 10 entries by nesting. There is no evidence of a break at any
+number — what the external corpus shows is the habit above, not a ceiling. Raise the
+budget when a flat list of peers is the right answer; reach for a family parent when the
+list is a dump nobody decided on.
+
 ## Page Conventions
 
 Every page under `contents/` follows the conventions below, and

--- a/spec/010-information_architecture/design.md
+++ b/spec/010-information_architecture/design.md
@@ -15,7 +15,7 @@ predicted**:
 | Decision | Answer | Derived how |
 |---|---|---|
 | The target tree (Q2) | **12 sections**, down from 19 | §3, and every one of the 110 pages is placed |
-| Section-size threshold (Q8) | **≤ 12 top-level entries per section, ≥ 2 pages, ≤ 3 URL segments** | §4 |
+| Section-size threshold (Q8) | **≤ ~~12~~ 20 top-level entries per section, ≥ 2 pages, ≤ ~~3~~ 4 URL segments** | §4 — both ceilings amended after measurement; see the S2 and S3 rows |
 | URL churn (Q3) | **74 of 110 URLs move; 36 do not** | measured, §5 |
 | Pages the 26 splits create | **32**, taking the corpus 110 → **142** | §7, row by row |
 | Anchor links to repoint | **34 inbound anchor links on 7 of the 26 pages**; 19 pages have none | measured, §8 |
@@ -187,7 +187,7 @@ mechanical rules over `SUMMARY.md`:
 | # | Rule | Rationale |
 |---|---|---|
 | **S1** | Every section holds **at least 2 pages** | A section of one is not a category. Six exist today |
-| **S2** | Every section holds **at most 12 top-level entries** | This is the number the navigation shows. Nesting is the escape hatch, and §3.1 of the requirements is why: a middle layer needs a real page to hang it from |
+| **S2** | Every section holds **at most ~~12~~ 20 top-level entries** | ~~This is the number the navigation shows.~~ **Amended 2026-08-27 — spec 012 design §9.2.** That rationale was a claim about GitBook with nothing behind it, and the measured table below says our widest section was **10**, so 12 was our own data plus two. GitBook's own 182-page docs also top out at **10**, by nesting — so no platform limit is established at any number and S2 is an **editorial budget**. Nesting is still the escape hatch, and §3.1 of the requirements is why: a middle layer needs a real page to hang it from |
 | **S3** | No published path exceeds **4 segments** | **Amended 2026-08-08 — see §17.** Four was measured on the live site, not assumed. It was 3, on the grounds that three is the deepest the site was *known* to work at; that was an evidence boundary rather than a platform limit, and it was distorting two placements |
 
 **S2 counts entries, not pages, and that is the whole point.** *Outbox and Inbox* holds
@@ -212,7 +212,8 @@ Measured against the tree in §3.1:
 | Understanding Brighter | 12 | 10 |
 | Reference | 2 | 2 |
 
-S1 ✅ (minimum 2) · S2 ✅ (maximum 10) · S3 ✅ (maximum 3). After all 32 split pages land
+S1 ✅ (minimum 2) · S2 ✅ (maximum 10 — **and that 10 is where S2's 12 came from**, see the
+row above) · S3 ✅ (maximum 3). After all 32 split pages land
 the worst case is *Understanding Brighter* at **10** entries and *Outbox and Inbox* at 39
 pages / **9** — still inside S2 with two entries of headroom, and the deepest path is
 **4 segments**, reached by exactly two pages. Those figures are pinned per split in

--- a/spec/012-configuration_reference/design.md
+++ b/spec/012-configuration_reference/design.md
@@ -54,8 +54,9 @@ requirements state correctly, and two find work the requirements do not list:
   (§12.5). So **619 is a floor.**
 - **Only one of the corpus's 44 documented option rows is already in the §7.1 shape**,
   and two of the twelve tables are not option tables at all (§12.2).
-- **Adding the five transport pages takes *Transports* to exactly 12 top-level entries,
-  which is S2's ceiling** (§9.2).
+- **Adding the five transport pages took *Transports* to exactly 12 top-level entries,
+  which was S2's ceiling — so S2 was measured, and moved to 20** (§9.2). It is the second
+  rule in this programme to move, and for the same reason S3 did.
 - **MSSQL-as-a-transport is a second Spanner case** — it takes the shared relational
   configuration and has no connection type of its own (§8.3).
 - **The inbox family ships Firestore and Spanner stores with no page**, exactly mirroring
@@ -789,25 +790,51 @@ store, so they add nothing to that section's top-level count, and each sits imme
 before its family's InMemory entry — matching the order the two families already use.
 **D15 is nested** under *Basic Configuration*, like the two Reference pages it joins.
 
-### 9.2 The five transport entries take *Transports* to exactly S2's ceiling
-
-Measured before writing the diff rather than discovered at the gate:
+### 9.2 The five transport entries filled S2's old ceiling, so S2 was measured and moved
 
 | Section | Top-level entries now | After D12 |
 |---|---|---|
 | Transports | 7 | **12** |
 
-`urlmap.py --check-shape` fails at `len(entries) > 12` (`tools/urlmap.py:221`), so **12
-passes with zero headroom.** Three consequences, all belonging in the tasks phase rather
-than being rediscovered:
+`urlmap.py --check-shape` failed at `len(entries) > 12`, so D12 landed on the ceiling
+exactly, with **zero headroom** — the eleventh transport Brighter ships would have failed
+the build. Found before writing the diff rather than at the gate, which is what made it
+cheap to do the next part properly.
 
-1. **The P2 index page of requirements §7.4 item 12 cannot go in *Transports*.** It
-   belongs in *Brighter Configuration*, which has four entries.
-2. **The eleventh transport Brighter ships forces a nesting decision**, and there is no
-   *Transports* overview page to nest under. Recorded, not solved — 012 does not create
-   one.
-3. **`--check-shape` is what will say so**, on every PR, so the failure is loud rather
-   than silent. That is the good case.
+**S2's rationale did not survive being read.** The number appears exactly once as a value
+(`tools/urlmap.py:58`) and once as a justification — 010 design §4's *"This is the number
+the navigation shows"* — and that is a claim about GitBook with nothing behind it. **The
+measured table four lines below that sentence says our own widest section was 10.** So 12
+was our data plus two, wearing a platform fact's clothes: precisely the shape that made
+**S3 the first rule in this programme to move**, where *"three is the deepest the live site
+is known to work at"* turned out to be a fact about our `SUMMARY.md`.
+
+**So the evidence was fetched, the way S3's was.** GitBook's own documentation, counted
+from its raw `sitemap-pages.xml` rather than through a summarising fetch: **182 pages, 13
+sections, widest section 10 top-level entries** — and its largest section,
+*create-content*, holds **55 pages behind those 10**. Nothing there establishes a break at
+12, at 20, or at any number. What it establishes is an *editorial habit of nesting*, which
+is what S2's failure message recommends and what S2 exists to prompt.
+
+**S2 is therefore an editorial budget, is documented as one, and is raised to 20**
+(`tools/urlmap.py:58`, amended 2026-08-27; 010 design §4's row is struck in place, as S3's
+was). **Red-proved before being trusted**: 21 entries fires it, exit 1, with the probe
+asserting it had produced input over the threshold *before* reading the verdict — the
+first attempt was vacuous twice over, once because nine entries pointing at one file
+dedupe to one path, and once because Transports is 7 today rather than the 12 this section
+projects.
+
+**Why raised rather than re-parented.** Ten transports are **peers**: a reader picks one
+and never reads the other nine, so a family parent page would add a click to every visit to
+buy tidiness in a sidebar. And retrofitting one is not free — **nesting a page moves its
+published URL**, so re-parenting the five documented transports costs five redirects.
+`CLAUDE.md` § *The two kinds of nesting* records the general rule this produced: sub-topic
+nesting absorbs detail, family nesting absorbs peers, and only the second controls a
+section's width — which is why *Outbox and Inbox* carries 39 pages behind 9 entries.
+
+**What remains true after the raise:** the P2 index page of requirements §7.4 item 12
+still belongs in *Brighter Configuration* (four entries), which is where requirements §10
+already files it — the ceiling was never what decided that.
 
 No entry moves a URL: slugs are filename-derived, so ordering within a section moves
 nothing. That has held five times, and adding to a section is the same operation.

--- a/tools/urlmap.py
+++ b/tools/urlmap.py
@@ -55,7 +55,25 @@ LINK_RE = re.compile(r"^(\s*)\*\s*\[(.+?)\]\((/contents/[^)]+)\)")
 # a section may hold any number of pages so long as its top level stays readable,
 # which is how Outbox and Inbox carries 39 pages behind 9 entries.
 MIN_PAGES_PER_SECTION = 2      # S1
-MAX_TOP_LEVEL_ENTRIES = 12     # S2
+MAX_TOP_LEVEL_ENTRIES = 20     # S2 — RAISED from 12 on 2026-08-27, spec 012 design.
+# S2 is the SECOND rule in this programme to move, and it moved for the same reason S3
+# did.  Its stated rationale was "this is the number the navigation shows" (010 design
+# §4) -- a claim about GitBook, made in the one place the number appears, with nothing
+# behind it.  The measured table four lines below that sentence says our widest section
+# was **10**, so 12 was our own data plus two, wearing a platform fact's clothes.
+#
+# Measured 2026-08-27, the way S3 was: GitBook's own documentation is 182 pages in 13
+# sections and its widest section shows **10** top-level entries -- create-content
+# carries 55 pages behind those 10.  So nothing anywhere establishes a platform limit
+# at 12, at 20, or at any number; what the external corpus shows is an *editorial*
+# habit of nesting, which is what the failure message recommends and what S2 exists to
+# prompt.  The threshold is therefore an editorial budget and is documented as one.
+#
+# Raised because ten shipping transports are PEERS, not a hierarchy: a reader picks one
+# and never reads the others, so a family parent page would add a click to every visit.
+# The alternative -- nesting them -- costs a published URL per page (nesting adds a path
+# segment), so it is cheap for a family that does not exist yet and expensive for one
+# that does.  See CLAUDE.md § The two kinds of nesting.
 MAX_URL_SEGMENTS = 4           # S3 — MEASURED 2026-08-08, design §17, not assumed.
 # S3 was 3 until it was measured, on a rationale that was the absence of evidence:
 # "three is the deepest the live site is known to work at".  That is a fact about our
@@ -221,7 +239,9 @@ def cmd_check_shape():
         if len(entries) > MAX_TOP_LEVEL_ENTRIES:
             failures.append(
                 f"S2: section {section!r} shows {len(entries)} top-level entries, "
-                f"maximum {MAX_TOP_LEVEL_ENTRIES} — nest some under a parent page")
+                f"maximum {MAX_TOP_LEVEL_ENTRIES} — nest the peers under a family "
+                f"parent page (this MOVES their URLs; see CLAUDE.md § The two kinds "
+                f"of nesting)")
 
     for path in sorted(paths):
         segments = path.count("/") + 1


### PR DESCRIPTION
Spec 012's D12 takes *Transports* **7 → 12** top-level entries, landing exactly on S2's
ceiling with zero headroom. Reading the rule's rationale is what moved it.

## The number had no provenance

`12` exists in exactly two places — the constant, and 010 design §4's rationale column:

> **S2** | Every section holds at most 12 top-level entries | *This is the number the navigation shows.*

That is a claim about GitBook, and **nothing anywhere backs it** — it appears nowhere in
010's requirements. Worse, **the measured table four lines below that sentence says our own
widest section was 10.** So the ceiling was *our data plus two*, wearing a platform fact's
clothes.

**That is exactly what made S3 the first rule in this programme to move**, where *"three is
the deepest the live site is known to work at"* turned out to be a fact about our own
`SUMMARY.md`. The lesson drawn from S3 was *when a rule's stated rationale is the absence of
evidence, go and get the evidence* — and nobody applied it to the rule sitting one row above
it in the same table.

## So the evidence was fetched

The way S3's was: raw `sitemap-pages.xml`, counted locally, because *a summarising fetch is
not a measurement*. GitBook's own documentation:

```
182 pages, 13 sections
widest section: 10 top-level entries
create-content: 55 pages behind those 10
```

Nothing establishes a break at 12, at 20, or at any number. What the corpus shows is an
**editorial habit of nesting** — which is what S2's own failure message recommends.

**S2 is a budget, not a limit, and now says so** in the constant, in `CLAUDE.md`, and in
010's design row, struck in place as S3's was.

## Red-proved at 21 before being trusted

Exit 1, S2 named, tree restored byte-identical from a copy. **The probe was vacuous twice
first**, both times the recorded lesson *assert the probe produced the input the branch
rejects, not merely that the file changed*:

- nine new entries all pointing at `KafkaConfiguration.md` **dedupe to one path**, so
  `widest` never moved while `text != orig` was perfectly true;
- nine *distinct* donors reached only **16**, because *Transports* is **7** today and the 12
  is a projection of work not yet done.

The assertion `n > MAX_TOP_LEVEL_ENTRIES` caught both.

## Why raised rather than re-parented

Ten transports are **peers** — a reader picks one and never reads the other nine, so a
family parent page adds a click to every visit. And **nesting moves a published URL**, so
retrofitting a parent costs a redirect per page: cheap for a family that does not exist yet,
expensive for one that does.

`CLAUDE.md` gains **§ The two kinds of nesting**: sub-topic nesting absorbs *detail*, family
nesting absorbs *peers*, and only the second controls a section's width. That is why *Outbox
and Inbox* carries 39 pages behind 9 entries and *Transports* does not.

Closed specs' `tasks.md` files still record the old cap and are **left alone** — they report
what the tool did on the day they ran. 010's *design* row defines the rule, so that is the
one amended.

## Gates

```
linkcheck.py                 No broken internal links (150 files checked).
pagelint.py                  0 errors, 790 warnings, 148 pages
urlmap.py --check-shape      0 — widest 10 of 20 top-level entries
urlmap.py --check-redirects  0 — 77 entries, 7858 bytes, printable ASCII
versioncheck.py              0 stale pins of 18 examined across 5 page(s).
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0146UueHL6H3zGBGTYwz7GtL