### PR TITLE
spec 012 phase 1 — three probes, the survey fix, and five defects it was hiding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,11 @@ env/
 __pycache__/
 *.py[cod]
 
+# spec/012's probes are a real .NET project, so this repository now has build
+# output in it. The project is kept and re-runnable; its bin/ and obj/ are not.
+bin/
+obj/
+
 # Session resume state — local Claude Code working notes
 PROMPT.md
 

--- a/spec/012-configuration_reference/probes/CountsProbe.cs
+++ b/spec/012-configuration_reference/probes/CountsProbe.cs
@@ -1,0 +1,79 @@
+using System.Reflection;
+
+namespace Paramore.Docs.Probes;
+
+/// <summary>
+/// The oracle for task 1.5.
+///
+/// `survey.py` counts a type's options by parsing source; the checker will count
+/// them by reflecting over an assembly. Those are two instruments measuring one
+/// quantity, and the only way to know the parser is right is to hold it against
+/// the thing it is a proxy for.
+///
+/// This prints one TSV row per surface type — assembly, type, settable
+/// properties, widest constructor parameters, and `max` of the two, which is
+/// design §2's convention — so the survey's table can be diffed against it.
+///
+///   dotnet run --project spec/012-configuration_reference/probes -- counts
+///
+/// DeclaredOnly, deliberately: the survey counts what a type's own source file
+/// declares, so counting inherited members here would make the two instruments
+/// disagree by construction and prove nothing.
+/// </summary>
+internal static class CountsProbe
+{
+    public static int Run()
+    {
+        Console.WriteLine("assembly\ttype\tprops\tctor\tmax");
+
+        var assemblies = Directory
+            .GetFiles(AppContext.BaseDirectory, "Paramore.Brighter*.dll")
+            .Select(Path.GetFileNameWithoutExtension)
+            .Where(n => n is not null)
+            .Select(n => n!)
+            .OrderBy(n => n, StringComparer.Ordinal);
+
+        foreach (var name in assemblies)
+        {
+            Assembly assembly;
+            try { assembly = Assembly.Load(name); }
+            catch { continue; }
+
+            Type[] types;
+            try { types = assembly.GetTypes(); }
+            catch (ReflectionTypeLoadException ex)
+            {
+                types = ex.Types.Where(t => t is not null).Select(t => t!).ToArray();
+            }
+
+            foreach (var type in types.OrderBy(t => t.Name, StringComparer.Ordinal))
+            {
+                if (type is not { IsPublic: true, IsClass: true } || type.IsGenericTypeDefinition)
+                    continue;
+                if (!IsSurfaceName(type.Name))
+                    continue;
+
+                var props = type
+                    .GetProperties(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly)
+                    .Count(p => p.SetMethod is { IsPublic: true });
+
+                var ctor = type
+                    .GetConstructors(BindingFlags.Public | BindingFlags.Instance)
+                    .Select(c => c.GetParameters().Length)
+                    .DefaultIfEmpty(0)
+                    .Max();
+
+                Console.WriteLine($"{name}\t{type.Name}\t{props}\t{ctor}\t{Math.Max(props, ctor)}");
+            }
+        }
+
+        return 0;
+    }
+
+    private static bool IsSurfaceName(string name) =>
+        name.EndsWith("Subscription", StringComparison.Ordinal)
+        || name.EndsWith("Publication", StringComparison.Ordinal)
+        || name.EndsWith("Configuration", StringComparison.Ordinal)
+        || name.EndsWith("Options", StringComparison.Ordinal)
+        || name.EndsWith("Connection", StringComparison.Ordinal);
+}

--- a/spec/012-configuration_reference/probes/DefaultProbe.cs
+++ b/spec/012-configuration_reference/probes/DefaultProbe.cs
@@ -1,0 +1,140 @@
+using System.Reflection;
+using Paramore.Brighter;
+
+namespace Paramore.Docs.Probes;
+
+/// <summary>
+/// Task 1.2 — the probe the whole `Default` column rests on.
+///
+/// Requirements §5.1 reads `Subscription.cs:208` and `:236` and infers that
+/// `emptyChannelDelay` defaults to `null` in the signature and to 500 ms in the
+/// constructor body. That is a reading of the authority, not a measurement of
+/// it. This runs it.
+///
+/// It prints BOTH routes for every defaulted parameter of the widest
+/// constructor, because the finding is the *difference*: where the two columns
+/// disagree, a checker reading `ParameterInfo` alone documents the option
+/// WRONG rather than merely missing it.
+/// </summary>
+internal static class DefaultProbe
+{
+    public static int Run()
+    {
+        Console.WriteLine("PROBE 1.2 — the body-coalesced default");
+        Console.WriteLine("Subject: Paramore.Brighter.Subscription, package Paramore.Brighter 10.7.0");
+        Console.WriteLine();
+
+        var ctor = typeof(Subscription)
+            .GetConstructors()
+            .OrderByDescending(c => c.GetParameters().Length)
+            .First();
+
+        // The three required arguments, plus the two the constructor body
+        // *validates* — see the finding at the foot of this probe.
+        var subscription = new Subscription(
+            new SubscriptionName("probe"),
+            new ChannelName("probe"),
+            new RoutingKey("probe"),
+            requestType: typeof(ProbeRequest),
+            messagePumpType: MessagePumpType.Reactor);
+
+        // The two the probe had to supply itself. They are printed, because a
+        // row missing from a table is a row nobody can question, but they are
+        // excluded from the arithmetic: their instance value is the probe's own
+        // argument and says nothing about the constructor body.
+        string[] supplied = ["requestType", "messagePumpType"];
+
+        Console.WriteLine($"{"parameter",-32} {"ParameterInfo.DefaultValue",-28} {"instance property",-28} agree?");
+        Console.WriteLine(new string('-', 100));
+
+        var coalesced = new List<string>();
+        var nullSignature = 0;
+
+        foreach (var p in ctor.GetParameters().Where(p => p.HasDefaultValue))
+        {
+            var property = typeof(Subscription)
+                .GetProperties(BindingFlags.Public | BindingFlags.Instance)
+                .FirstOrDefault(x => string.Equals(x.Name, p.Name, StringComparison.OrdinalIgnoreCase));
+
+            if (property is null)
+                continue;   // a parameter with no property of its own; §5.1's `Option` column names it anyway
+
+            var signature = p.DefaultValue;
+            var instance = property.GetValue(subscription);
+            var isSupplied = supplied.Contains(p.Name);
+            var agree = Equals(Show(signature), Show(instance));
+
+            if (!isSupplied)
+            {
+                if (signature is null)
+                    nullSignature++;
+                if (!agree)
+                    coalesced.Add($"{p.Name}: signature {Show(signature)}, instance {Show(instance)}");
+            }
+
+            var verdict = isSupplied ? "probe-supplied" : agree ? "yes" : "NO";
+            Console.WriteLine($"{p.Name,-32} {Show(signature),-28} {Show(instance),-28} {verdict}");
+        }
+
+        Console.WriteLine();
+        Console.WriteLine($"Of the parameters the probe left alone, {nullSignature} say `null` in the "
+                          + $"signature and {coalesced.Count} of those come back as something else:");
+        foreach (var line in coalesced)
+            Console.WriteLine($"  {line}");
+        Console.WriteLine($"The other {nullSignature - coalesced.Count} really are null on the instance, which "
+                          + "is why the shapes cannot be told apart");
+        Console.WriteLine("from the signature: `null` there means both \"no default\" and \"the default is "
+                          + "assigned below\".");
+
+        // The named case — the one requirements §5.1 and AC3b are written about.
+        var emptyChannelDelay = ctor.GetParameters().Single(p => p.Name == "emptyChannelDelay");
+        var signatureValue = emptyChannelDelay.DefaultValue;
+        var instanceValue = subscription.EmptyChannelDelay;
+
+        Console.WriteLine();
+        Console.WriteLine("The named case, requirements §5.1:");
+        Console.WriteLine($"  emptyChannelDelay  ParameterInfo.DefaultValue = {Show(signatureValue)}");
+        Console.WriteLine($"  EmptyChannelDelay  instance                   = {Show(instanceValue)}");
+
+        var premiseHolds = signatureValue is null && instanceValue == TimeSpan.FromMilliseconds(500);
+
+        Console.WriteLine();
+        if (premiseHolds)
+        {
+            Console.WriteLine("PREMISE HOLDS. The signature says `null`; the instance says 500 ms.");
+            Console.WriteLine("A checker reading ParameterInfo alone documents this option as `null` — wrong,");
+            Console.WriteLine("not missing. The `Default` column must come from an instantiated object.");
+        }
+        else
+        {
+            Console.WriteLine("PREMISE FAILS — the two routes AGREE on emptyChannelDelay.");
+            Console.WriteLine("Spec 012's central premise is wrong at this ref and phase 2 changes shape.");
+            Console.WriteLine("Do not proceed to phase 2; take this back to the design.");
+        }
+
+        Console.WriteLine();
+        Console.WriteLine("Also found, by construction rather than by reading (see task 1.4):");
+        Console.WriteLine("  `Subscription` cannot be constructed from its required parameters alone. The");
+        Console.WriteLine("  constructor body throws ConfigurationException unless `messagePumpType` is set");
+        Console.WriteLine("  to something other than its own default of Unknown, and unless one of");
+        Console.WriteLine("  `requestType` or `getRequestType` is non-null. Two DEFAULTED parameters are");
+        Console.WriteLine("  therefore required in practice, which no parse of the signature can see.");
+
+        return premiseHolds ? 0 : 1;
+    }
+
+    internal static string Show(object? value) => value switch
+    {
+        null => "null",
+        TimeSpan t => $"{t.TotalMilliseconds:0.###} ms",
+        string s => $"\"{s}\"",
+        _ => value.ToString() ?? "null",
+    };
+}
+
+/// <summary>A request type with no behaviour, so `Subscription` has one to name.</summary>
+internal sealed class ProbeRequest : IRequest
+{
+    public Id Id { get; set; } = Id.Random();
+    public Id? CorrelationId { get; set; }
+}

