### PR TITLE
spec 012 phase 1 — measure which defaulted parameters are required, not which were supplied

### DIFF
--- a/spec/012-configuration_reference/probes/README.md
+++ b/spec/012-configuration_reference/probes/README.md
@@ -148,7 +148,7 @@ objects.**
 
 ### The finding: thirteen constructors reject their own defaults
 
-Every subscription type in Brighter, plus `SqsSubscription`'s extra pair:
+Every subscription type in Brighter:
 
 ```text
 InMemorySubscription, Subscription, SqsSubscription, AzureServiceBusSubscription,
@@ -157,10 +157,21 @@ PostgresSubscription, RmqSubscription (Async), RmqSubscription (Sync),
 RedisSubscription, RocketSubscription
 ```
 
-All thirteen need `requestType` and `messagePumpType` supplied, and all thirteen
-need `makeChannels` — a defaulted `enum` whose declared default the body will
-not accept. `KafkaSubscription` needs six such parameters, `SqsSubscription`
-five, `GcpPubSubSubscription` four.
+**All thirteen require a request type** — `requestType`, or `dataType` on
+`PostgresSubscription` — and **eleven of the thirteen also require
+`messagePumpType`**, whose declared default of `Unknown` the body will not
+accept. The two exceptions declare a usable default of their own:
+`MsSqlSubscription` defaults it to `Proactor` and `RMQ.Sync`'s `RmqSubscription`
+to `Reactor`, that package supporting only the one pump.
+
+> **Necessity is measured, not inferred from what was supplied.** Pass 2 hands
+> every defaulted `enum` and `Type` parameter a value, and most of them are not
+> needed; the probe puts each candidate back to its own declared default one at
+> a time and keeps the ones whose removal breaks construction. A first draft of
+> this section read the supplied list as the required list and reported that
+> **all thirteen need `makeChannels`**. **Not one of them does.** Supplying a
+> value is not evidence that it was required, and the difference is a claim
+> about the product.
 
 **This is the one thing phase 2 must budget for that design does not name.**
 A synthesiser that supplies only the parameters carrying no default constructs

--- a/spec/012-configuration_reference/probes/SynthesisProbe.cs
+++ b/spec/012-configuration_reference/probes/SynthesisProbe.cs
@@ -60,7 +60,7 @@ internal static class SynthesisProbe
             }
             else
             {
-                var why = ValidatedDefaults(ctor);
+                var why = ValidatedDefaults(type, ctor);
                 pass2.Add((type, why));
                 Console.WriteLine($"{type.Name,-38} {Package(type),-46} {need,3} {2,4}  constructed, "
                                   + "defaults overridden");
@@ -81,7 +81,7 @@ internal static class SynthesisProbe
             Console.WriteLine("The pass-2 types — a constructor body that rejects its own defaults, which no");
             Console.WriteLine("parse of a signature can see:");
             foreach (var (type, why) in pass2)
-                Console.WriteLine($"  {type.Name}: {why}");
+                Console.WriteLine($"  {type.Name} ({Package(type)}): {why}");
         }
 
         if (failed.Count > 0)
@@ -145,17 +145,29 @@ internal static class SynthesisProbe
             .OrderByDescending(c => c.GetParameters().Length)
             .FirstOrDefault();
 
-    /// <summary>The defaulted parameters pass 2 had to supply a value for.</summary>
-    private static string ValidatedDefaults(ConstructorInfo ctor)
+    /// <summary>
+    /// The defaulted parameters the constructor genuinely REQUIRES a value for.
+    ///
+    /// Pass 2 supplies every defaulted `enum` and `Type` parameter, and most of
+    /// them are not needed — supplying a value is not evidence that it was
+    /// required. Each candidate is put back to its own declared default, one at
+    /// a time; the ones whose removal breaks construction are the finding.
+    /// </summary>
+    private static string ValidatedDefaults(Type type, ConstructorInfo ctor)
     {
-        var names = ctor.GetParameters()
-            .Where(p => p.HasDefaultValue)
+        var candidates = ctor.GetParameters()
+            .Where(p => p.HasDefaultValue && p.Name is not null)
             .Where(p => p.ParameterType.IsEnum || p.ParameterType == typeof(Type))
-            .Select(p => p.Name)
-            .Where(n => n is not null)
+            .Select(p => p.Name!)
             .ToList();
 
-        return names.Count == 0 ? "a defaulted parameter" : string.Join(", ", names);
+        var required = candidates
+            .Where(name => !Synthesiser.CanConstructKeeping(type, new HashSet<string> { name }))
+            .ToList();
+
+        return required.Count == 0
+            ? "no single defaulted parameter is required on its own"
+            : string.Join(", ", required);
     }
 
     private static string Package(Type type) => type.Assembly.GetName().Name ?? "?";