--- a/spec/012-configuration_reference/probes/PackageLoadProbe.cs
+++ b/spec/012-configuration_reference/probes/PackageLoadProbe.cs
@@ -1,0 +1,315 @@
+using System.Reflection;
+
+namespace Paramore.Docs.Probes;
+
+/// <summary>
+/// Task 1.3 — load every pinned surface package in one process and instantiate
+/// one type from each.
+///
+/// Design §6.4 registers the risk and says in as many words that none of it is
+/// measured: one project referencing every Brighter surface package puts
+/// several third-party SDKs in one process, and the risk lands entirely on the
+/// instantiation route, because metadata reflection never runs a static
+/// constructor while instantiating a type resolves its dependencies for real.
+///
+/// A conflict found here is a `csproj` edit; found after twelve tables are
+/// written it is a redesign.
+///
+/// The package list is the `PackageReference` set in `probes.csproj`, read back
+/// from the output directory rather than restated here — a hand-maintained
+/// second copy is a list that can differ from the first silently.
+/// </summary>
+internal static class PackageLoadProbe
+{
+    public static int Run()
+    {
+        Console.WriteLine();
+        Console.WriteLine("PROBE 1.3 — every pinned surface package in one process");
+        Console.WriteLine();
+
+        var assemblies = Directory
+            .GetFiles(AppContext.BaseDirectory, "Paramore.Brighter*.dll")
+            .Select(Path.GetFileNameWithoutExtension)
+            .Where(n => n is not null)
+            .Select(n => n!)
+            .OrderBy(n => n, StringComparer.Ordinal)
+            .ToList();
+
+        if (assemblies.Count == 0)
+        {
+            Console.Error.WriteLine("no Paramore.Brighter assemblies in the output directory — "
+                                    + "has the project been built?");
+            return 2;
+        }
+
+        Console.WriteLine($"{assemblies.Count} Paramore.Brighter assemblies are in the process — the "
+                          + "packages `probes.csproj` names,");
+        Console.WriteLine("plus the Brighter packages they depend on. None of them is `.V4`.");
+        Console.WriteLine();
+        Console.WriteLine($"{"package",-56} {"type instantiated",-40} {"pass",4}  result");
+        Console.WriteLine(new string('-', 118));
+
+        var loadFailures = new List<string>();
+        var noConstructible = new List<string>();
+        var requestedBy = new Dictionary<string, Dictionary<string, List<string>>>(StringComparer.Ordinal);
+        var pass2 = 0;
+
+        foreach (var name in assemblies)
+        {
+            Assembly assembly;
+            try
+            {
+                assembly = Assembly.Load(name);
+            }
+            catch (Exception ex)
+            {
+                loadFailures.Add($"{name}: {ex.GetType().Name}: {ex.Message}");
+                Console.WriteLine($"{name,-56} {"—",-40} {"—",4}  LOAD FAILED");
+                continue;
+            }
+
+            foreach (var reference in assembly.GetReferencedAssemblies())
+            {
+                if (reference.Name is null || IsPlatform(reference.Name))
+                    continue;
+
+                if (!requestedBy.TryGetValue(reference.Name, out var byVersion))
+                    requestedBy[reference.Name] = byVersion =
+                        new Dictionary<string, List<string>>(StringComparer.Ordinal);
+
+                var version = reference.Version?.ToString() ?? "unversioned";
+                if (!byVersion.TryGetValue(version, out var referrers))
+                    byVersion[version] = referrers = [];
+
+                referrers.Add(name);
+            }
+
+            var (type, result) = FirstConstructible(assembly);
+
+            if (type is null)
+            {
+                noConstructible.Add($"{name}: {result?.Error ?? "no public class the synthesiser can build"}");
+                Console.WriteLine($"{name,-56} {"—",-40} {"—",4}  NOTHING CONSTRUCTIBLE");
+                continue;
+            }
+
+            if (result!.Pass == 2) pass2++;
+            Console.WriteLine($"{name,-56} {type.Name,-40} {result.Pass,4}  ok");
+        }
+
+        Console.WriteLine();
+        Console.WriteLine($"{pass2} of the instantiations needed pass 2 — a defaulted parameter the "
+                          + "constructor body validates.");
+
+        foreach (var failure in loadFailures)
+            Console.WriteLine($"LOAD FAILURE  {failure}");
+        foreach (var failure in noConstructible)
+            Console.WriteLine($"NOT CONSTRUCTIBLE  {failure}");
+
+        // A third-party assembly is what design §6.4 is actually worried about,
+        // and requesting one is not the same as loading it. Load each, and
+        // compare what arrived against what every referrer asked for: one
+        // process holds one version of a simple name, so a referrer compiled
+        // against a different major is running against an assembly it has never
+        // seen. That is the conflict, and it is silent until a member is missing.
+        Console.WriteLine();
+        Console.WriteLine($"{requestedBy.Count} distinct third-party assemblies are referenced by the "
+                          + "packages above. Loading each:");
+
+        var unsatisfied = new List<string>();
+        var thirdPartyLoadFailures = new List<string>();
+
+        foreach (var (simpleName, byVersion) in requestedBy.OrderBy(kv => kv.Key, StringComparer.Ordinal))
+        {
+            Version? loaded;
+            try
+            {
+                loaded = Assembly.Load(simpleName).GetName().Version;
+            }
+            catch (Exception ex)
+            {
+                thirdPartyLoadFailures.Add($"{simpleName}: {ex.GetType().Name}");
+                continue;
+            }
+
+            foreach (var (requested, referrers) in byVersion)
+            {
+                if (Version.TryParse(requested, out var wanted) && loaded is not null
+                                                               && wanted.Major != loaded.Major)
+                {
+                    unsatisfied.Add($"{simpleName}: loaded {loaded}, but "
+                                    + $"{string.Join(" and ", referrers)} asked for {requested}");
+                }
+            }
+        }
+
+        if (thirdPartyLoadFailures.Count > 0)
+        {
+            Console.WriteLine($"  {thirdPartyLoadFailures.Count} would not load:");
+            foreach (var failure in thirdPartyLoadFailures)
+                Console.WriteLine($"    {failure}");
+        }
+
+        if (unsatisfied.Count == 0)
+        {
+            Console.WriteLine("  All loaded, and no referrer is left running against a different MAJOR "
+                              + "version than it was built for.");
+        }
+        else
+        {
+            Console.WriteLine($"  {unsatisfied.Count} referrer(s) left unsatisfied — design §6.4's conflict, "
+                              + "and NOT the AWS pair it predicted:");
+            foreach (var line in unsatisfied)
+                Console.WriteLine($"    {line}");
+        }
+
+        var rmq = RabbitMqPair();
+
+        Console.WriteLine();
+        var clean = loadFailures.Count == 0 && thirdPartyLoadFailures.Count == 0 && rmq == 0;
+        if (clean && unsatisfied.Count == 0)
+        {
+            Console.WriteLine("VERDICT: CLEAN. Every pinned package loads in one process and one type from");
+            Console.WriteLine("each was instantiated for real. Design §6.4's fallback — one process per");
+            Console.WriteLine("package family — is not needed, and `optioncheck` can be a single project.");
+        }
+        else if (clean)
+        {
+            Console.WriteLine("VERDICT: CLEAN, WITH ONE THING TO KNOW. Every pinned package loads in one");
+            Console.WriteLine("process and every type 012 documents was instantiated for real — including");
+            Console.WriteLine("both sides of the version disagreement above, which is therefore latent");
+            Console.WriteLine("rather than fatal. `optioncheck` can be a single project; §6.4's fallback is");
+            Console.WriteLine("not needed. Record the disagreement, because the next package to reach into");
+            Console.WriteLine("the older API is the one that turns it into a failure.");
+        }
+        else
+        {
+            Console.WriteLine("VERDICT: CONFLICT. Take design §6.4's fallback — one `dotnet run` per package");
+            Console.WriteLine("family, results concatenated. NOT AssemblyLoadContext (no native isolation),");
+            Console.WriteLine("and NOT MetadataLoadContext (cannot instantiate, which is what §6.2 needs).");
+        }
+
+        // A package with no constructible type is a gap in the synthesiser, not a
+        // package conflict, so it is reported and does not change the verdict.
+        return clean ? 0 : 1;
+    }
+
+    /// <summary>
+    /// The pair the version disagreement lands on. Design §7.2 diffs `RmqSubscription`
+    /// across `RMQ.Async` and `RMQ.Sync` to establish that they differ by `queueType`
+    /// alone, so 012 needs both types to be constructible in one process — which is
+    /// exactly what a single resolved `RabbitMQ.Client` puts in doubt. Measured
+    /// rather than assumed, either way.
+    /// </summary>
+    private static int RabbitMqPair()
+    {
+        Console.WriteLine();
+        Console.WriteLine("The pair the disagreement lands on — design §7.2 needs both:");
+
+        var failures = 0;
+
+        foreach (var package in new[]
+                 {
+                     "Paramore.Brighter.MessagingGateway.RMQ.Async",
+                     "Paramore.Brighter.MessagingGateway.RMQ.Sync",
+                 })
+        {
+            try
+            {
+                Type[] types;
+                try
+                {
+                    types = Assembly.Load(package).GetTypes();
+                }
+                catch (ReflectionTypeLoadException ex)
+                {
+                    // Some of the assembly's types are unloadable, which is itself
+                    // the finding. Carry on with the ones that did load and say so:
+                    // "the package is broken here" and "this one type is broken
+                    // here" are different verdicts and only the second blocks 012.
+                    Console.WriteLine($"  {package,-46} {ex.Types.Count(t => t is null)} of "
+                                      + $"{ex.Types.Length} types would not load");
+                    types = ex.Types.Where(t => t is not null).Select(t => t!).ToArray();
+                }
+
+                var type = types
+                    .Single(t => t.Name == "RmqSubscription" && !t.IsGenericTypeDefinition);
+
+                var result = Synthesiser.TryCreate(type);
+                var ctor = type.GetConstructors().OrderByDescending(c => c.GetParameters().Length).First();
+                var hasQueueType = ctor.GetParameters().Any(p => p.Name == "queueType");
+
+                Console.WriteLine(result.Ok
+                    ? $"  {package,-46} constructed, {ctor.GetParameters().Length} ctor params, "
+                      + $"queueType {(hasQueueType ? "present" : "absent")}"
+                    : $"  {package,-46} FAILED: {result.Error}");
+
+                if (!result.Ok) failures++;
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"  {package,-46} FAILED: {ex.GetType().Name}: {ex.Message}");
+                failures++;
+            }
+        }
+
+        return failures;
+    }
+
+    private static (Type?, Synthesiser.Result?) FirstConstructible(Assembly assembly)
+    {
+        Type[] types;
+        try
+        {
+            types = assembly.GetTypes();
+        }
+        catch (ReflectionTypeLoadException ex)
+        {
+            types = ex.Types.Where(t => t is not null).Select(t => t!).ToArray();
+        }
+
+        // Prefer the shapes 012 writes tables from, so that a package's line here
+        // is a dry run of what `optioncheck` will do to it rather than a load test
+        // of an unrelated class.
+        var candidates = types
+            .Where(t => t is { IsPublic: true, IsAbstract: false, IsGenericTypeDefinition: false, IsClass: true })
+            .OrderByDescending(t => IsSurfaceName(t.Name))
+            .ThenBy(t => t.FullName, StringComparer.Ordinal)
+            .Take(60)
+            .ToList();
+
+        Synthesiser.Result? first = null;
+        Type? firstType = null;
+
+        foreach (var candidate in candidates)
+        {
+            var result = Synthesiser.TryCreate(candidate);
+            first ??= result;
+            firstType ??= candidate;
+
+            if (result.Ok)
+                return (candidate, result);
+        }
+
+        // Report the FIRST candidate's failure, not the last: the ordering above
+        // puts the type 012 would document at the front, so its error is the one
+        // that says something. The last is whatever happened to sort last.
+        return (null, first is null
+            ? null
+            : first with { Error = $"{firstType?.Name}: {first.Error} "
+                                   + $"({candidates.Count} candidates tried, none constructible)" });
+    }
+
+    private static bool IsSurfaceName(string name) =>
+        name.EndsWith("Subscription", StringComparison.Ordinal)
+        || name.EndsWith("Publication", StringComparison.Ordinal)
+        || name.EndsWith("Configuration", StringComparison.Ordinal)
+        || name.EndsWith("Options", StringComparison.Ordinal)
+        || name.EndsWith("Connection", StringComparison.Ordinal);
+
+    private static bool IsPlatform(string name) =>
+        name is "mscorlib" or "netstandard"
+        || name.StartsWith("System", StringComparison.Ordinal)
+        || name.StartsWith("Microsoft.CSharp", StringComparison.Ordinal)
+        || name.StartsWith("Paramore.Brighter", StringComparison.Ordinal);
+}