--- a/spec/012-configuration_reference/probes/Synthesiser.cs
+++ b/spec/012-configuration_reference/probes/Synthesiser.cs
@@ -39,33 +39,7 @@ internal static class Synthesiser
 
         for (var pass = 1; pass <= 2; pass++)
         {
-            var args = new object?[ctor.GetParameters().Length];
-            var unsynthesisable = (ParameterInfo?)null;
-
-            foreach (var p in ctor.GetParameters())
-            {
-                if (p.HasDefaultValue && pass == 1)
-                {
-                    args[p.Position] = p.DefaultValue;
-                    continue;
-                }
-
-                var value = Synthesise(p.ParameterType, depth);
-                if (value is null && !IsNullable(p))
-                {
-                    if (p.HasDefaultValue)
-                    {
-                        // pass 2 has nothing better to offer than the declared default
-                        args[p.Position] = p.DefaultValue;
-                        continue;
-                    }
-
-                    unsynthesisable = p;
-                    break;
-                }
-
-                args[p.Position] = value ?? (p.HasDefaultValue ? p.DefaultValue : null);
-            }
+            var (args, unsynthesisable) = BuildArgs(ctor, pass, depth, null);
 
             if (unsynthesisable is not null)
                 return new Result(null, pass,
@@ -83,6 +57,64 @@ internal static class Synthesiser
         }
 
         return new Result(null, 2, firstError, ctor);
+    }
+
+    /// <summary>
+    /// Can this type be constructed with pass-2 arguments, except for the named
+    /// parameters, which keep their own declared default?
+    ///
+    /// This is what turns "pass 2 supplied these five parameters" into "the
+    /// constructor requires these two" — supplying a value is not evidence that
+    /// it was needed, and the difference is a claim about the product.
+    /// </summary>
+    public static bool CanConstructKeeping(Type type, IReadOnlySet<string> keepOwnDefault)
+    {
+        var ctor = type.GetConstructors(BindingFlags.Public | BindingFlags.Instance)
+            .OrderByDescending(c => c.GetParameters().Length)
+            .FirstOrDefault();
+
+        if (ctor is null) return false;
+
+        var (args, unsynthesisable) = BuildArgs(ctor, pass: 2, depth: 0, keepOwnDefault);
+        if (unsynthesisable is not null) return false;
+
+        try { return ctor.Invoke(args) is not null; }
+        catch { return false; }
+    }
+
+    private static (object?[] Args, ParameterInfo? Unsynthesisable) BuildArgs(
+        ConstructorInfo ctor, int pass, int depth, IReadOnlySet<string>? keepOwnDefault)
+    {
+        var args = new object?[ctor.GetParameters().Length];
+
+        foreach (var p in ctor.GetParameters())
+        {
+            var keep = p.HasDefaultValue
+                       && (pass == 1 || (p.Name is not null && keepOwnDefault?.Contains(p.Name) == true));
+
+            if (keep)
+            {
+                args[p.Position] = p.DefaultValue;
+                continue;
+            }
+
+            var value = Synthesise(p.ParameterType, depth);
+            if (value is null && !IsNullable(p))
+            {
+                if (p.HasDefaultValue)
+                {
+                    // pass 2 has nothing better to offer than the declared default
+                    args[p.Position] = p.DefaultValue;
+                    continue;
+                }
+
+                return (args, p);
+            }
+
+            args[p.Position] = value ?? (p.HasDefaultValue ? p.DefaultValue : null);
+        }
+
+        return (args, null);
     }
 
     /// <summary>A value for a parameter type, or null where the synthesiser has none.</summary>

--- a/spec/012-configuration_reference/tasks.md
+++ b/spec/012-configuration_reference/tasks.md
@@ -384,11 +384,15 @@ parsed by a `survey.py` that task 1.5 then found five defects in. **The rebuilt 
 the running probe now agree exactly at 34 / 70.**
 
 - **Thirteen constructors reject their own defaults** — every subscription type in the
-  product. All thirteen need `requestType`, `messagePumpType` **and `makeChannels`
-  supplied**; `KafkaSubscription` needs six such parameters. A synthesiser using only
-  the parameters that carry no default builds **19 of 34**; adding defaulted `enum` and
-  `Type` parameters takes it to **32**. **Phase 2 must budget for this and design does
-  not name it.**
+  product. **All thirteen require a request type** (`requestType`, or `dataType` on
+  `PostgresSubscription`) and **eleven also require `messagePumpType`**, whose declared
+  default of `Unknown` the body refuses; the two exceptions default it to a usable value
+  themselves. A synthesiser using only the parameters that carry no default builds **19 of
+  34**; adding defaulted `enum` and `Type` parameters takes it to **32**. **Phase 2 must
+  budget for this and design does not name it.**
+  *(Necessity is measured — each candidate is put back to its own default one at a time.
+  A first draft read what pass 2 **supplied** as what the constructors **require** and
+  reported that all thirteen need `makeChannels`; **not one of them does.**)*
 - **Two types need a hand-written factory, not four** — `AzureBlobArchiveProviderOptions`
   and `S3LuggageOptions`. The other three build because their unbuildable parameters are
   *reference* types and `null` is accepted. **That is a new obligation, not a saving:** a


### PR DESCRIPTION
A correction to [#127](https://github.com/BrighterCommand/Docs/pull/127), which touched no page under `contents/` and neither does this.

Probe 1.4 reported the defaulted `enum` and `Type` parameters that pass 2 **supplied**, and the write-up read that as the set the constructors **require**. It isn't — supplying a value is not evidence that it was needed. The claim that all thirteen subscription constructors need `makeChannels` was wrong: **not one of them does.**

The probe now measures necessity rather than inferring it. Each candidate is put back to its own declared default, one at a time, and the ones whose removal breaks construction are kept.

**All thirteen require a request type** — `requestType`, or `dataType` on `PostgresSubscription`. **Eleven also require `messagePumpType`**, whose declared default of `Unknown` the body refuses. The two exceptions default it themselves: `MsSqlSubscription` to `Proactor`, and `RMQ.Sync`'s `RmqSubscription` to `Reactor`, that package supporting only the one pump.

Nothing else moves — 34 types, 70 required parameters, 19 built from their required parameters alone, 32 of 34 built in all, 2 needing a factory — and the five gates are unmoved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0146UueHL6H3zGBGTYwz7GtL