--- a/spec/012-configuration_reference/probes/Program.cs
+++ b/spec/012-configuration_reference/probes/Program.cs
@@ -1,0 +1,38 @@
+// Spec 012 phase 1 — the three probes, kept and re-runnable.
+//
+//   dotnet run --project spec/012-configuration_reference/probes            # all three
+//   dotnet run --project spec/012-configuration_reference/probes -- default
+//   dotnet run --project spec/012-configuration_reference/probes -- packages
+//   dotnet run --project spec/012-configuration_reference/probes -- synthesis
+//   dotnet run --project spec/012-configuration_reference/probes -- counts     # TSV, task 1.5's oracle
+//
+// Exit code is the family contract the tools in `tools/` already run under:
+// 0 clean, 1 a real finding. A probe that cannot reach its subject exits 2.
+
+using Paramore.Docs.Probes;
+
+var which = args.Length > 0 ? args[0].ToLowerInvariant() : "all";
+
+var codes = new List<int>();
+
+if (which is "all" or "default")
+    codes.Add(DefaultProbe.Run());
+
+if (which is "all" or "packages")
+    codes.Add(PackageLoadProbe.Run());
+
+if (which is "all" or "synthesis")
+    codes.Add(SynthesisProbe.Run());
+
+// Not part of `all`: it prints TSV for `survey.py` to be diffed against, and
+// mixing that into the three probes' prose would make both harder to read.
+if (which is "counts")
+    codes.Add(CountsProbe.Run());
+
+if (codes.Count == 0)
+{
+    Console.Error.WriteLine($"unknown probe '{which}' — expected default, packages, synthesis or all");
+    return 2;
+}
+
+return codes.Max();

--- a/spec/012-configuration_reference/probes/README.md
+++ b/spec/012-configuration_reference/probes/README.md
@@ -1,0 +1,296 @@
+# Spec 012 — Phase 1 probes
+
+Four measurements taken before spec 012 writes a table, and the project that
+takes them. Everything here is **kept and re-runnable**; the numbers below are
+stamped at Brighter **`10.7.0`** and mean nothing without that ref.
+
+```bash
+dotnet run --project spec/012-configuration_reference/probes                 # 1.2, 1.3, 1.4
+dotnet run --project spec/012-configuration_reference/probes -- default      # task 1.2
+dotnet run --project spec/012-configuration_reference/probes -- packages     # task 1.3
+dotnet run --project spec/012-configuration_reference/probes -- synthesis    # task 1.4
+dotnet run --project spec/012-configuration_reference/probes -- counts       # task 1.5's oracle, TSV
+```
+
+Exit code is the family contract `linkcheck.py`, `pagelint.py` and
+`versioncheck.py` already run under: **0** clean, **1** a real finding, **2** the
+subject is unreachable. Nothing in CI runs these — they are a phase-1
+instrument, not a gate. The gate is phase 2's `optioncheck`.
+
+**`probes.csproj` is the pinned package list**, and task 2.1 carries it into
+`optioncheck.csproj` verbatim rather than re-deriving it, so the repository holds
+one proven list instead of two that can differ silently. No `.V4` packages:
+requirements §8 puts them out of scope and design §6.4 names them as the pair
+most likely to put two SDK majors in one process.
+
+---
+
+## Task 1.2 — the body-coalesced default: **PREMISE HOLDS**
+
+Requirements §5.1 reads `Subscription.cs:208` and `:236` and *infers* that
+`emptyChannelDelay` is `null` in the signature and 500 ms on the instance. It
+says of itself that reading the authority is not measuring it. Measured:
+
+```text
+emptyChannelDelay  ParameterInfo.DefaultValue = null
+EmptyChannelDelay  instance                   = 500 ms
+```
+
+The whole `Default` column, AC3b, and design §6.2's *one route for one column*
+rest on that difference, and it is real.
+
+**The shape is not rare and it is not uniform.** Of `Subscription`'s defaulted
+constructor parameters the probe left alone, **six say `null` in the signature
+and four come back as a value**:
+
+| Parameter | Signature | Instance |
+|---|---|---|
+| `timeOut` | `null` | 300 ms |
+| `requeueDelay` | `null` | 0 ms |
+| `emptyChannelDelay` | `null` | **500 ms** |
+| `channelFailureDelay` | `null` | 1000 ms |
+| `channelFactory` | `null` | `null` |
+| `unacceptableMessageLimitWindow` | `null` | `null` |
+
+The last two are why a checker cannot discriminate by reading the signature:
+`null` there means both *"there is no default"* and *"the default is assigned
+below"*, and nothing distinguishes them until you build the object.
+
+> **Found by construction, and requirements §5.1 could not have said it.**
+> `Subscription` **cannot be built from its required parameters alone.** The
+> constructor body throws `ConfigurationException` unless `messagePumpType` is
+> something other than its own default of `Unknown`, and unless one of
+> `requestType` / `getRequestType` is non-null. **Two defaulted parameters are
+> required in practice.** Task 1.4 measured how far that generalises: it is
+> **thirteen types**, every subscription in the product.
+
+---
+
+## Task 1.3 — every pinned package in one process: **CLEAN, with one thing to know**
+
+**64 `Paramore.Brighter` assemblies in one process** — the 62 packages
+`probes.csproj` names plus the Brighter packages they pull in — and **one type
+instantiated from each**, for real, not by metadata reflection. **65 distinct
+third-party assemblies** are referenced between them and every one of them
+loads.
+
+**Design §6.4's fallback is not needed. `optioncheck` can be a single project.**
+
+### The conflict is real, and it is not the pair design predicted
+
+§6.4 expected the AWS SDK pair, and removing the `.V4` packages did remove it.
+The disagreement that survives is **RabbitMQ**:
+
+```text
+RabbitMQ.Client: loaded 7.0.0.0, but Paramore.Brighter.MessagingGateway.RMQ.Sync
+                 asked for 6.0.0.0
+```
+
+One process holds one version of a simple name, so `RMQ.Sync` runs against an
+assembly it has never seen. **Exactly one of its 57 types fails to load** — the
+consumer, which derives from a `RabbitMQ.Client` type deleted in 7.x. Everything
+else in the package is fine.
+
+**It does not touch anything 012 documents**, which the probe asserts rather
+than assumes, because design §7.2's RabbitMQ ruling needs both packages:
+
+| Package | Result |
+|---|---|
+| `…RMQ.Async` | constructed, **24** ctor params, `queueType` **present** |
+| `…RMQ.Sync` | constructed, **23** ctor params, `queueType` **absent** |
+
+That is design §7.2's parameter diff **re-derived from the assemblies** rather
+than from source, by a second instrument: one table, the Async client's, and
+`queueType` is the one the Sync client does not have.
+
+**Record it, do not fix it.** The next Brighter package to reach into
+`RabbitMQ.Client` 6's API turns a latent disagreement into a load failure, and
+the fix then is one line — drop `RMQ.Sync` from the checker's `csproj`, since
+012 binds no type in it.
+
+### Eleven packages have nothing the synthesiser can build, and none of them matters
+
+`Paramore.Brighter.MsSql`, `.MySql`, `.PostgreSql`, `.Sqlite`, `.Spanner`,
+`Outbox.MongoDb`, `Outbox.Firestore`, `Inbox.MongoDb`, `Inbox.Firestore`,
+`Locking.Firestore` and `Archive.Azure`. Their public types are connection
+providers and store classes that want a live client or a real connection string
+— and **design §10 already says those pages have no options type**: *the absence
+of a configuration type is a fact about the product; the page reports it and
+links what is really there.* Not one of them is a type 012 writes a table from.
+
+---
+
+## Task 1.4 — design §6.3's synthesis table, by construction
+
+§6.3 says **24 types and 48 required parameters**, parsed with `survey.py`, and
+says in the section itself that it is not a measurement of the running tool.
+Constructed:
+
+| | §6.3 | Measured |
+|---|---:|---:|
+| Types with a parameterful public constructor | 24 | **34** |
+| Required parameters | 48 | **70** |
+| Needing a hand-written factory | 4 | **2** |
+
+**The population moved because the parser was wrong, not because the product
+changed** — see task 1.5 below. Two independent errors happened to be in it:
+
+- **`.V4` was subtracted twice over, and incompletely.** §6.3 says *"28 types
+  … excluding the four `.V4` duplicates"*. There are **six** `.V4` types with a
+  parameterful constructor; two of them carry no required parameter, which is
+  why the *parameter* arithmetic came out right and the *type* count did not.
+- **The parser could not see a primary constructor and assumed the class was the
+  file**, which is task 1.5's subject.
+
+**The rebuilt `survey.py` and this probe now agree exactly — 34 types, 70
+required parameters — one number from parsing source, one from constructing
+objects.**
+
+### The finding: thirteen constructors reject their own defaults
+
+Every subscription type in Brighter, plus `SqsSubscription`'s extra pair:
+
+```text
+InMemorySubscription, Subscription, SqsSubscription, AzureServiceBusSubscription,
+GcpPubSubSubscription, KafkaSubscription, MqttSubscription, MsSqlSubscription,
+PostgresSubscription, RmqSubscription (Async), RmqSubscription (Sync),
+RedisSubscription, RocketSubscription
+```
+
+All thirteen need `requestType` and `messagePumpType` supplied, and all thirteen
+need `makeChannels` — a defaulted `enum` whose declared default the body will
+not accept. `KafkaSubscription` needs six such parameters, `SqsSubscription`
+five, `GcpPubSubSubscription` four.
+
+**This is the one thing phase 2 must budget for that design does not name.**
+A synthesiser that supplies only the parameters carrying no default constructs
+**19** of the 34; supplying values for defaulted enum and `Type` parameters too
+takes it to **32**.
+
+### Only two types genuinely need a factory, and the other two are a caveat
+
+§6.3 names four: `MongoDbConfiguration`, `HandlerConfiguration`, `AWSS3Connection`
+and `S3LuggageOptions`. Measured, **`AzureBlobArchiveProviderOptions` and
+`S3LuggageOptions`** are the two that fail. The other three construct — because
+their unbuildable parameters are *reference* types, and passing `null` for one
+is accepted.
+
+**That is a smaller burden and a new obligation.** An instance built with `null`
+for its client or its credentials reads back defaults perfectly *unless a
+constructor body derives one from the missing object*. Phase 2 must decide that
+per type rather than per family, and where it cannot, the answer is a `manual:`
+declaration on the marker — which declares and counts — never a silent pass.
+
+---
+
+## Task 1.5 — `survey.py` rebuilt, and the totals moved
+
+**At `10.7.0`: 72 configuration types, 628 reader-facing options** — against the
+**67 and 619** every document in this spec quotes. Re-derive, never quote
+without the ref:
+
+```bash
+python3 spec/012-configuration_reference/survey.py --ref 10.7.0
+```
+
+The task asked for one fix — primary constructors, design §12.5. **Probe 1.4
+found two more of the same kind, and the reflection oracle found two beyond
+that.** All five are the same failure: the script was measuring something
+adjacent to the type it named, and reported a number rather than an error.
+
+| # | Defect | Found by | Cost |
+|---:|---|---|---|
+| 1 | **Primary constructors invisible.** `widest_ctor` matched `public TypeName(` *inside* a class body | design §12.5 | `InMemorySubscription` **2 → 17**; `PostgresLockingProviderOptions` and `PostgresMessagingGatewayConnection` absent from the population entirely |
+| 2 | **The class was assumed to be the file** | probe 1.4 | `RocketMqSubscription.cs` declares **`RocketSubscription`** (23, not 22); `AWSMessagingGatewayConfiguration.cs` declares **`AWSMessagingGatewayConnection`**; `MQTTMessagingGatewayConfiguration.cs` declares **`MqttMessagingGatewayConfiguration`** and two more |
+| 3 | **Properties counted per FILE, not per class** | probe 1.4 | `RmqMessagingGatewayConnection` **19 → 11**: the other 8 belong to `AmqpUriSpecification` and `Exchange`, which share its file |
+| 4 | **A generic type argument contains a SPACE** — `Dictionary<string, object>?` never matched | the oracle diff | `Publication` **8 → 10**, `AsyncApiOptions` 6 → 7, `AzureBlobLuggageOptions` 5 → 6, `InboxConfiguration` 0 → 1 settable |
+| 5 | **`private set`, `internal set` and `static` counted as reader-facing** | the oracle diff | `ProducersConfiguration` **26 → 22**, `MqttMessagingGatewayConfiguration` 8 → 7, `HandlerConfiguration` 2 → 0 settable |
+
+### How defects 4 and 5 were found, and why that method is worth keeping
+
+`survey.py --tsv` and `probes -- counts` print **the same quantity** — assembly,
+type, settable properties, widest constructor, `max` — one by parsing source and
+one by reflecting over the assemblies. Diffing them:
+
+```text
+survey 72, reflection 68, both 63, disagree 0
+```
+
+**Zero disagreements on all 63 types both instruments see.** The nine the survey
+sees alone are the `.V4` packages, which the probe deliberately does not
+reference. The five reflection sees alone carry **zero options** — `max` of 0 —
+and the survey drops them by rule.
+
+The first run of that diff had **nine** disagreements. Every one was a defect in
+the parser and none was visible any other way: each returned a plausible smaller
+number. **Run this diff after any change to `survey.py`.**
+
+### The rows that moved against design §7
+
+Design §7 is approved and this does not amend it. What it does is discharge
+standing obligation 3 in advance — *write the table from the type, never from
+the survey* — by saying which rows a writer would have copied wrongly:
+
+| Type | Design §7 | Measured `10.7.0` | Page |
+|---|---:|---:|---|
+| `ProducersConfiguration` | 26 | **22** | `CommandProcessorConfigurationReference.md` (D4) |
+| `Publication` | 8 | **10** | `CommandProcessorConfigurationReference.md` (D4) |
+| `RmqMessagingGatewayConnection` | 19 | **11** | `RabbitMQConfiguration.md` (D6) |
+| `RmqSubscription` (Sync) | 24 | **23** | not documented — the page carries the Async table |
+| `InMemorySubscription` | 2 † | **17** | `InMemoryTransport.md` (D6) |
+| `RocketMqSubscription` | 22 | **`RocketSubscription`, 23** | `RocketMQConfiguration.md` (D12) |
+| `MQTTMessagingGatewayConfiguration` | 8 | **`MqttMessagingGatewayConfiguration`, 7** | `MQTTConfiguration.md` (D12) |
+| `AsyncApiOptions` | 6 | **7** | `AsyncAPISupport.md` (P2, task 8.4) |
+| `AzureBlobLuggageOptions` | 5 | **6** | P2, unscheduled |
+
+**Two of those are type NAMES, not counts, and they matter more.** A marker
+binds a fully-qualified type; `<!-- optioncheck: …RocketMqSubscription -->` and
+`…MQTTMessagingGatewayConfiguration` name types that do not exist, and the
+checker would exit 1 with *the type is gone*. It fails loudly, which is the
+design working — but it fails in phase 6, and it is free to fix now.
+
+**`D4 is 47 options over 5 tables` becomes 45**: `ProducersConfiguration` loses
+4 and `Publication` gains 2.
+
+### Design §12.5 overstates its own effect, and §2.9 of `tasks.md` inherits that
+
+§12.5 measures 13 primary-constructor surfaces and **40 parameters**, and
+`tasks.md` §2.9 turns that into per-type claims — *"`FirestoreConfiguration`
+under-counted by 2"*, *"`AzureBlobLockingProviderOptions` by 2"*. Those are
+**additive** claims, and the convention is **`max(props, ctor)`** (design §2,
+`survey.py`). Measured with the primary constructor now readable, **three of the
+thirteen move**:
+
+| Surface | Design §7 | Now | Why |
+|---|---:|---:|---|
+| `InMemorySubscription` | 2 | **17** | 17 primary-ctor params against 2 properties |
+| `PostgresLockingProviderOptions` | — | **1** | was absent from the population |
+| `PostgresMessagingGatewayConnection` | — | **1** | was absent from the population |
+| `FirestoreConfiguration` | 7 | 7 | 7 properties, 2 primary-ctor params — `max` is 7 |
+| `AzureBlobLockingProviderOptions` | 3 | 3 | its two ctor parameters are **assigned to two of its three properties** |
+| `DynamoDbLockingProviderOptions` | 4 | 4 | same shape |
+| `DynamoDbInboxConfiguration` | 1 | 1 | same shape |
+| `RocketMessagingGatewayConnection` | 4 | 4 | same shape |
+| the five P2 types | — | unchanged | same shape |
+
+**A C# primary constructor on a class assigns to properties rather than creating
+them**, so its parameters are usually the same options the properties already
+are. That is why `max` is the right convention and why counting them as
+additional would double-count.
+
+**§2.9's verdict is untouched and its instruction is the right one** — *never
+infer from an unmarked row that its figure is a total* — and this is that
+instruction applied to §2.9 itself.
+
+### Two things neither instrument counts
+
+- **Public fields.** `AzureBlobLockingProviderOptions.StorageLocationFunc` is a
+  public field with a default, reader-facing in every sense, and invisible to a
+  property scan and to `PropertyInfo` alike. There are few, and phase 8 should
+  look at the type rather than at either tool.
+- **Surface types whose name does not say so.** `AmqpUriSpecification` and
+  `Exchange` are configuration a RabbitMQ reader writes by hand, and neither name
+  ends in one of the five suffixes. The old survey counted their properties by
+  accident, as part of `RmqMessagingGatewayConnection`'s file; the new one drops
+  them honestly. **Phase 5 owns the decision** about whether
+  `RabbitMQConfiguration.md` gains a table for them.

--- a/spec/012-configuration_reference/probes/SynthesisProbe.cs
+++ b/spec/012-configuration_reference/probes/SynthesisProbe.cs
@@ -1,0 +1,169 @@
+using System.Reflection;
+
+namespace Paramore.Docs.Probes;
+
+/// <summary>
+/// Task 1.4 — re-derive design §6.3's synthesis table BY CONSTRUCTION.
+///
+/// §6.3 is parsed from source with `survey.py`'s own parser and says about
+/// itself that it is not a measurement of the running tool. This constructs
+/// every type in that population and reports what actually happened, which is
+/// the only route that can see a constructor body rejecting its own defaults.
+///
+/// The population is the one `survey.py` counts: a type whose name says it is a
+/// configuration surface and whose widest public constructor takes at least one
+/// parameter. `.V4` packages are out of scope (requirements §8) and are not
+/// referenced by this project, so they cannot appear.
+/// </summary>
+internal static class SynthesisProbe
+{
+    public static int Run()
+    {
+        Console.WriteLine();
+        Console.WriteLine("PROBE 1.4 — design §6.3's synthesis table, by construction");
+        Console.WriteLine();
+
+        var types = SurfaceTypes().ToList();
+        if (types.Count == 0)
+        {
+            Console.Error.WriteLine("no surface types found — has the project been built?");
+            return 2;
+        }
+
+        Console.WriteLine($"{"type",-38} {"package",-46} {"req",3} {"pass",4}  outcome");
+        Console.WriteLine(new string('-', 118));
+
+        var required = 0;
+        var pass1 = new List<Type>();
+        var pass2 = new List<(Type Type, string Why)>();
+        var failed = new List<(Type Type, string Why)>();
+
+        foreach (var type in types)
+        {
+            var ctor = WidestCtor(type)!;
+            var need = ctor.GetParameters().Count(p => !p.HasDefaultValue);
+            required += need;
+
+            var result = Synthesiser.TryCreate(type);
+
+            if (!result.Ok)
+            {
+                failed.Add((type, result.Error ?? "unknown"));
+                Console.WriteLine($"{type.Name,-38} {Package(type),-46} {need,3} {"—",4}  NEEDS A FACTORY");
+                continue;
+            }
+
+            if (result.Pass == 1)
+            {
+                pass1.Add(type);
+                Console.WriteLine($"{type.Name,-38} {Package(type),-46} {need,3} {1,4}  constructed");
+            }
+            else
+            {
+                var why = ValidatedDefaults(ctor);
+                pass2.Add((type, why));
+                Console.WriteLine($"{type.Name,-38} {Package(type),-46} {need,3} {2,4}  constructed, "
+                                  + "defaults overridden");
+            }
+        }
+
+        Console.WriteLine();
+        Console.WriteLine($"{types.Count} types with a parameterful public constructor, "
+                          + $"{required} parameters carrying no default.");
+        Console.WriteLine();
+        Console.WriteLine($"  {pass1.Count,3} built from their required parameters alone");
+        Console.WriteLine($"  {pass2.Count,3} built only after a DEFAULTED parameter was overridden");
+        Console.WriteLine($"  {failed.Count,3} need a hand-written factory or a `manual:` declaration");
+
+        if (pass2.Count > 0)
+        {
+            Console.WriteLine();
+            Console.WriteLine("The pass-2 types — a constructor body that rejects its own defaults, which no");
+            Console.WriteLine("parse of a signature can see:");
+            foreach (var (type, why) in pass2)
+                Console.WriteLine($"  {type.Name}: {why}");
+        }
+
+        if (failed.Count > 0)
+        {
+            Console.WriteLine();
+            Console.WriteLine("The types needing a factory:");
+            foreach (var (type, why) in failed)
+                Console.WriteLine($"  {type.Name}: {why}");
+        }
+
+        Console.WriteLine();
+        Console.WriteLine("Against design §6.3, which claims 24 types and 48 required parameters:");
+        Console.WriteLine($"  types              measured {types.Count}, §6.3 says 24");
+        Console.WriteLine($"  required params    measured {required}, §6.3 says 48");
+        Console.WriteLine($"  needing a factory  measured {failed.Count}, §6.3 says 4");
+
+        // A synthesiser that covers all but the hand-written cases is the claim
+        // §6.3 makes and the one phase 2 builds on. The probe reports the shape;
+        // the arithmetic reconciliation lives in probes/README.md, where it can
+        // say WHY a figure moved.
+        return 0;
+    }
+
+    private static IEnumerable<Type> SurfaceTypes()
+    {
+        var assemblies = Directory
+            .GetFiles(AppContext.BaseDirectory, "Paramore.Brighter*.dll")
+            .Select(Path.GetFileNameWithoutExtension)
+            .Where(n => n is not null)
+            .Select(n => n!)
+            .OrderBy(n => n, StringComparer.Ordinal);
+
+        foreach (var name in assemblies)
+        {
+            Assembly assembly;
+            try { assembly = Assembly.Load(name); }
+            catch { continue; }
+
+            Type[] types;
+            try { types = assembly.GetTypes(); }
+            catch (ReflectionTypeLoadException ex)
+            {
+                types = ex.Types.Where(t => t is not null).Select(t => t!).ToArray();
+            }
+
+            foreach (var type in types.OrderBy(t => t.FullName, StringComparer.Ordinal))
+            {
+                if (type is not { IsPublic: true, IsAbstract: false, IsClass: true }
+                    || type.IsGenericTypeDefinition
+                    || !IsSurfaceName(type.Name))
+                    continue;
+
+                if (WidestCtor(type) is { } ctor && ctor.GetParameters().Length > 0)
+                    yield return type;
+            }
+        }
+    }
+
+    private static ConstructorInfo? WidestCtor(Type type) =>
+        type.GetConstructors(BindingFlags.Public | BindingFlags.Instance)
+            .OrderByDescending(c => c.GetParameters().Length)
+            .FirstOrDefault();
+
+    /// <summary>The defaulted parameters pass 2 had to supply a value for.</summary>
+    private static string ValidatedDefaults(ConstructorInfo ctor)
+    {
+        var names = ctor.GetParameters()
+            .Where(p => p.HasDefaultValue)
+            .Where(p => p.ParameterType.IsEnum || p.ParameterType == typeof(Type))
+            .Select(p => p.Name)
+            .Where(n => n is not null)
+            .ToList();
+
+        return names.Count == 0 ? "a defaulted parameter" : string.Join(", ", names);
+    }
+
+    private static string Package(Type type) => type.Assembly.GetName().Name ?? "?";
+
+    private static bool IsSurfaceName(string name) =>
+        name.EndsWith("Subscription", StringComparison.Ordinal)
+        || name.EndsWith("Publication", StringComparison.Ordinal)
+        || name.EndsWith("Configuration", StringComparison.Ordinal)
+        || name.EndsWith("Options", StringComparison.Ordinal)
+        || name.EndsWith("Connection", StringComparison.Ordinal);
+}

--- a/spec/012-configuration_reference/probes/Synthesiser.cs
+++ b/spec/012-configuration_reference/probes/Synthesiser.cs
@@ -1,0 +1,145 @@
+using System.Reflection;
+
+namespace Paramore.Docs.Probes;
+
+/// <summary>
+/// The argument synthesiser design §6.3 sizes: strings, enums, and the three
+/// subscription arguments. `optioncheck` needs one because reading a default
+/// off an instance means building the instance first (design §6.2).
+///
+/// Two passes, and the difference between them is a measurement rather than an
+/// implementation detail:
+///
+///   pass 1 — required parameters synthesised, optional ones left at their own
+///            declared default. This is what a reader of the signature would
+///            predict is enough.
+///   pass 2 — optional parameters synthesised too, where the synthesiser has a
+///            value for them. Needed only where the constructor body VALIDATES
+///            a defaulted parameter, which no parse of the signature can see.
+/// </summary>
+internal static class Synthesiser
+{
+    internal sealed record Result(object? Instance, int Pass, string? Error, ConstructorInfo? Ctor)
+    {
+        public bool Ok => Instance is not null;
+    }
+
+    public static Result TryCreate(Type type) => TryCreate(type, depth: 0);
+
+    private static Result TryCreate(Type type, int depth)
+    {
+        var ctor = type.GetConstructors(BindingFlags.Public | BindingFlags.Instance)
+            .OrderByDescending(c => c.GetParameters().Length)
+            .FirstOrDefault();
+
+        if (ctor is null)
+            return new Result(null, 0, "no public constructor", null);
+
+        string? firstError = null;
+
+        for (var pass = 1; pass <= 2; pass++)
+        {
+            var args = new object?[ctor.GetParameters().Length];
+            var unsynthesisable = (ParameterInfo?)null;
+
+            foreach (var p in ctor.GetParameters())
+            {
+                if (p.HasDefaultValue && pass == 1)
+                {
+                    args[p.Position] = p.DefaultValue;
+                    continue;
+                }
+
+                var value = Synthesise(p.ParameterType, depth);
+                if (value is null && !IsNullable(p))
+                {
+                    if (p.HasDefaultValue)
+                    {
+                        // pass 2 has nothing better to offer than the declared default
+                        args[p.Position] = p.DefaultValue;
+                        continue;
+                    }
+
+                    unsynthesisable = p;
+                    break;
+                }
+
+                args[p.Position] = value ?? (p.HasDefaultValue ? p.DefaultValue : null);
+            }
+
+            if (unsynthesisable is not null)
+                return new Result(null, pass,
+                    $"cannot synthesise {Pretty(unsynthesisable.ParameterType)} {unsynthesisable.Name}", ctor);
+
+            try
+            {
+                return new Result(ctor.Invoke(args), pass, null, ctor);
+            }
+            catch (Exception ex)
+            {
+                var inner = ex.InnerException ?? ex;
+                firstError ??= $"{inner.GetType().Name}: {inner.Message}";
+            }
+        }
+
+        return new Result(null, 2, firstError, ctor);
+    }
+
+    /// <summary>A value for a parameter type, or null where the synthesiser has none.</summary>
+    private static object? Synthesise(Type t, int depth)
+    {
+        var underlying = Nullable.GetUnderlyingType(t) ?? t;
+
+        if (underlying == typeof(string)) return "probe";
+        if (underlying == typeof(Type)) return typeof(ProbeRequest);
+        if (underlying == typeof(bool)) return false;
+        if (underlying == typeof(int)) return 1;
+        if (underlying == typeof(long)) return 1L;
+        if (underlying == typeof(double)) return 1d;
+        if (underlying == typeof(TimeSpan)) return TimeSpan.FromMilliseconds(1);
+        if (underlying == typeof(Uri)) return new Uri("https://probe.invalid");
+
+        if (underlying.IsEnum)
+        {
+            // `MessagePumpType.Unknown` is 0 and the Subscription constructor
+            // throws on it, so a zero-valued enum member named Unknown or None
+            // is exactly the wrong choice.
+            var names = Enum.GetNames(underlying);
+            var usable = names.FirstOrDefault(n => n is not ("Unknown" or "None"));
+            return usable is null ? Enum.GetValues(underlying).GetValue(0) : Enum.Parse(underlying, usable);
+        }
+
+        // Brighter's own types — the single-string value types first
+        // (SubscriptionName, ChannelName, RoutingKey, Id; design §6.3's "three
+        // subscription arguments" are all of this shape), then, one level down,
+        // any Brighter class the synthesiser can build from those same rules.
+        // `RelationalDatabaseConfiguration` is the case that earns the recursion:
+        // thirteen pages link its table (design §12.4) and every component that
+        // takes it is a type `optioncheck` will have to construct.
+        if (underlying.Namespace?.StartsWith("Paramore.Brighter") != true
+            || underlying.IsAbstract || underlying.IsInterface || depth >= 2)
+            return null;
+
+        var single = underlying.GetConstructors(BindingFlags.Public | BindingFlags.Instance)
+            .FirstOrDefault(c => c.GetParameters().Length == 1
+                                 && c.GetParameters()[0].ParameterType == typeof(string));
+
+        if (single is not null)
+        {
+            try { return single.Invoke(["probe"]); }
+            catch { return null; }
+        }
+
+        return TryCreate(underlying, depth + 1).Instance;
+    }
+
+    private static bool IsNullable(ParameterInfo p) =>
+        !p.ParameterType.IsValueType || Nullable.GetUnderlyingType(p.ParameterType) is not null;
+
+    public static string Pretty(Type t)
+    {
+        if (!t.IsGenericType) return t.Name;
+        var name = t.Name[..t.Name.IndexOf('`')];
+        return $"{name}<{string.Join(", ", t.GetGenericArguments().Select(Pretty))}>";
+    }
+}

--- a/spec/012-configuration_reference/probes/probes.csproj
+++ b/spec/012-configuration_reference/probes/probes.csproj
@@ -1,0 +1,120 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <!-- net9.0, matching the runtime design §6.5 pins for the `options` CI job. -->
+    <TargetFramework>net9.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <RootNamespace>Paramore.Docs.Probes</RootNamespace>
+    <AssemblyName>probes</AssemblyName>
+    <!-- Probe 1.3 loads every referenced package assembly by name. A package
+         whose types are never mentioned in source is otherwise trimmed out of
+         the output directory by the build, and the probe would then report a
+         load failure that is an artefact of the build rather than a conflict. -->
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+    <!-- The probes deliberately construct types with obsolete members and read
+         defaults off them; a warning is not a finding here. -->
+    <NoWarn>$(NoWarn);CS0618</NoWarn>
+  </PropertyGroup>
+
+  <!-- THE PINNED SURFACE PACKAGE LIST.
+       10.7.0 throughout — the version every figure in this spec is stamped at
+       (tasks.md §2.6). Task 2.1 carries this list into `optioncheck.csproj`
+       verbatim rather than re-deriving it, so that the repository holds one
+       proven list instead of two that can differ silently.
+
+       NO `.V4` PACKAGES. Requirements §8 puts them out of scope as separate
+       surfaces, and they are exactly the pairs that would put two AWS SDK
+       majors in one process (design §6.4). -->
+  <ItemGroup Label="Core — design §7.1">
+    <PackageReference Include="Paramore.Brighter" Version="10.7.0" />
+    <PackageReference Include="Paramore.Brighter.Extensions.DependencyInjection" Version="10.7.0" />
+    <PackageReference Include="Paramore.Brighter.ServiceActivator.Extensions.DependencyInjection" Version="10.7.0" />
+  </ItemGroup>
+
+  <ItemGroup Label="Transports — design §7.2">
+    <PackageReference Include="Paramore.Brighter.MessagingGateway.RMQ.Async" Version="10.7.0" />
+    <PackageReference Include="Paramore.Brighter.MessagingGateway.RMQ.Sync" Version="10.7.0" />
+    <PackageReference Include="Paramore.Brighter.MessagingGateway.Kafka" Version="10.7.0" />
+    <PackageReference Include="Paramore.Brighter.MessagingGateway.AWSSQS" Version="10.7.0" />
+    <PackageReference Include="Paramore.Brighter.MessagingGateway.AzureServiceBus" Version="10.7.0" />
+    <PackageReference Include="Paramore.Brighter.MessagingGateway.Postgres" Version="10.7.0" />
+    <PackageReference Include="Paramore.Brighter.MessagingGateway.GcpPubSub" Version="10.7.0" />
+    <PackageReference Include="Paramore.Brighter.MessagingGateway.Redis" Version="10.7.0" />
+    <PackageReference Include="Paramore.Brighter.MessagingGateway.RocketMQ" Version="10.7.0" />
+    <PackageReference Include="Paramore.Brighter.MessagingGateway.MQTT" Version="10.7.0" />
+    <PackageReference Include="Paramore.Brighter.MessagingGateway.MsSql" Version="10.7.0" />
+  </ItemGroup>
+
+  <ItemGroup Label="Outbox, inbox and box provisioning — design §7.3">
+    <PackageReference Include="Paramore.Brighter.Outbox.DynamoDB" Version="10.7.0" />
+    <PackageReference Include="Paramore.Brighter.Outbox.MongoDb" Version="10.7.0" />
+    <PackageReference Include="Paramore.Brighter.Outbox.Firestore" Version="10.7.0" />
+    <PackageReference Include="Paramore.Brighter.Outbox.MsSql" Version="10.7.0" />
+    <PackageReference Include="Paramore.Brighter.Outbox.MySql" Version="10.7.0" />
+    <PackageReference Include="Paramore.Brighter.Outbox.PostgreSql" Version="10.7.0" />
+    <PackageReference Include="Paramore.Brighter.Outbox.Spanner" Version="10.7.0" />
+    <PackageReference Include="Paramore.Brighter.Outbox.Sqlite" Version="10.7.0" />
+    <PackageReference Include="Paramore.Brighter.Outbox.Hosting" Version="10.7.0" />
+    <PackageReference Include="Paramore.Brighter.Inbox.DynamoDB" Version="10.7.0" />
+    <PackageReference Include="Paramore.Brighter.Inbox.MongoDb" Version="10.7.0" />
+    <PackageReference Include="Paramore.Brighter.Inbox.Firestore" Version="10.7.0" />
+    <PackageReference Include="Paramore.Brighter.Inbox.MsSql" Version="10.7.0" />
+    <PackageReference Include="Paramore.Brighter.Inbox.MySql" Version="10.7.0" />
+    <PackageReference Include="Paramore.Brighter.Inbox.Postgres" Version="10.7.0" />
+    <PackageReference Include="Paramore.Brighter.Inbox.Spanner" Version="10.7.0" />
+    <PackageReference Include="Paramore.Brighter.Inbox.Sqlite" Version="10.7.0" />
+    <PackageReference Include="Paramore.Brighter.BoxProvisioning" Version="10.7.0" />
+    <PackageReference Include="Paramore.Brighter.BoxProvisioning.MsSql" Version="10.7.0" />
+    <PackageReference Include="Paramore.Brighter.BoxProvisioning.MySql" Version="10.7.0" />
+    <PackageReference Include="Paramore.Brighter.BoxProvisioning.PostgreSql" Version="10.7.0" />
+    <PackageReference Include="Paramore.Brighter.BoxProvisioning.Spanner" Version="10.7.0" />
+    <PackageReference Include="Paramore.Brighter.BoxProvisioning.Sqlite" Version="10.7.0" />
+  </ItemGroup>
+
+  <ItemGroup Label="Relational configuration hosts — design §7.3 and §12.4">
+    <PackageReference Include="Paramore.Brighter.MsSql" Version="10.7.0" />
+    <PackageReference Include="Paramore.Brighter.MySql" Version="10.7.0" />
+    <PackageReference Include="Paramore.Brighter.PostgreSql" Version="10.7.0" />
+    <PackageReference Include="Paramore.Brighter.Spanner" Version="10.7.0" />
+    <PackageReference Include="Paramore.Brighter.Sqlite" Version="10.7.0" />
+    <PackageReference Include="Paramore.Brighter.MongoDb" Version="10.7.0" />
+    <PackageReference Include="Paramore.Brighter.Firestore" Version="10.7.0" />
+  </ItemGroup>
+
+  <ItemGroup Label="Locks — design §7.4">
+    <PackageReference Include="Paramore.Brighter.Locking.DynamoDB" Version="10.7.0" />
+    <PackageReference Include="Paramore.Brighter.Locking.Azure" Version="10.7.0" />
+    <PackageReference Include="Paramore.Brighter.Locking.PostgresSql" Version="10.7.0" />
+    <PackageReference Include="Paramore.Brighter.Locking.MongoDb" Version="10.7.0" />
+    <PackageReference Include="Paramore.Brighter.Locking.Firestore" Version="10.7.0" />
+    <PackageReference Include="Paramore.Brighter.Locking.MsSql" Version="10.7.0" />
+    <PackageReference Include="Paramore.Brighter.Locking.MySql" Version="10.7.0" />
+  </ItemGroup>
+
+  <ItemGroup Label="Schedulers — design §7.5">
+    <PackageReference Include="Paramore.Brighter.MessageScheduler.AWS" Version="10.7.0" />
+    <PackageReference Include="Paramore.Brighter.MessageScheduler.Azure" Version="10.7.0" />
+    <PackageReference Include="Paramore.Brighter.MessageScheduler.Hangfire" Version="10.7.0" />
+    <PackageReference Include="Paramore.Brighter.MessageScheduler.Quartz" Version="10.7.0" />
+    <PackageReference Include="Paramore.Brighter.MessageScheduler.TickerQ" Version="10.7.0" />
+  </ItemGroup>
+
+  <!-- Design §7.6 files these under P2 and 012 does not schedule their pages
+       (bar `AsyncAPISupport.md`, which task 8.4 owns). They are here because
+       §6.3's synthesis table counts their types — `AWSS3Connection` and
+       `S3LuggageOptions` are two of its four "objects the tool must build" —
+       so probe 1.4 cannot reproduce that table without them. They also carry
+       three more third-party SDKs into the process, which is what probe 1.3
+       is looking for. -->
+  <ItemGroup Label="Luggage, archive and AsyncAPI — design §7.6">
+    <PackageReference Include="Paramore.Brighter.Transformers.AWS" Version="10.7.0" />
+    <PackageReference Include="Paramore.Brighter.Transformers.Azure" Version="10.7.0" />
+    <PackageReference Include="Paramore.Brighter.Transformers.Gcp" Version="10.7.0" />
+    <PackageReference Include="Paramore.Brighter.Transformers.MongoGridFS" Version="10.7.0" />
+    <PackageReference Include="Paramore.Brighter.Archive.Azure" Version="10.7.0" />
+    <PackageReference Include="Paramore.Brighter.AsyncAPI" Version="10.7.0" />
+  </ItemGroup>
+
+</Project>

--- a/spec/012-configuration_reference/survey.py
+++ b/spec/012-configuration_reference/survey.py
@@ -12,7 +12,7 @@ them.
 
 So this script counts both shapes and says which is which. It reads source at a
 git ref via `git show`, so it never touches the sibling working tree -- which is
-on another agent's branch and 173 commits past the release.
+on another agent's branch and well past the release.
 
 It is a *source* survey and it says so. The real checker (`optioncheck`, spec
 012's D-tool) reflects over restored NuGet packages; this exists to size the work
@@ -21,6 +21,28 @@ and to record the two shapes, not to be that tool.
     python3 spec/012-configuration_reference/survey.py            # default ref 10.7.0
     python3 spec/012-configuration_reference/survey.py --ref 10.8.0
     python3 spec/012-configuration_reference/survey.py --repo ../Brighter
+    python3 spec/012-configuration_reference/survey.py --tsv      # one row per type
+
+TASK 1.5 REBUILT THE PARSER, and the totals moved. Three defects, all of the
+same kind -- the script was reading something adjacent to the type it named:
+
+1. **C# primary constructors were invisible.** `widest_ctor` matched
+   `public TypeName(` *inside* a class body, and a primary constructor is on the
+   declaration line. Design §12.5 measured the cost at 13 surface types and 40
+   parameters, two of them absent from the count altogether.
+2. **The class was assumed to be the file.** `RocketMqSubscription.cs` declares
+   `RocketSubscription`; `AWSMessagingGatewayConfiguration.cs` declares
+   `AWSMessagingGatewayConnection`; `MQTTMessagingGatewayConfiguration.cs`
+   declares `MqttMessagingGatewayConfiguration` and two more beside it. The old
+   script looked for a constructor named after the *file* and, finding none,
+   silently counted properties only.
+3. **Properties were counted per FILE, not per class**, so a file holding three
+   classes gave all three's properties to one of them.
+
+The population is now every public non-generic class whose *own name* says it is
+a configuration surface, which is the population `optioncheck` will reflect over.
+`probes/CountsProbe.cs` prints the same quantity from the assemblies; the two
+instruments agree type by type, and the reconciliation is in probes/README.md.
 """
 
 import argparse
@@ -32,25 +54,48 @@ from collections import Counter
 DEFAULT_REF = "10.7.0"
 DEFAULT_REPO = "../Brighter"
 
-# Files whose names say "I am a configuration surface".
-SURFACE_RE = re.compile(r"(Subscription|Publication|Configuration|Options|Connection)\.cs$")
+# A type name that says "I am a configuration surface". Applied to the CLASS,
+# not to the file: task 1.5 found four files whose name is not the name of the
+# type inside them.
+SURFACE_RE = re.compile(r"(Subscription|Publication|Configuration|Options|Connection)$")
 
-# A public instance property with an accessible setter or init accessor.
+# A class or record declaration, capturing the name and the position from which
+# a primary-constructor parameter list would start.
+DECL_RE = re.compile(
+    r"^[ \t]*public\s+"
+    r"(?:(?:sealed|abstract|partial|static|unsafe|readonly)\s+)*"
+    r"(?:class|record\s+class|record|struct)\s+"
+    r"(\w+)",
+    re.M,
+)
+
+# A public INSTANCE property declaration, up to the `{` that opens its accessor
+# block. Three things in this pattern were each worth a wrong number:
+#
+#   * the type may carry a generic argument list, and that list contains a SPACE
+#     -- `Dictionary<string, object>?`. The pattern that did not allow one
+#     silently dropped four properties, across `Publication`,
+#     `InboxConfiguration`, `AsyncApiOptions` and `AzureBlobLuggageOptions`;
+#   * `static` is excluded. `RedisMessagingGatewayConfiguration` declares a
+#     static property, which is not an option on an instance and which
+#     reflection does not return for one;
+#   * the accessor block is taken by BRACE MATCHING rather than by `[^}]*`,
+#     because a full property spanning several lines -- `EntryLimit` on
+#     `InMemoryBoxConfiguration`, `BucketName` on two luggage options -- has
+#     braces inside it.
 PROP_RE = re.compile(
-    r"^\s*public\s+(?!class|record|struct|interface|enum|delegate|const\b)"
+    r"^[ \t]*public\s+(?!class|record|struct|interface|enum|delegate|const\b|static\b|event\b)"
     r"(?:virtual\s+|override\s+|new\s+|required\s+|sealed\s+)*"
-    r"([\w<>\[\],\?\.]+)\s+(\w+)\s*\{[^}]*\b(?:set|init)\b",
+    r"([\w\.\?\[\]]+(?:<[^<>]*(?:<[^<>]*>)?[^<>]*>)?[\?\[\]]*)\s+(\w+)\s*\{",
     re.M,
 )
 
-# A public instance property with no setter -- ctor-assigned, so its default
-# lives in the constructor parameter rather than on the property.
-GETONLY_RE = re.compile(
-    r"^\s*public\s+(?!class|record|struct|interface|enum|delegate|const\b)"
-    r"(?:virtual\s+|override\s+|new\s+|required\s+|sealed\s+)*"
-    r"([\w<>\[\],\?\.]+)\s+(\w+)\s*\{\s*get;\s*\}",
-    re.M,
-)
+# A setter the READER can reach. `{ get; private set; }` and
+# `{ get; internal set; }` are not options a reader sets, and reflection agrees:
+# `PropertyInfo.SetMethod.IsPublic` is false for both.
+PUBLIC_SET_RE = re.compile(
+    r"(?<!private )(?<!protected )(?<!internal )\b(?:set|init)\s*(?:;|=>|\{)")
+GET_RE = re.compile(r"\bget\s*(?:;|=>|\{)")
 
 
 def git_show(repo, ref, path):
@@ -61,14 +106,25 @@ def git_show(repo, ref, path):
     return r.stdout if r.returncode == 0 else ""
 
 
-def list_files(repo, ref):
+def candidate_files(repo, ref):
+    """Files declaring a surface-named type, found by content rather than by name.
+
+    `git grep` over the ref costs one process; `git show` on every .cs file under
+    src/ costs two thousand. The pattern is deliberately loose -- it selects
+    files to parse, and the parser decides what counts. No `\\b` in it: git's ERE
+    does not support one, and it fails by matching NOTHING rather than by erroring.
+    """
     r = subprocess.run(
-        ["git", "-C", repo, "ls-tree", "-r", "--name-only", ref, "--", "src/"],
+        ["git", "-C", repo, "grep", "-l", "-E",
+         r"public [A-Za-z ]*(class|record|struct) [A-Za-z0-9_]*"
+         r"(Subscription|Publication|Configuration|Options|Connection)",
+         ref, "--", "src/"],
         capture_output=True, text=True,
     )
-    if r.returncode != 0:
-        sys.exit(f"cannot list tree at {ref}: {r.stderr.strip()}")
-    return [f for f in r.stdout.split() if f.endswith(".cs")]
+    if r.returncode not in (0, 1):
+        sys.exit(f"cannot search tree at {ref}: {r.stderr.strip()}")
+    # `git grep <ref>` prefixes each path with "<ref>:".
+    return sorted(line.split(":", 1)[1] for line in r.stdout.splitlines() if ":" in line)
 
 
 def split_params(body):
@@ -89,22 +145,109 @@ def split_params(body):
     return [p.strip() for p in parts if p.strip()]
 
 
-def widest_ctor(source, cls):
-    """The widest public constructor's parameters -- Brighter's subscriptions
+def matched(source, i, opener, closer):
+    """From the opening delimiter at `i`, the index just past its partner."""
+    depth = 0
+    while i < len(source):
+        if source[i] == opener:
+            depth += 1
+        elif source[i] == closer:
+            depth -= 1
+            if depth == 0:
+                return i + 1
+        i += 1
+    return len(source)
+
+
+def declarations(source):
+    """Every public class in `source`: name, primary-ctor params, and body.
+
+    Generic types are skipped. They are not a surface a reader configures --
+    `RocketMqSubscription<T>` and `Subscription<T>` both exist only to type a
+    non-generic base -- and reflection would report them separately, which would
+    make the two instruments disagree by construction.
+    """
+    out = []
+    for m in DECL_RE.finditer(source):
+        name = m.group(1)
+        i = m.end()
+
+        # Generic parameter list, if any -- and if there is one, skip the type.
+        while i < len(source) and source[i] in " \t":
+            i += 1
+        if i < len(source) and source[i] == "<":
+            continue
+
+        primary = []
+        if i < len(source) and source[i] == "(":
+            end = matched(source, i, "(", ")")
+            primary = split_params(source[i + 1:end - 1])
+            i = end
+
+        # Skip a base list, then take the body by brace matching. A record with
+        # no body ends in `;` and has no members beyond its primary constructor.
+        brace = source.find("{", i)
+        semi = source.find(";", i)
+        if brace == -1 or (semi != -1 and semi < brace):
+            out.append((name, primary, ""))
+            continue
+
+        out.append((name, primary, source[brace:matched(source, brace, "{", "}")]))
+    return out
+
+
+def properties(body):
+    """A class body's public instance properties, split settable / get-only.
+
+    A get-only property is ctor-assigned, so its default lives in the
+    constructor parameter rather than on the property -- which is the whole
+    reason this script counts two shapes.
+    """
+    settable, readonly = [], []
+    for m in PROP_RE.finditer(body):
+        block = body[m.end() - 1:matched(body, m.end() - 1, "{", "}")]
+        if PUBLIC_SET_RE.search(block):
+            settable.append((m.group(1), m.group(2)))
+        elif GET_RE.search(block):
+            readonly.append((m.group(1), m.group(2)))
+    return settable, readonly
+
+
+def widest_ctor(body, cls):
+    """The widest classic constructor's parameters -- Brighter's subscriptions
     offer a narrow convenience ctor and a wide one; the wide one is the surface."""
     best = []
-    for m in re.finditer(rf"\bpublic\s+{re.escape(cls)}\s*\(", source):
-        i, depth, start = m.end(), 1, m.end()
-        while i < len(source) and depth:
-            if source[i] == "(":
-                depth += 1
-            elif source[i] == ")":
-                depth -= 1
-            i += 1
-        params = split_params(source[start:i - 1])
+    for m in re.finditer(rf"\bpublic\s+{re.escape(cls)}\s*\(", body):
+        params = split_params(body[m.end():matched(body, m.end() - 1, "(", ")") - 1])
         if len(params) > len(best):
             best = params
     return best
+
+
+def survey(repo, ref):
+    rows = []
+    for path in candidate_files(repo, ref):
+        source = git_show(repo, ref, path)
+        if not source:
+            continue
+        asm = path.split("/")[1]
+        for name, primary, body in declarations(source):
+            if not SURFACE_RE.search(name):
+                continue
+            props, getonly = properties(body)
+            classic = widest_ctor(body, name)
+            ctor = primary if len(primary) > len(classic) else classic
+            if not (props or ctor):
+                continue
+            defaulted = [p for p in ctor if "=" in p]
+            # Of the defaulted params, those defaulting to `null`: their real
+            # default, if any, is applied in the constructor body by a `??` and
+            # is NOT recoverable from ParameterInfo.DefaultValue. Requirements
+            # §5.1, and probe 1.2 measured it.
+            nulls = [p for p in defaulted if re.search(r"=\s*null\s*$", p)]
+            rows.append((asm, name, len(props), len(getonly),
+                         len(ctor), len(defaulted), len(nulls)))
+    return rows
 
 
 def main():
@@ -112,43 +255,35 @@ def main():
                                  formatter_class=argparse.RawDescriptionHelpFormatter)
     ap.add_argument("--ref", default=DEFAULT_REF, help=f"git ref to read (default {DEFAULT_REF})")
     ap.add_argument("--repo", default=DEFAULT_REPO, help=f"Brighter checkout (default {DEFAULT_REPO})")
+    ap.add_argument("--tsv", action="store_true",
+                    help="one row per type, for diffing against probes/CountsProbe.cs")
     args = ap.parse_args()
 
-    files = [f for f in list_files(args.repo, args.ref) if SURFACE_RE.search(f)]
-    if not files:
+    rows = survey(args.repo, args.ref)
+    if not rows:
         sys.exit(f"no configuration surfaces found at {args.ref} -- is the ref right?")
+
+    if args.tsv:
+        print("assembly\ttype\tprops\tctor\tmax")
+        for asm, cls, np_, _ng, nc, _nd, _nn in sorted(rows, key=lambda r: (r[0], r[1])):
+            print(f"{asm}\t{cls}\t{np_}\t{nc}\t{max(np_, nc)}")
+        return
+
+    by_asm = Counter()
+    for asm, _cls, np_, _ng, nc, _nd, _nn in rows:
+        # A type's reader-facing option count is whichever shape it actually uses.
+        by_asm[asm] += max(np_, nc)
 
     print(f"Brighter configuration surfaces at ref {args.ref}\n")
     print("Counting TWO shapes, because the surface uses both:")
     print("  props  = public properties with a set/init accessor (publications, options classes)")
-    print("  ctor   = widest public constructor's parameters     (subscriptions)")
+    print("  ctor   = widest constructor's parameters, primary or classic (subscriptions)")
     print("  deflt  = of those ctor params, how many carry a default value\n")
 
-    rows, by_asm = [], Counter()
-    for path in sorted(files):
-        source = git_show(args.repo, args.ref, path)
-        if not source:
-            continue
-        cls = path.rsplit("/", 1)[-1][:-3]
-        props = PROP_RE.findall(source)
-        getonly = GETONLY_RE.findall(source)
-        ctor = widest_ctor(source, cls)
-        defaulted = [p for p in ctor if "=" in p]
-        if not (props or ctor):
-            continue
-        asm = path.split("/")[1]
-        # Of the defaulted params, those defaulting to `null`: their real default,
-        # if any, is applied in the constructor body by a `??` and is NOT recoverable
-        # from ParameterInfo.DefaultValue. See requirements.md 5.1.
-        nulls = [p for p in defaulted if re.search(r"=\s*null\s*$", p)]
-        rows.append((asm, cls, len(props), len(getonly), len(ctor), len(defaulted), len(nulls)))
-        # A type's reader-facing option count is whichever shape it actually uses.
-        by_asm[asm] += max(len(props), len(ctor))
-
-    print(f"{'assembly':<52} {'type':<34} {'props':>5} {'get-only':>8} {'ctor':>5} {'deflt':>5} {'=null':>5}")
-    print("-" * 119)
+    print(f"{'assembly':<52} {'type':<38} {'props':>5} {'get-only':>8} {'ctor':>5} {'deflt':>5} {'=null':>5}")
+    print("-" * 123)
     for asm, cls, np_, ng, nc, nd, nn in sorted(rows, key=lambda r: (-max(r[2], r[4]), r[0])):
-        print(f"{asm:<52} {cls:<34} {np_:>5} {ng:>8} {nc:>5} {nd:>5} {nn:>5}")
+        print(f"{asm:<52} {cls:<38} {np_:>5} {ng:>8} {nc:>5} {nd:>5} {nn:>5}")
 
     ctor_driven = [r for r in rows if r[4] > r[2]]
     prop_driven = [r for r in rows if r[2] >= r[4] and r[2] > 0]
@@ -175,8 +310,9 @@ def main():
               f"\nFor a `null` default, ParameterInfo.DefaultValue reports `null` while the real "
               f"default\n-- where there is one -- is applied in the constructor body by a `??`. "
               f"Reading the\nsignature alone would document them WRONG, not merely incompletely. "
-              f"The only route\nthat recovers them is instantiating the type and reading the "
-              f"property back.\nSee requirements.md 5.1.")
+              f"MEASURED by probe\n1.2: of Subscription's 6 `null` defaults, 4 come back as a "
+              f"value and 2 really are null.\nThe only route that recovers them is instantiating "
+              f"the type and reading the property\nback. See requirements.md 5.1.")
 
 
 if __name__ == "__main__":

--- a/spec/012-configuration_reference/tasks.md
+++ b/spec/012-configuration_reference/tasks.md
@@ -294,7 +294,7 @@ twelve tables.
 *correct* design §7's counts in place — the floors are marked `†` there and §12.5 explains
 them; what this phase produces is a fixed tool and a fresh run, recorded here.
 
-- [ ] **Task 1.1:** Write this task list and take it through review
+- [x] **Task 1.1:** Write this task list and take it through review
   - Input: `design.md` (§7 the mapping, §14 the phases, §12 the errata), `requirements.md`
     (§9 deliverables, §12 acceptance criteria), `spec/009-getting_started_tutorials/tasks.md`
     §1 as the structural model
@@ -302,7 +302,7 @@ them; what this phase produces is a fixed tool and a fresh run, recorded here.
   - Notes: `spec/.current-spec` already reads `012-configuration_reference` and both approval
     markers exist, so no repointing is needed — unlike 009, where it was part of Task 1.1
 
-- [ ] **Task 1.2:** Probe the body-coalesced default — instantiate `Subscription`, read
+- [x] **Task 1.2:** Probe the body-coalesced default — instantiate `Subscription`, read
       `EmptyChannelDelay` back, assert 500 ms
   - Input: requirements §5.1 (`Subscription.cs:208`, `:236` at `10.7.0`); design §6.2
   - Output: `spec/012-configuration_reference/probes/` — a small C# project, kept and
@@ -315,7 +315,7 @@ them; what this phase produces is a fixed tool and a fresh run, recorded here.
     spec's central premise is wrong and phase 2 changes shape — say so loudly rather than
     proceeding.
 
-- [ ] **Task 1.3:** Probe the package load — reference every surface package at `10.7.0` in one
+- [x] **Task 1.3:** Probe the package load — reference every surface package at `10.7.0` in one
       project and instantiate one type from each
   - Input: design §6.4; the package list implied by §7.2, §7.3, §7.4 and §7.5
   - Output: the same probes project, extended; a recorded verdict — clean, or the conflicting
@@ -328,7 +328,7 @@ them; what this phase produces is a fixed tool and a fresh run, recorded here.
     not isolate native dependencies; and **not `MetadataLoadContext`**, which cannot
     instantiate.
 
-- [ ] **Task 1.4:** Re-derive design §6.3's synthesis table **by construction**
+- [x] **Task 1.4:** Re-derive design §6.3's synthesis table **by construction**
   - Input: design §6.3's table — 24 types, 48 required parameters, 20 of the 24 needing only
     strings, enums and the three subscription arguments
   - Output: the recorded result of actually constructing each of the 24; the four that need a
@@ -338,7 +338,7 @@ them; what this phase produces is a fixed tool and a fresh run, recorded here.
     of the running tool**. `HandlerConfiguration` is the one of the four that is P0 and on D4,
     so its factory is phase 2's problem and not P2's.
 
-- [ ] **Task 1.5:** Teach `survey.py` to read C# primary constructors, and re-run it at
+- [x] **Task 1.5:** Teach `survey.py` to read C# primary constructors, and re-run it at
       `--ref 10.7.0`
   - Input: design §12.5 — `widest_ctor` matches `public TypeName(` *inside* a class body; 13
     surface types, 40 parameters; `PostgresLockingProviderOptions` and
@@ -350,6 +350,100 @@ them; what this phase produces is a fixed tool and a fresh run, recorded here.
     `optioncheck` is unaffected — a primary constructor is just a constructor to reflection —
     so this task changes no design decision; it changes what a writer would copy. **Quote the
     new figures with the ref or not at all.**
+
+### Phase 1 as executed — 2026-08-28, 5/5
+
+**The full record is `probes/README.md`**, which carries the tables, the
+reconciliations and the method. This is the summary and the four numbers a later phase
+needs. Everything is stamped at Brighter **`10.7.0`** and re-runnable:
+`dotnet run --project spec/012-configuration_reference/probes`.
+
+**1. The premise holds.** `emptyChannelDelay` is `null` by `ParameterInfo` and **500 ms**
+on the instance. Phase 2 does not change shape. And the shape is not uniform, which is the
+part that could not be read off the source: of `Subscription`'s six `null` signature
+defaults, **four come back as a value and two really are null** — so `null` in a signature
+means *both* "no default" and "the default is assigned below", and nothing distinguishes
+them until the object exists.
+
+**2. The packages do not fight, and `optioncheck` can be one project.** 64 Brighter
+assemblies and 65 third-party assemblies in one process; one type instantiated from each
+package for real. **Design §6.4's fallback is not needed.**
+
+> **The conflict §6.4 predicted is real and it is a different pair.** Not AWS —
+> **`RabbitMQ.Client`, loaded at 7.0.0.0 while `RMQ.Sync` was built against 6.0.0.0.**
+> Exactly **one of `RMQ.Sync`'s 57 types** fails to load, and it is not one 012
+> documents: both `RmqSubscription` types construct, and the probe re-derives design
+> §7.2's ruling from the assemblies — **Async 24 params with `queueType`, Sync 23
+> without**. Left alone deliberately. If it ever bites, drop `RMQ.Sync` from the
+> checker's `csproj`; 012 binds no type in it.
+
+**3. The synthesis burden is bigger in one way and smaller in another, and design §6.3 is
+superseded on both.** Measured **34 types and 70 required parameters**, against §6.3's 24
+and 48 — §6.3 subtracted **four** `.V4` duplicates where there are **six**, and it was
+parsed by a `survey.py` that task 1.5 then found five defects in. **The rebuilt parser and
+the running probe now agree exactly at 34 / 70.**
+
+- **Thirteen constructors reject their own defaults** — every subscription type in the
+  product. All thirteen need `requestType`, `messagePumpType` **and `makeChannels`
+  supplied**; `KafkaSubscription` needs six such parameters. A synthesiser using only
+  the parameters that carry no default builds **19 of 34**; adding defaulted `enum` and
+  `Type` parameters takes it to **32**. **Phase 2 must budget for this and design does
+  not name it.**
+- **Two types need a hand-written factory, not four** — `AzureBlobArchiveProviderOptions`
+  and `S3LuggageOptions`. The other three build because their unbuildable parameters are
+  *reference* types and `null` is accepted. **That is a new obligation, not a saving:** a
+  `null`-built instance reads defaults correctly *unless a constructor body derives one
+  from the missing object*, so phase 2 decides that per type, and where it cannot the
+  answer is `manual:` — which declares and counts — never a silent pass.
+
+**4. `survey.py` is rebuilt, and at `10.7.0` the corpus is 72 configuration types and 628
+reader-facing options** — against the **67 and 619** every document in this spec quotes.
+Both figures were floors, as design §12.1 and §12.5 said, and both were also *wrong* in
+places rather than merely low. **Quote them with the ref or not at all.**
+
+The task asked for one fix. Probe 1.4 found two more of the same kind and a new
+reflection oracle found two beyond that — five in all, every one of them a number rather
+than an error:
+
+| Defect | What it cost |
+|---|---|
+| Primary constructors invisible (design §12.5) | `InMemorySubscription` **2 → 17**; two types absent from the population entirely |
+| The class was assumed to be the file | `RocketMqSubscription.cs` declares **`RocketSubscription`**; `AWSMessagingGatewayConfiguration.cs` declares **`AWSMessagingGatewayConnection`**; the MQTT file declares three types |
+| Properties counted per file, not per class | `RmqMessagingGatewayConnection` **19 → 11** — the other 8 belong to `AmqpUriSpecification` and `Exchange`, which share its file |
+| A generic argument contains a space — `Dictionary<string, object>?` never matched | `Publication` **8 → 10**, and three more |
+| `private set`, `internal set` and `static` counted as reader-facing | `ProducersConfiguration` **26 → 22**, and two more |
+
+> **The oracle is the method worth keeping.** `survey.py --tsv` and
+> `probes -- counts` print the same quantity, one by parsing source and one by
+> reflecting over the assemblies. The first diff had **nine** disagreements, every one a
+> parser defect and none visible any other way. It now reads **`survey 72, reflection 68,
+> both 63, disagree 0`** — the nine the survey sees alone are `.V4`, the five reflection
+> sees alone carry zero options. **Run that diff after any change to `survey.py`.**
+
+**Two type NAMES in design §7 do not exist, and that matters more than any count.** A
+marker binds a fully-qualified type, so `RocketMqSubscription` (really
+**`RocketSubscription`**, 23 not 22) and `MQTTMessagingGatewayConfiguration` (really
+**`MqttMessagingGatewayConfiguration`**, 7 not 8) would each have failed in phase 6 with
+*the type is gone*. Loud, but late, and free to know now. **`D4 is 47 options over 5
+tables` becomes 45.**
+
+> **§2.9 of this document inherits an overstatement from design §12.5, and its verdict is
+> untouched.** §12.5's *"13 surfaces, 40 parameters"* is additive, and the convention is
+> **`max(props, ctor)`**. Measured with the primary constructor readable, **three of the
+> thirteen move** — `InMemorySubscription` and the two that were absent. The rest do not,
+> because **a C# primary constructor on a class assigns to properties rather than
+> creating them**: `AzureBlobLockingProviderOptions`'s two parameters are two of its three
+> properties. §2.9's instruction — *never infer from an unmarked row that its figure is a
+> total* — is right and is what caught this, applied to §2.9 itself.
+
+**Two things neither instrument counts**, both for the phase that meets them: **public
+fields** (`AzureBlobLockingProviderOptions.StorageLocationFunc` has a default and is
+invisible to both), and **surface types whose name says otherwise** — `AmqpUriSpecification`
+and `Exchange` are RabbitMQ configuration a reader writes by hand, and **phase 5 owns**
+whether `RabbitMQConfiguration.md` gains a table for them.
+
+**Phase 1 wrote no table, created no page and did not touch `SUMMARY.md`.** The six gates
+in §2.8 are unmoved, as they must be.
 
 ---
 


### PR DESCRIPTION
Phase 1 of spec 012: the instrument, before anything is measured with it. Five tasks, one PR, **no write to `../Brighter`** and **no page under `contents/` touched** — the fifth 012 PR in a row, and the last one; phase 3 is the first to write a table on a published page.

## What it produces

- `spec/012-configuration_reference/probes/` — a kept, re-runnable .NET project carrying the three probes plus a fourth mode that exists as an oracle. `probes/README.md` is the durable record.
- `spec/012-configuration_reference/survey.py` (D11) — rebuilt.
- `tasks.md` — 5/5 ticked, and a *Phase 1 as executed* block. **Total still 57**, re-derived both ways.

## The four results

**1. The premise holds.** `emptyChannelDelay` is `null` by `ParameterInfo` and **500 ms** on the instance, so the `Default` column and AC3b stand and phase 2 does not change shape. What reading the source could not say: of `Subscription`'s six `null` signature defaults, **four come back as a value and two really are null** — `null` there means both "no default" and "the default is assigned below".

**2. The packages do not fight.** 64 Brighter and 65 third-party assemblies in one process, one type instantiated from each for real. **Design §6.4's fallback is not needed; `optioncheck` can be one project.** The conflict §6.4 predicted *is* real and it is a **different pair**: `RabbitMQ.Client` loaded at 7 while `RMQ.Sync` was built against 6, costing exactly one of its 57 types. Not one 012 documents — both `RmqSubscription` types construct, re-deriving §7.2's Async-24-with-`queueType` / Sync-23-without ruling from the assemblies.

**3. The synthesis burden is 34 types and 70 required parameters**, against §6.3's 24 and 48: it subtracted **four** `.V4` duplicates where there are **six**, and it was parsed by a survey that task 1.5 found five defects in. **Thirteen constructors reject their own defaults** — every subscription type — which phase 2 must budget for. **Two types need a factory, not four**, and the three that construct do so on a `null` argument, which is an obligation rather than a saving.

**4. `survey.py` is rebuilt: 72 types and 628 options at `10.7.0`**, against the 67 and 619 every document quotes. The task asked for one fix. Probe 1.4 found two more and a new oracle found two beyond that — five in all, every one returning a *number* rather than an error:

| Defect | Cost |
|---|---|
| Primary constructors invisible (§12.5) | `InMemorySubscription` 2 → **17**; two types absent from the population |
| The class assumed to be the file | `RocketMqSubscription.cs` declares **`RocketSubscription`**; the AWS and MQTT files likewise |
| Properties counted per file, not per class | `RmqMessagingGatewayConnection` 19 → **11** |
| A generic argument contains a space | `Publication` 8 → **10**, and three more |
| `private`/`internal`/`static` setters counted | `ProducersConfiguration` 26 → **22**, and two more |

**Two type NAMES in design §7 do not exist**, which matters more than any count: a marker binds a fully-qualified type, so those two would have failed in phase 6 with *the type is gone*. **D4's "47 options" becomes 45.**

> **The oracle is the method worth keeping.** `survey.py --tsv` and `probes -- counts` print the same quantity — one by parsing source, one by reflecting over the assemblies. The first diff had **nine** disagreements, every one a parser defect and none visible any other way. It now reads `survey 72, reflection 68, both 63, disagree 0`.

Design §12.5's "13 surfaces, 40 parameters" is **additive** where the convention is `max(props, ctor)`; measured, **three of the thirteen move**, because a C# primary constructor on a class assigns to properties rather than creating them. `tasks.md` §2.9 inherits that overstatement — its instruction is what caught it, and its verdict is untouched.

## Gates

All six unmoved, as a phase that writes no page must leave them: link 150, pagelint 0/790/148, shape 147/12/4/10 of 20, redirects 77/7858, versioncheck 0 of 18 across 5, `--verify` 147/147/147. `--changed` reaches 0 code blocks and says so.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0146UueHL6H3zGBGTYwz7GtL