### PR TITLE
spec: 012 phase 2 — optioncheck, its CI job, its pin, and three red-proofs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -108,3 +108,31 @@ jobs:
         with:
           python-version: '3.12'
       - run: python3 tools/versioncheck.py
+
+  # Spec 012 D1/D2. tools/optioncheck diffs every option table in contents/
+  # against the type its `<!-- optioncheck: -->` marker names, reflecting over
+  # the packages pinned in tools/optioncheck/optioncheck.csproj.
+  #
+  # NO GUARD, and none may be added. The `if [ -f ... ]` that stood in the
+  # versions job until D9 landed existed only to keep the build green while the
+  # tool was absent, and a guard that outlives its tool silently un-gates the
+  # check it was protecting.
+  #
+  # NO `schedule:` TRIGGER either, and this is the opposite of the versions job
+  # rather than an oversight. AC4's schedule clause was struck at design review
+  # (design §6.5, §13.2): optioncheck reflects over a PINNED package, so nothing
+  # outside this repository can change its verdict. A scheduled run can only
+  # repeat the last PR's answer — or exit 2 because NuGet was briefly
+  # unreachable, which is a red build caused by the weather.
+  #
+  # The invocation is bare for the same reason versioncheck.py's is. Exit 2 is
+  # "the pinned packages are not in this process", which is an unchecked corpus
+  # rather than a pass, so no `|| true` and no swallowing the code in a pipeline.
+  options:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '9.0.x'
+      - run: dotnet run --project tools/optioncheck

--- a/RELEASE_CHECKLIST.md
+++ b/RELEASE_CHECKLIST.md
@@ -23,7 +23,24 @@ closes it.
    and record the result in the table.
 4. **Re-time each one.** If the stated duration has drifted, change the page. A tutorial that
    claims ten minutes and takes forty is a defect a reader meets before anything else.
-5. **Run `python3 tools/linkcheck.py` and `python3 tools/pagelint.py`.**
+5. **Bump the pin in `tools/optioncheck/optioncheck.csproj` to the new release, and run
+   `dotnet run --project tools/optioncheck`.** One `Version=` per `PackageReference`, all of
+   them the same number — the pin lives in that file and nowhere else, which is why this is
+   one edit rather than one per table (design §5.2). **Expect it to be green before the bump
+   and to have something to say after it**: every mismatch it reports is a default that
+   changed in the release, which is the drift spec 012 exists to catch. Fix the row on the
+   page; record what it said, because the ledger of what the checker caught is the only
+   evidence that the drift was ever real.
+6. **Run `python3 tools/linkcheck.py` and `python3 tools/pagelint.py`.**
+
+> **`versioncheck.py` and `optioncheck` are the same family with OPPOSITE triggers, and
+> reasoning about them together is a mistake.** `versioncheck.py` resolves the **latest**
+> version from NuGet, so a release in another repository turns it red with no commit here —
+> it is step 1 and it tells you a release happened. `optioncheck` reflects over a **pinned**
+> package, so nothing outside this repository can change its verdict: it goes red at **step
+> 5**, when you bump the pin, performed by someone who is at that moment looking for exactly
+> this information. That is also why it has no `schedule:` trigger in CI and must not be
+> given one (design §6.5, requirements AC4 as amended).
 
 **What this does not cover.** `versioncheck.py` reads only lines naming a
 `Paramore.Brighter*` package, by design — a broader match would start policing pages that

--- a/contents/SweeperCircuitBreaking.md
+++ b/contents/SweeperCircuitBreaking.md
@@ -81,9 +81,11 @@ public void ConfigureServices(IServiceCollection services)
 
 The `OutboxCircuitBreakerOptions` class provides the following configuration:
 
+<!-- optioncheck: Paramore.Brighter.CircuitBreaker.OutboxCircuitBreakerOptions -->
+
 | Option | Type | Default | Description |
-|--------|------|---------|-------------|
-| **CooldownCount** | `int` | 10 | Number of sweeper iterations before a tripped topic is eligible for retry |
+|---|---|---|---|
+| `CooldownCount` | `int` | `10` | Sweeper iterations a tripped topic waits before it is retried. |
 
 ### Calculating Cooldown Time
 

--- a/spec/012-configuration_reference/redproof/fixture_subscription.md
+++ b/spec/012-configuration_reference/redproof/fixture_subscription.md
@@ -1,0 +1,42 @@
+# Red-proof fixture — `Subscription`
+
+This is not a documentation page. It is the input the red-proofs in
+`redproof_optioncheck.py` mutate, and it lives here rather than under
+`contents/` for two reasons: `optioncheck` takes path arguments (tasks.md
+§2.5), so a fixture does not have to be a published page; and AC3b has to be
+proved in phase 2, before phase 3 has written a `Subscription` table anywhere
+in the corpus.
+
+**It must be green as it stands.** A red-proof that starts at its first
+mutation cannot tell a rule that fires from a tool that is broken.
+
+The table below is `Paramore.Brighter.Subscription` at `10.7.0`, written from
+the type. Every `Default` is the value on a constructed instance — which for
+`emptyChannelDelay` is **500 ms** where the signature says `null`, the single
+measurement the whole spec rests on.
+
+<!-- optioncheck: Paramore.Brighter.Subscription
+     omit: channelFactory — not reader-set; supplied by AddConsumers
+     manual: requestType — the constructor rejects its own default of null, so an instance reads back the checker's argument
+     manual: getRequestType — no property of that name on the instance
+     manual: messagePumpType — the constructor rejects its own default of Unknown
+-->
+
+| Option | Type | Default | Description |
+|---|---|---|---|
+| `subscriptionName` | `SubscriptionName` | `none` | Names the subscription. |
+| `channelName` | `ChannelName` | `none` | Names the channel the subscription reads. |
+| `routingKey` | `RoutingKey` | `none` | The routing key the channel is bound to. |
+| `requestType` | `Type?` | `none` | The request type messages on this channel deserialise to. |
+| `getRequestType` | `Func<Message, Type>?` | `null` | Derives the request type from the message where one type per channel is too few. |
+| `bufferSize` | `int` | `1` | Messages prefetched per read. |
+| `noOfPerformers` | `int` | `1` | Message pumps run for this subscription. |
+| `timeOut` | `TimeSpan?` | `300 ms` | How long a read waits for a message. |
+| `requeueCount` | `int` | `-1` | Times a message is requeued before it is rejected; -1 is unlimited. |
+| `requeueDelay` | `TimeSpan?` | `0 ms` | Delay before a requeued message is available again. |
+| `unacceptableMessageLimit` | `int` | `0` | Unacceptable messages tolerated before the pump stops; 0 is unlimited. |
+| `messagePumpType` | `MessagePumpType` | `none` | Selects the Reactor or Proactor pump. |
+| `makeChannels` | `OnMissingChannel` | `Create` | What the transport does when the channel is missing. |
+| `emptyChannelDelay` | `TimeSpan?` | `500 ms` | Pause after a read that found no message. |
+| `channelFailureDelay` | `TimeSpan?` | `1000 ms` | Pause after a read that failed. |
+| `unacceptableMessageLimitWindow` | `TimeSpan?` | `null` | Window the unacceptable-message limit is counted over. |

--- a/spec/012-configuration_reference/redproof/redproof_optioncheck.py
+++ b/spec/012-configuration_reference/redproof/redproof_optioncheck.py
@@ -1,0 +1,226 @@
+#!/usr/bin/env python3
+"""Tasks 2.7, 2.8 and 2.9 -- force tools/optioncheck red, one branch at a time.
+
+    python3 spec/012-configuration_reference/redproof/redproof_optioncheck.py
+
+Requirements §12 AC3 asks for "a red-proof that a changed ctor default is
+caught -- NOT merely that the tool runs", AC3b for one on a body-coalesced
+default, and AC5 for exit 2 being distinguishable from exit 0. This is all
+three, in 009's `redproof_versioncheck.py` shape, and the discipline is that
+file's:
+
+  * print a BASELINE first and require it GREEN. A probe that starts at its
+    first mutation cannot tell a rule that fires from a tool that is broken.
+  * assert the mutation produced *the input the branch rejects*, not merely
+    that the text changed. Three of 010's rule-7 proofs reported SILENT and all
+    three were the probe's fault.
+  * assert the fixture is IN SCOPE before reading any verdict. 010's S2
+    red-proof was vacuous twice over for skipping that step, and this tool
+    prints its scope before its verdict for exactly this reason.
+  * restore from a copy taken aside, never `git checkout --`, and assert the
+    restored file is byte-identical.
+  * when an assertion disagrees with the exit code, the assertion is the
+    suspect.
+"""
+import hashlib
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+
+# Derived from __file__, never hard-coded: urlmap.py shipped a `parents[2]`
+# that was correct where it was written and silently wrong one directory later.
+# This file lives at spec/012-configuration_reference/redproof/, so the repo is
+# three up.
+HERE = os.path.dirname(os.path.abspath(__file__))
+REPO = os.path.dirname(os.path.dirname(os.path.dirname(HERE)))
+
+FIXTURE = os.path.join(HERE, 'fixture_subscription.md')
+PROJECT = os.path.join(REPO, 'tools', 'optioncheck')
+BIN = os.path.join(PROJECT, 'bin', 'Debug', 'net9.0')
+DLL = os.path.join(BIN, 'optioncheck.dll')
+
+results = []
+
+
+def run(args, dll=DLL):
+    """Run the built checker, returning (exit code, stdout + stderr)."""
+    done = subprocess.run(['dotnet', dll] + args, capture_output=True, text=True)
+    return done.returncode, done.stdout + done.stderr
+
+
+def report(name, expected, code, out, assertion):
+    verdict = 'FIRED' if code == expected else 'SILENT'
+    results.append((verdict, name, expected, code))
+    print(f'\n----- {name}')
+    print(f'  precondition asserted: {assertion}')
+    print('  ' + out.rstrip().replace('\n', '\n  '))
+    print(f'  exit={code} expected={expected}  -> {verdict}')
+
+
+def digest(path):
+    with open(path, 'rb') as handle:
+        return hashlib.sha256(handle.read()).hexdigest()
+
+
+def read():
+    with open(FIXTURE, encoding='utf-8') as handle:
+        return handle.read()
+
+
+def write(text):
+    with open(FIXTURE, 'w', encoding='utf-8') as handle:
+        handle.write(text)
+
+
+def mutate(original, old, new):
+    """Replace `old` with `new`, asserting the substitution actually happened."""
+    assert old in original, f'the fixture does not contain {old!r} -- it has moved'
+    text = original.replace(old, new, 1)
+    assert text != original, 'the mutation changed nothing'
+    write(text)
+    assert new in read(), f'the mutated fixture does not contain {new!r}'
+    return text
+
+
+def main():
+    build = subprocess.run(['dotnet', 'build', PROJECT, '-v', 'quiet', '--nologo'],
+                           capture_output=True, text=True)
+    if build.returncode != 0:
+        print(build.stdout + build.stderr)
+        print('the checker does not build; nothing below would be measuring it')
+        return 2
+
+    original = digest(FIXTURE)
+    keep = os.path.join(tempfile.mkdtemp(), 'fixture_subscription.md')
+    shutil.copy2(FIXTURE, keep)
+    assert digest(keep) == original, 'the copy aside is not the file'
+    print(f'copy taken aside at {keep}')
+    print(f'sha256 {original}')
+
+    text = read()
+
+    # ---------------------------------------------------------------- BASELINE
+    code, out = run([FIXTURE])
+    assert 'scope: 1 table, 16 rows, 1 type' in out, (
+        'baseline precondition: the fixture must be IN SCOPE. Everything below '
+        f'is vacuous if it is not, and the scope line says:\n{out}')
+    report('0. BASELINE (must be green)', 0, code, out,
+           'the run reaches 1 table, 16 rows, 1 type')
+    if code != 0:
+        print('\nthe baseline is not green; every branch below is measuring '
+              'that instead of the rule it names')
+        return 1
+
+    try:
+        # ------------------------------------------- 1. AC3, a changed default
+        # `bufferSize` is a CONSTRUCTOR PARAMETER with a signature default. A
+        # checker reading properties alone never sees it, which is the 43% of
+        # the surface AC3 exists to keep in scope.
+        mutate(text, '| `bufferSize` | `int` | `1` |', '| `bufferSize` | `int` | `10` |')
+        code, out = run([FIXTURE])
+        report('1. AC3 -- a changed CONSTRUCTOR default', 1, code, out,
+               'the table now says bufferSize defaults to 10; the type says 1')
+        assert 'WRONG DEFAULT' in out and 'bufferSize' in out, (
+            'exit 1 is only correct if the finding NAMES the row')
+        write(text)
+
+        # ------------------------------ 2. AC3b, the body-coalesced default
+        # THE ONE THAT MATTERS. The signature says `null`; the constructor body
+        # assigns 500 ms. A checker reading ParameterInfo documents this option
+        # WRONG rather than missing, and a reader has no reason to doubt a wrong
+        # default.
+        mutate(text, '| `emptyChannelDelay` | `TimeSpan?` | `500 ms` |',
+               '| `emptyChannelDelay` | `TimeSpan?` | `null` |')
+        code, out = run([FIXTURE])
+        report('2. AC3b -- a body-coalesced default written as `null`', 1, code, out,
+               'the table now says `null`, which is exactly what the SIGNATURE says')
+        assert '500 ms' in out and 'emptyChannelDelay' in out, (
+            'exit 1 is only correct if the finding says the value is 500 ms -- '
+            'otherwise the tool caught something else about the same row')
+        write(text)
+
+        # ---------------------------------- 3. the spelling the reader types
+        mutate(text, '| `bufferSize` | `int` |', '| `BufferSize` | `int` |')
+        code, out = run([FIXTURE])
+        report('3. WRONG SPELLING -- the property, not the parameter', 1, code, out,
+               'the table now writes the PROPERTY spelling, `BufferSize`')
+        assert 'WRONG SPELLING' in out, (
+            'requirements §7.1 calls this a real hazard: on a constructor-driven '
+            'type the reader SETS one spelling and READS BACK the other')
+        write(text)
+
+        # ------------------------------------- 4. an escape with no reason
+        mutate(text, 'omit: channelFactory — not reader-set; supplied by AddConsumers',
+               'omit: channelFactory')
+        code, out = run([FIXTURE])
+        report('4. ESCAPE WITHOUT REASON', 1, code, out,
+               'the marker now carries a bare `omit: channelFactory`')
+        assert 'ESCAPE WITHOUT REASON' in out, (
+            'both keys DECLARE rather than silence (design §5.1); a parser that '
+            'accepts a reasonless `omit:` lets a green build be written over the '
+            'hard half of every table')
+        write(text)
+
+        # --------------------------------------------- 5. the type is gone
+        # Phase 1 found two of these in design §7 -- `RocketMqSubscription` and
+        # `MQTTMessagingGatewayConfiguration` name types that do not exist -- and
+        # this is the branch that would have caught them.
+        mutate(text, '<!-- optioncheck: Paramore.Brighter.Subscription',
+               '<!-- optioncheck: Paramore.Brighter.SubscriptionThatWasRenamed')
+        code, out = run([FIXTURE])
+        report('5. THE TYPE IS GONE', 1, code, out,
+               'the marker now names a type no pinned package declares')
+        assert 'THE TYPE IS GONE' in out, (
+            'a marker binds a fully-qualified type; a renamed type must fail '
+            'loudly rather than pass as a table nobody checked')
+        write(text)
+
+    finally:
+        write(text)
+
+    assert digest(FIXTURE) == original, 'the fixture did not survive the probe'
+    print(f'\nfixture restored byte-identical: sha256 {digest(FIXTURE)}')
+
+    # -------------------------------------- 6. AC5, the authority unreachable
+    # Exit 2 has to be reachable as a VERDICT rather than as a restore failure:
+    # a failed `dotnet restore` never runs the program at all. So the pinned
+    # list travels inside the assembly and is checked against what loaded.
+    #
+    # The control matters as much as the mutation. Copying the output somewhere
+    # else is itself a change, and without the control an exit 2 from the copy
+    # would prove nothing about the missing package.
+    staging = tempfile.mkdtemp()
+    control = os.path.join(staging, 'control')
+    removed = os.path.join(staging, 'removed')
+    shutil.copytree(BIN, control)
+    shutil.copytree(BIN, removed)
+
+    code, out = run([FIXTURE], dll=os.path.join(control, 'optioncheck.dll'))
+    report('6a. AC5 CONTROL -- the same output directory, nothing removed', 0, code, out,
+           f'the checker was copied to {control} and run from there')
+
+    victim = os.path.join(removed, 'Paramore.Brighter.MessagingGateway.Kafka.dll')
+    assert os.path.exists(victim), 'the assembly to remove is not there to remove'
+    os.remove(victim)
+    assert not os.path.exists(victim), 'the assembly is still there'
+
+    code, out = run([FIXTURE], dll=os.path.join(removed, 'optioncheck.dll'))
+    report('6b. AC5 -- one pinned package removed', 2, code, out,
+           'Paramore.Brighter.MessagingGateway.Kafka.dll deleted from the copy')
+    assert 'AUTHORITY UNREACHABLE' in out and 'Kafka' in out, (
+        'exit 2 is only correct if the message NAMES THE AUTHORITY rather than '
+        'the symptom -- "authority unreachable is not a pass" is the whole point')
+    shutil.rmtree(staging)
+
+    print('\n===== SUMMARY =====')
+    for verdict, name, expected, code in results:
+        print(f'  {verdict:6}  expected {expected}, got {code}  {name}')
+    silent = [r for r in results if r[0] == 'SILENT']
+    print(f'\n{len(results) - len(silent)}/{len(results)} branches fired.')
+    return 1 if silent else 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/spec/012-configuration_reference/tasks.md
+++ b/spec/012-configuration_reference/tasks.md
@@ -660,6 +660,21 @@ is the one to notice**: design §12.1 says the schedulers are invisible to `surv
 a type, so the tool does not care** — phase 9's 25 options are checkable on the same terms as
 everything else.
 
+**AC4's evidence, naming the job.** The `options` job ran on
+[#129](https://github.com/BrighterCommand/Docs/pull/129) and passed in **33s**, and the line
+that matters is the one it printed on the runner:
+
+```text
+optioncheck — Brighter 10.7.0, 62 pinned packages (tools/optioncheck/optioncheck.csproj)
+scope: 1 table, 1 row, 1 type, on 1 page of 147 files scanned.
+0 mismatches across 1 table and 1 row.
+```
+
+**That is the same scope the local run reports**, which is what says the CI job is checking the
+corpus rather than passing on an empty one — and it is why task 2.6 exists. All eight check
+rows were read in full: `check`, `options` and `versions` on both the `push` and the
+`pull_request` event, plus the two GitBook rows.
+
 **The six gates in §2.8 are unmoved to the digit**, on the branch and after staging: link 150,
 pagelint 0 errors / 790 warnings / 148 pages, shape 147 pages / 12 sections / widest 10 of 20,
 redirects 77 entries / 7858 bytes, versioncheck 0 stale of 18 across 5, `--verify` 147/147/147.

--- a/spec/012-configuration_reference/tasks.md
+++ b/spec/012-configuration_reference/tasks.md
@@ -461,7 +461,7 @@ may it add a `schedule:` trigger: AC4's schedule clause was struck at design rev
 and a pinned checker on a schedule can only repeat yesterday's verdict or exit 2 on a NuGet
 outage.
 
-- [ ] **Task 2.1:** Create `tools/optioncheck` — project, pinned package references, and the
+- [x] **Task 2.1:** Create `tools/optioncheck` — project, pinned package references, and the
       run contract
   - Input: design §3.1's file list, §6.4's pinning rule, and **task 1.3's package list carried
     forward verbatim, not re-derived** — probe 1.3 assembles exactly this set and proves it
@@ -473,7 +473,7 @@ outage.
   - Notes: **No `.V4` packages.** The pin lives here and nowhere else — design §5.2: a version
     on every marker would be a hundred pins to bump instead of one.
 
-- [ ] **Task 2.2:** `Binding.cs` — parse the marker and its two keys
+- [x] **Task 2.2:** `Binding.cs` — parse the marker and its two keys
   - Input: design §5 and §5.1
   - Output: a parser for `<!-- optioncheck: <type> -->`, with `omit:` and `manual:` lines, each
     carrying a reason; the table rows beneath it
@@ -482,7 +482,7 @@ outage.
     with no reason is a parser that lets 012 reach a green build by writing `omit:` over the
     hard half of every table.
 
-- [ ] **Task 2.3:** `Reflect.cs` — the two routes, one per column
+- [x] **Task 2.3:** `Reflect.cs` — the two routes, one per column
   - Input: design §6.2's table
   - Output: name and type from `ParameterInfo` / `PropertyInfo`; **`Default` from an
     instantiated object, read back, always**
@@ -492,7 +492,7 @@ outage.
     shape two. Reader-facing members are settable properties and the **widest** constructor's
     parameters, which is `survey.py:143`'s `max(props, ctor)` convention expressed as code.
 
-- [ ] **Task 2.4:** `Synthesise.cs` — constructor arguments for the 24 types that need them
+- [x] **Task 2.4:** `Synthesise.cs` — constructor arguments for the 24 types that need them
   - Input: task 1.4's re-derived table; design §6.3
   - Output: strings, enums and the three subscription arguments handled generically; a
     hand-written factory for `HandlerConfiguration`; the other three declared `manual:` where
@@ -500,7 +500,7 @@ outage.
   - Notes: 20 of the 24 need only the generic path. **`HandlerConfiguration` is P0** — it is on
     D4, phase 3 — so it gets the factory rather than the declaration.
 
-- [ ] **Task 2.5:** `Program.cs` — scope line, verdict, exit 0/1/2
+- [x] **Task 2.5:** `Program.cs` — scope line, verdict, exit 0/1/2
   - Input: design §6.1's seven steps and §6.5's exit codes
   - Output: the scope printed **before** the verdict — tables, rows, types, and the `omit:` and
     `manual:` counts, each named; then the diff; then exit 0, 1 or 2
@@ -508,7 +508,7 @@ outage.
     that is the family contract `versioncheck.py` set, and it is the whole defence against a
     vacuous green. Exit **2** is *authority unreachable*, and it is not a pass.
 
-- [ ] **Task 2.6:** Mark `SweeperCircuitBreaking.md`'s existing table, so the first CI run is
+- [x] **Task 2.6:** Mark `SweeperCircuitBreaking.md`'s existing table, so the first CI run is
       not vacuous
   - Input: design §12.2 — it is the **one** table in the corpus already in the §7.1 shape, and
     it has a single row; `OutboxCircuitBreakerOptions`, 1 option (§7.3)
@@ -523,7 +523,7 @@ outage.
     gate whose first CI run is vacuous being a gate nobody has tested — and **§2.7 records
     that this one is spent**, so no phase-8 task repeats it.
 
-- [ ] **Task 2.7:** AC3's red-proof — a changed constructor default is caught
+- [x] **Task 2.7:** AC3's red-proof — a changed constructor default is caught
   - Input: requirements §12 AC3; `spec/009-getting_started_tutorials/redproof_versioncheck.py`
     as the shape to copy
   - Output: `spec/012-configuration_reference/redproof/` — a fixture `.md` with a marker and a
@@ -533,7 +533,7 @@ outage.
     green this programme has met repeatedly. Assert the fixture is in scope **before** reading
     the verdict — 010's S2 red-proof was vacuous twice over for skipping that step.
 
-- [ ] **Task 2.8:** AC3b's red-proof — a body-coalesced default is reported as its real value,
+- [x] **Task 2.8:** AC3b's red-proof — a body-coalesced default is reported as its real value,
       never as `null`
   - Input: task 1.2's measurement; requirements §12 AC3b
   - Output: a fixture whose `EmptyChannelDelay` row says `null`; a recorded exit **1** saying
@@ -542,14 +542,14 @@ outage.
     this option *wrong, not missing*, and a reader has no reason to doubt a wrong default.
     Prove it fires before trusting the 619 rows that follow.
 
-- [ ] **Task 2.9:** AC5's red-proof — exit 2 is distinguishable from exit 0
+- [x] **Task 2.9:** AC5's red-proof — exit 2 is distinguishable from exit 0
   - Input: requirements §12 AC5; design §6.5
   - Output: a recorded run with the package source removed, exiting **2**, with a message that
     names the authority rather than the symptom
   - Notes: 009's `versioncheck.py` has the same contract and PROMPT records why it matters:
     *exit 2 is authority unreachable, which is not a pass.*
 
-- [ ] **Task 2.10:** D2 — add the job to `.github/workflows/docs.yml`, unguarded
+- [x] **Task 2.10:** D2 — add the job to `.github/workflows/docs.yml`, unguarded
   - Input: design §6.5's YAML
   - Output: a third job running `dotnet run --project tools/optioncheck` on push and pull
     request; a green CI run **naming the job** in the evidence
@@ -557,12 +557,114 @@ outage.
     `gh pr checks` — it lists a `push` row and a `pull_request` row per commit and they
     legitimately disagree; a `tail` of that output merged a red build in session 23.
 
-- [ ] **Task 2.11:** D3 — the pin joins `versioncheck.py`'s in `RELEASE_CHECKLIST.md`
+- [x] **Task 2.11:** D3 — the pin joins `versioncheck.py`'s in `RELEASE_CHECKLIST.md`
   - Input: `RELEASE_CHECKLIST.md`; requirements §9 D3; design §13.2
   - Output: a step bumping `optioncheck.csproj`'s pin, beside the existing tutorial-pin step
   - Notes: **State the trigger, because the two tools have opposite ones.**
     `versioncheck.py` goes red *by itself* when Brighter ships; `optioncheck` goes red *at this
     step*, performed by someone who is at that moment looking for exactly this information.
+
+### Phase 2 as executed — 2026-08-28, 11/11
+
+**The gate exists, it is proved to fail before it is trusted to pass, and it is unguarded in
+CI.** Everything below is at Brighter **`10.7.0`**, the pin in
+`tools/optioncheck/optioncheck.csproj` and nowhere else:
+
+```bash
+dotnet run --project tools/optioncheck                    # every page under contents/
+dotnet run --project tools/optioncheck -- <paths>         # just these files (§2.5)
+python3 spec/012-configuration_reference/redproof/redproof_optioncheck.py
+```
+
+**Six files, where design §3.1 lists five.** The sixth is `Authority.cs`, and it exists
+because **exit 2 has to be reachable as a verdict rather than as a restore failure**: a failed
+`dotnet restore` never runs the program at all, so a run whose packages were missing could
+never have said so. The `csproj` now writes its own `PackageReference` list into the assembly
+at build time, and the checker holds what loaded against what was pinned. That is what task
+2.9's red-proof measures, and it is not a change to any design decision — §6.5's exit codes
+are unchanged.
+
+**Task 2.6's seed marker exits 0, and the task was right to refuse to predict it.**
+`SweeperCircuitBreaking.md`'s single row says `CooldownCount`, `int`, `10`, and
+`OutboxCircuitBreakerOptions` at `10.7.0` says `CooldownCount`, `int`, `10`. **The corpus's
+one already-well-shaped table is correct**, so day two produced no ledger entry — which is a
+result, not an absence, and it is the first row of task 11.3's ledger either way: *checked,
+and it was right.* What the task did change is presentation — a bold `**CooldownCount**`
+became the spelling a reader types in backticks, the default gained its backticks, and the
+description gained a full stop.
+
+**The red-proofs: eight branches, all eight fired.** The two that matter are AC3b and AC5:
+
+| Branch | Expected | Got |
+|---|---:|---:|
+| 0. Baseline — the fixture must be green, and its scope asserted first | 0 | 0 |
+| 1. **AC3** — `bufferSize`'s *constructor* default changed 1 → 10 | 1 | 1 |
+| 2. **AC3b** — `emptyChannelDelay` written as `null`, which is what the *signature* says | 1 | 1 |
+| 3. `BufferSize` for `bufferSize` — the property spelling, not the parameter's | 1 | 1 |
+| 4. `omit:` with no reason | 1 | 1 |
+| 5. The type is gone — the marker renamed | 1 | 1 |
+| 6a. **AC5 control** — the built output copied elsewhere, nothing removed | 0 | 0 |
+| 6b. **AC5** — one pinned assembly deleted from that copy | 2 | 2 |
+
+**6a is not padding.** Copying the output somewhere else is itself a change, and without the
+control an exit 2 from the copy would prove nothing about the missing package. Branch 2 fires
+saying **`emptyChannelDelay` is `500 ms`**, which is phase 1's measurement arriving as a
+verdict. Branch 5 is the mechanised form of the two type names phase 1 found in design §7:
+`RocketMqSubscription` and `MQTTMessagingGatewayConfiguration` would each have produced it.
+
+**Four decisions phase 2 made that design does not name.** Each was forced by something phase
+1 measured:
+
+1. **A parameter with no declared default reads `none`, not a value.** Whatever the instance
+   holds for it is the argument the checker passed in. That is standing obligation 1's word
+   for it and a fact about the parameter rather than a limit of the tool.
+2. **An argument the checker had to supply is declared, never printed.** Phase 1's *thirteen
+   constructors reject their own defaults* lands exactly here: on `Subscription`,
+   `requestType` and `messagePumpType` are supplied and therefore unreadable, so the table
+   owes a `manual:` for each — which declares and counts. **Necessity is measured per type**,
+   probe 1.4's method carried into the tool: each supplied candidate is put back to its own
+   default and kept only if removal breaks construction. `makeChannels` is the case that
+   proves it works — it reads `Create` from its own default and stays fully checkable.
+3. **`max(props, ctor)` is a SELECTION, not a union.** The union would document `bufferSize`
+   and `BufferSize` as two options, when they are one option and the case hazard requirements
+   §7.1 names. Properties are `DeclaredOnly`, so a transport publication owes rows for its own
+   options and not for `Publication`'s ten — which is what design §7 maps as two tables.
+4. **Both escapes are checked against the type.** `OMIT NAMES NOTHING` and `MANUAL NAMES
+   NOTHING` catch a stale escape; `MANUAL NOT NEEDED` catches a `manual:` over a default the
+   tool can read, which would be an unchecked row wearing a declaration.
+
+**A third instrument now agrees with the other two.** `survey.py` parses source, probe 1.5's
+oracle reflects over assemblies, and the checker enumerates what a table owes. Twelve types
+run through it, and **every count matches phase 1's** — including the five where design §7 is
+superseded:
+
+| Type | Design §7 | `optioncheck` |
+|---|---:|---:|
+| `GcpPubSubSubscription` | 33 | 33 |
+| `KafkaSubscription` | 30 | 30 |
+| `KafkaPublication` | 17 | 17 |
+| `KafkaMessagingGatewayConfiguration` | 11 | 11 |
+| `ProducersConfiguration` | 26 | **22** |
+| `Publication` | 8 | **10** |
+| `InMemorySubscription` | 2 † | **17** |
+| `RmqMessagingGatewayConnection` | 19 | **11** |
+| `RelationalDatabaseConfiguration` | 8 | 8 |
+| `AzureBlobLockingProviderOptions` | 3 | 3 |
+| `DynamoDbInboxConfiguration` | 1 | 1 |
+| `QuartzSchedulerFactory` | 4 (§12.1) | 4 |
+
+**None of the twelve failed to construct and none produced an unprintable default**, so the
+synthesiser reaches every shape phase 3 through phase 9 will meet. **`QuartzSchedulerFactory`
+is the one to notice**: design §12.1 says the schedulers are invisible to `survey.py` because
+`SURFACE_RE` matches filenames and a factory is not a `*Configuration.cs`. **The marker binds
+a type, so the tool does not care** — phase 9's 25 options are checkable on the same terms as
+everything else.
+
+**The six gates in §2.8 are unmoved to the digit**, on the branch and after staging: link 150,
+pagelint 0 errors / 790 warnings / 148 pages, shape 147 pages / 12 sections / widest 10 of 20,
+redirects 77 entries / 7858 bytes, versioncheck 0 stale of 18 across 5, `--verify` 147/147/147.
+**`pagelint --changed` reaches 0 code blocks and says so** — the one page edited is a table,
+not a fence, so the strict run is legitimately vacuous and prints that it is.
 
 ---
 

--- a/tools/optioncheck/Authority.cs
+++ b/tools/optioncheck/Authority.cs
@@ -1,0 +1,97 @@
+using System.Reflection;
+
+namespace Paramore.Docs.OptionCheck;
+
+/// <summary>
+/// Exit 2 — the authority is unreachable, which is NOT a pass.
+///
+/// The family contract `linkcheck.py`, `pagelint.py` and `versioncheck.py`
+/// already run under: 0 clean, 1 a real finding, 2 the subject could not be
+/// consulted. For this tool the subject is the pinned packages, and the failure
+/// has to be reachable as a verdict rather than only as a `dotnet restore`
+/// error — a failed restore never runs this program at all, and a run that
+/// checked nothing because its assemblies were missing must not be able to
+/// print `0 mismatches`.
+///
+/// So `optioncheck.csproj` writes its own `PackageReference` list into the
+/// assembly at build time, and this class holds what loaded against what was
+/// pinned. Both halves of the pin are then in one place: the version the tables
+/// are checked against, and the list of packages that version applies to.
+/// </summary>
+internal static class Authority
+{
+    internal sealed record Package(string Id, string Version);
+
+    private static List<Assembly>? _loaded;
+
+    /// <summary>The pinned list, as the build recorded it.</summary>
+    public static IReadOnlyList<Package> Pinned()
+    {
+        using var stream = typeof(Authority).Assembly.GetManifestResourceStream("pinned-packages.txt");
+        if (stream is null) return [];
+
+        using var reader = new StreamReader(stream);
+        var packages = new List<Package>();
+
+        while (reader.ReadLine() is { } line)
+        {
+            var parts = line.Split(' ', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+            if (parts.Length == 2) packages.Add(new Package(parts[0], parts[1]));
+        }
+
+        return packages;
+    }
+
+    /// <summary>The one version every table in spec 012 is checked against.</summary>
+    public static string Pin() =>
+        Pinned().Select(p => p.Version).Distinct(StringComparer.Ordinal).SingleOrDefault() ?? "mixed";
+
+    /// <summary>
+    /// Every Brighter assembly in the process, for <see cref="Reflect.Resolve"/>
+    /// to search. Loaded from the output directory rather than from
+    /// `AppDomain.CurrentDomain.GetAssemblies()`, which sees only what has
+    /// already been touched — the trap 009 met in `AutoFromAssemblies`.
+    /// </summary>
+    public static IReadOnlyList<Assembly> Loaded()
+    {
+        if (_loaded is not null) return _loaded;
+
+        _loaded = [];
+
+        foreach (var path in Directory
+                     .GetFiles(AppContext.BaseDirectory, "Paramore.Brighter*.dll")
+                     .OrderBy(p => p, StringComparer.Ordinal))
+        {
+            try { _loaded.Add(Assembly.Load(Path.GetFileNameWithoutExtension(path))); }
+            catch { /* reported by Missing() below, where it is a verdict rather than a silence */ }
+        }
+
+        return _loaded;
+    }
+
+    /// <summary>
+    /// The pinned packages whose assembly is not in this process. Any at all is
+    /// exit 2: the checker cannot say a table is right against an assembly it
+    /// never read.
+    /// </summary>
+    public static IReadOnlyList<string> Missing()
+    {
+        var loaded = Loaded()
+            .Select(a => a.GetName().Name)
+            .Where(n => n is not null)
+            .Select(n => n!)
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+        return Pinned()
+            .Where(p => !loaded.Contains(AssemblyNameOf(p.Id)))
+            .Select(p => $"{p.Id} {p.Version}")
+            .ToList();
+    }
+
+    /// <summary>
+    /// Every Brighter package ships an assembly of its own name. Kept as a
+    /// method rather than inlined so that the day one does not, the exception
+    /// has somewhere to live and a comment beside it.
+    /// </summary>
+    private static string AssemblyNameOf(string packageId) => packageId;
+}

--- a/tools/optioncheck/Binding.cs
+++ b/tools/optioncheck/Binding.cs
@@ -1,0 +1,204 @@
+using System.Text.RegularExpressions;
+
+namespace Paramore.Docs.OptionCheck;
+
+/// <summary>
+/// Task 2.2 — the marker and its two keys (design §5, §5.1).
+///
+/// A checker reading markdown has no way to know which .NET type a table
+/// describes, and inferring it from the heading fails as *a table nobody
+/// checked, reported as a table that passed*. So the binding is explicit:
+///
+///   &lt;!-- optioncheck: Paramore.Brighter.MessagingGateway.Kafka.KafkaSubscription
+///        omit: channelFactory — not reader-set; supplied by AddConsumers
+///        manual: sweepInterval — default applied by the Dispatcher, not the type
+///   --&gt;
+///
+/// BOTH ESCAPES DECLARE RATHER THAN SILENCE, AND BOTH ARE COUNTED. That is
+/// `pagelint.py` rule 6's `// ...` applied to a second tool. A parser that
+/// accepted `omit:` with no reason would let 012 reach a green build by writing
+/// `omit:` over the hard half of every table, so a reasonless escape is a fault
+/// here rather than an escape.
+/// </summary>
+internal static class Binding
+{
+    /// <summary>A member deliberately absent from the table, or one whose default the tool cannot determine.</summary>
+    internal sealed record Escape(string Member, string Reason);
+
+    /// <summary>One row of a §7.1 table, as written.</summary>
+    internal sealed record Row(string Option, string Type, string Default, string Description, int Line);
+
+    /// <summary>One marker, the table beneath it, and anything malformed about either.</summary>
+    internal sealed record Marker(
+        string File,
+        int Line,
+        string TypeName,
+        IReadOnlyList<Escape> Omit,
+        IReadOnlyList<Escape> Manual,
+        IReadOnlyList<Row> Rows,
+        IReadOnlyList<string> Faults);
+
+    private static readonly Regex Open = new(@"^\s*<!--\s*optioncheck:\s*(?<type>[^\s>]+)\s*(?<close>-->)?\s*$",
+        RegexOptions.Compiled);
+
+    private static readonly Regex Key = new(@"^\s*(?<key>omit|manual):\s*(?<body>.*?)\s*(?<close>-->)?\s*$",
+        RegexOptions.Compiled);
+
+    /// <summary>The four columns requirements §7.1 fixes, in one order.</summary>
+    private static readonly string[] Columns = ["Option", "Type", "Default", "Description"];
+
+    public static IReadOnlyList<Marker> Parse(string path, string relative)
+    {
+        var lines = File.ReadAllLines(path);
+        var markers = new List<Marker>();
+
+        for (var i = 0; i < lines.Length; i++)
+        {
+            var open = Open.Match(lines[i]);
+            if (!open.Success) continue;
+
+            var faults = new List<string>();
+            var omit = new List<Escape>();
+            var manual = new List<Escape>();
+            var markerLine = i + 1;
+            var closed = open.Groups["close"].Success;
+            var cursor = i + 1;
+
+            while (!closed && cursor < lines.Length)
+            {
+                var line = lines[cursor];
+
+                if (line.TrimStart().StartsWith("-->", StringComparison.Ordinal))
+                {
+                    closed = true;
+                    cursor++;
+                    break;
+                }
+
+                var key = Key.Match(line);
+                if (!key.Success)
+                {
+                    faults.Add($"{relative}:{cursor + 1}: MARKER MALFORMED — "
+                               + $"expected `omit:`, `manual:` or `-->`, found `{line.Trim()}`");
+                    cursor++;
+                    continue;
+                }
+
+                var escape = ReadEscape(key.Groups["body"].Value, relative, cursor + 1, faults);
+                if (escape is not null)
+                    (key.Groups["key"].Value == "omit" ? omit : manual).Add(escape);
+
+                if (key.Groups["close"].Success) closed = true;
+                cursor++;
+            }
+
+            if (!closed)
+            {
+                faults.Add($"{relative}:{markerLine}: MARKER UNTERMINATED — no `-->`");
+                markers.Add(new Marker(relative, markerLine, open.Groups["type"].Value, omit, manual, [], faults));
+                continue;
+            }
+
+            var rows = ReadTable(lines, ref cursor, relative, markerLine, faults);
+            markers.Add(new Marker(relative, markerLine, open.Groups["type"].Value, omit, manual, rows, faults));
+            i = cursor - 1;
+        }
+
+        return markers;
+    }
+
+    /// <summary>
+    /// `member — reason`. The reason is required: an escape with no reason is a
+    /// silence wearing a declaration's clothes, and §5.1 is explicit that both
+    /// keys declare and are counted.
+    /// </summary>
+    private static Escape? ReadEscape(string body, string file, int line, List<string> faults)
+    {
+        var parts = body.Split(['—', '-', ':'], 2);
+        var member = parts[0].Trim();
+        var reason = parts.Length > 1 ? parts[1].Trim() : string.Empty;
+
+        if (member.Length == 0)
+        {
+            faults.Add($"{file}:{line}: MARKER MALFORMED — an escape with no member name");
+            return null;
+        }
+
+        if (reason.Length == 0)
+        {
+            faults.Add($"{file}:{line}: ESCAPE WITHOUT REASON — `{member}` declares nothing. "
+                       + $"Write `{member} — <why>`; an escape with no reason is a silent exemption");
+            return null;
+        }
+
+        return new Escape(member, reason);
+    }
+
+    /// <summary>
+    /// The table must be the next thing after the marker. Design §5 puts the
+    /// comment "immediately above the table", and a marker floating above prose
+    /// is a table nobody checks.
+    /// </summary>
+    private static IReadOnlyList<Row> ReadTable(
+        string[] lines, ref int cursor, string file, int markerLine, List<string> faults)
+    {
+        while (cursor < lines.Length && lines[cursor].Trim().Length == 0) cursor++;
+
+        if (cursor >= lines.Length || !lines[cursor].TrimStart().StartsWith('|'))
+        {
+            faults.Add($"{file}:{markerLine}: NO TABLE — the marker names a type but nothing follows it. "
+                       + "The marker binds the table immediately below it");
+            return [];
+        }
+
+        var header = Cells(lines[cursor]);
+        if (!header.SequenceEqual(Columns))
+        {
+            faults.Add($"{file}:{cursor + 1}: WRONG COLUMNS — expected "
+                       + $"`{string.Join(" | ", Columns)}`, found `{string.Join(" | ", header)}`");
+        }
+
+        cursor++;
+        if (cursor < lines.Length && IsSeparator(lines[cursor])) cursor++;
+
+        var rows = new List<Row>();
+        while (cursor < lines.Length && lines[cursor].TrimStart().StartsWith('|'))
+        {
+            var cells = Cells(lines[cursor]);
+            if (cells.Count < 4)
+            {
+                faults.Add($"{file}:{cursor + 1}: SHORT ROW — {cells.Count} cells, expected 4");
+                cursor++;
+                continue;
+            }
+
+            rows.Add(new Row(cells[0], cells[1], cells[2], cells[3], cursor + 1));
+            cursor++;
+        }
+
+        if (rows.Count == 0)
+            faults.Add($"{file}:{markerLine}: EMPTY TABLE — a header and no rows");
+
+        return rows;
+    }
+
+    private static bool IsSeparator(string line) =>
+        line.TrimStart().StartsWith('|') && line.Replace("|", "").Replace("-", "").Replace(":", "").Trim().Length == 0;
+
+    /// <summary>
+    /// The cells as a reader sees them: `**CooldownCount**` and `` `CooldownCount` ``
+    /// are the same option, written by two authors. Presentation is not the
+    /// subject — the spelling is.
+    /// </summary>
+    private static List<string> Cells(string line)
+    {
+        var trimmed = line.Trim();
+        if (trimmed.StartsWith('|')) trimmed = trimmed[1..];
+        if (trimmed.EndsWith('|')) trimmed = trimmed[..^1];
+
+        return trimmed.Split('|').Select(Clean).ToList();
+    }
+
+    public static string Clean(string cell) =>
+        cell.Replace("`", "").Replace("**", "").Replace("*", "").Trim();
+}

--- a/tools/optioncheck/Program.cs
+++ b/tools/optioncheck/Program.cs
@@ -147,10 +147,14 @@ internal static class Program
             return;
         }
 
+        // First one wins, and none of these throws on a duplicate. A type that
+        // declares two members of one name, or a marker that names one twice,
+        // is a thing to report — not a stack trace that stops the whole run and
+        // leaves every other table unchecked.
         var surface = Reflect.Describe(type);
-        var byName = surface.Members.ToDictionary(m => m.Name, StringComparer.Ordinal);
-        var omit = marker.Omit.ToDictionary(e => e.Member, StringComparer.Ordinal);
-        var declared = marker.Manual.ToDictionary(e => e.Member, StringComparer.Ordinal);
+        var byName = First(surface.Members, m => m.Name);
+        var omit = First(marker.Omit, e => e.Member);
+        var declared = First(marker.Manual, e => e.Member);
 
         foreach (var escape in marker.Omit)
         {
@@ -308,6 +312,13 @@ internal static class Program
         }
 
         return null;
+    }
+
+    private static Dictionary<string, T> First<T>(IEnumerable<T> items, Func<T, string> key)
+    {
+        var map = new Dictionary<string, T>(StringComparer.Ordinal);
+        foreach (var item in items) map.TryAdd(key(item), item);
+        return map;
     }
 
     private static string Count(int n, string singular, string? plural = null) =>

--- a/tools/optioncheck/Program.cs
+++ b/tools/optioncheck/Program.cs
@@ -1,0 +1,315 @@
+using Paramore.Docs.OptionCheck;
+
+/// <summary>
+/// Task 2.5 — D1's entry point. Design §6.1's seven steps, §6.5's exit codes.
+///
+///   dotnet run --project tools/optioncheck              # every page under contents/
+///   dotnet run --project tools/optioncheck -- <paths>   # just these files or directories
+///
+/// The optional path arguments are `linkcheck.py`'s and `pagelint.py`'s
+/// contract (tasks.md §2.5), and they are what lets phase 2's red-proofs run
+/// against fixtures outside `contents/` rather than waiting for a page phase 3
+/// has not written yet.
+///
+/// IT PRINTS ITS SCOPE BEFORE ITS VERDICT. `0 mismatches` across 0 tables and
+/// `0 mismatches` across 628 must not print the same line — that is the family
+/// contract `versioncheck.py` set, and it is the whole defence against a
+/// vacuous green.
+/// </summary>
+internal static class Program
+{
+    private const int Clean = 0;
+    private const int Findings = 1;
+    private const int Unreachable = 2;
+
+    private static int Main(string[] args)
+    {
+        // Step 1 of design §6.1, and it runs before anything else so that its
+        // message is the one a reader gets. The packages are the authority, and
+        // a checker that cannot read them has not passed.
+        var missing = Authority.Missing();
+        if (missing.Count > 0)
+        {
+            Console.Error.WriteLine($"optioncheck: AUTHORITY UNREACHABLE — {missing.Count} of "
+                                    + $"{Authority.Pinned().Count} pinned packages "
+                                    + $"{(missing.Count == 1 ? "is" : "are")} not in this process:");
+            foreach (var package in missing) Console.Error.WriteLine($"  {package}");
+            Console.Error.WriteLine("The pin is tools/optioncheck/optioncheck.csproj. Restore and build the "
+                                    + "project, then run it again.");
+            Console.Error.WriteLine("This is exit 2, not exit 1: nothing was checked, which is not the same "
+                                    + "as nothing being wrong.");
+            return Unreachable;
+        }
+
+        var root = RepositoryRoot();
+        if (root is null && args.Length == 0)
+        {
+            Console.Error.WriteLine("optioncheck: cannot find the repository root (a directory holding "
+                                    + "SUMMARY.md and contents/) above this assembly, and no paths were "
+                                    + "given, so there is nothing to check.");
+            return Unreachable;
+        }
+
+        var files = Files(args, root);
+        if (files.Count == 0)
+        {
+            Console.Error.WriteLine("optioncheck: no markdown files to check in "
+                                    + $"{(args.Length == 0 ? "contents/" : string.Join(", ", args))}");
+            return Unreachable;
+        }
+
+        var markers = files
+            .SelectMany(f => Binding.Parse(f, Report(root, f)))
+            .ToList();
+
+        var findings = new List<string>();
+        var omitted = new List<string>();
+        var manual = new List<string>();
+
+        foreach (var marker in markers)
+            Check(marker, findings, omitted, manual);
+
+        Scope(files.Count, markers, omitted, manual);
+
+        Console.WriteLine();
+        foreach (var finding in findings) Console.WriteLine(finding);
+
+        if (findings.Count > 0) Console.WriteLine();
+        Console.WriteLine(findings.Count == 0
+            ? $"0 mismatches across {Count(markers.Count, "table")} and "
+              + $"{Count(markers.Sum(m => m.Rows.Count), "row")}."
+            : $"{Count(findings.Count, "mismatch", "mismatches")} across "
+              + $"{Count(markers.Count, "table")}.");
+
+        return findings.Count == 0 ? Clean : Findings;
+    }
+
+    /// <summary>
+    /// Design §6.1's step 2, printed before anything is diffed. The `omit:` and
+    /// `manual:` declarations are named individually, not totalled: §5.1 says
+    /// both escapes declare and are counted, and a count with no names is a
+    /// number nobody can question.
+    /// </summary>
+    private static void Scope(
+        int filesScanned,
+        IReadOnlyList<Binding.Marker> markers,
+        IReadOnlyList<string> omitted,
+        IReadOnlyList<string> manual)
+    {
+        var types = markers.Select(m => m.TypeName).Distinct(StringComparer.Ordinal).Count();
+        var pages = markers.Select(m => m.File).Distinct(StringComparer.Ordinal).Count();
+
+        Console.WriteLine($"optioncheck — Brighter {Authority.Pin()}, "
+                          + $"{Authority.Pinned().Count} pinned packages "
+                          + "(tools/optioncheck/optioncheck.csproj)");
+        Console.WriteLine();
+
+        if (markers.Count == 0)
+        {
+            Console.WriteLine($"scope: NOTHING. {Count(filesScanned, "file")} scanned and not one "
+                              + "`<!-- optioncheck: -->` marker in any of them.");
+            Console.WriteLine("       A run that reaches no table checks no default. This is not a pass "
+                              + "with nothing to do;");
+            Console.WriteLine("       it is a pass with nothing in scope, and the two look identical in a "
+                              + "CI log that prints only a verdict.");
+            return;
+        }
+
+        Console.WriteLine($"scope: {Count(markers.Count, "table")}, "
+                          + $"{Count(markers.Sum(m => m.Rows.Count), "row")}, "
+                          + $"{Count(types, "type")}, on {Count(pages, "page")} "
+                          + $"of {Count(filesScanned, "file")} scanned.");
+
+        Console.WriteLine(omitted.Count == 0
+            ? "       0 omit: declarations."
+            : $"       {Count(omitted.Count, "omit: declaration")}, each counted rather than silenced:");
+        foreach (var line in omitted) Console.WriteLine($"         {line}");
+
+        Console.WriteLine(manual.Count == 0
+            ? "       0 manual: declarations."
+            : $"       {Count(manual.Count, "manual: declaration")} — "
+              + "the residue requirements §7.3 asks to measure rather than estimate:");
+        foreach (var line in manual) Console.WriteLine($"         {line}");
+    }
+
+    /// <summary>Design §6.1 steps 3 to 6, for one marker.</summary>
+    private static void Check(
+        Binding.Marker marker, List<string> findings, List<string> omitted, List<string> manual)
+    {
+        findings.AddRange(marker.Faults);
+
+        var type = Reflect.Resolve(marker.TypeName);
+        if (type is null)
+        {
+            findings.Add($"{marker.File}:{marker.Line}: THE TYPE IS GONE — `{marker.TypeName}` is in none of "
+                         + $"the {Authority.Pinned().Count} pinned packages at {Authority.Pin()}. "
+                         + "Either it was renamed, or the marker never named a real type");
+            return;
+        }
+
+        var surface = Reflect.Describe(type);
+        var byName = surface.Members.ToDictionary(m => m.Name, StringComparer.Ordinal);
+        var omit = marker.Omit.ToDictionary(e => e.Member, StringComparer.Ordinal);
+        var declared = marker.Manual.ToDictionary(e => e.Member, StringComparer.Ordinal);
+
+        foreach (var escape in marker.Omit)
+        {
+            omitted.Add($"{marker.File}:{marker.Line} {type.Name}.{escape.Member} — {escape.Reason}");
+            if (!byName.ContainsKey(escape.Member))
+                findings.Add($"{marker.File}:{marker.Line}: OMIT NAMES NOTHING — `{escape.Member}` is not a "
+                             + $"reader-facing member of `{type.Name}`. A stale escape suppresses a row that "
+                             + "no longer exists and hides the one that replaced it");
+        }
+
+        foreach (var escape in marker.Manual)
+        {
+            manual.Add($"{marker.File}:{marker.Line} {type.Name}.{escape.Member} — {escape.Reason}");
+            if (!byName.ContainsKey(escape.Member))
+                findings.Add($"{marker.File}:{marker.Line}: MANUAL NAMES NOTHING — `{escape.Member}` is not a "
+                             + $"reader-facing member of `{type.Name}`");
+        }
+
+        var rows = new Dictionary<string, Binding.Row>(StringComparer.OrdinalIgnoreCase);
+        foreach (var row in marker.Rows)
+        {
+            if (row.Option.Length == 0)
+            {
+                findings.Add($"{marker.File}:{row.Line}: EMPTY OPTION CELL");
+                continue;
+            }
+
+            if (!rows.TryAdd(row.Option, row))
+                findings.Add($"{marker.File}:{row.Line}: DUPLICATE ROW — `{row.Option}` is documented twice");
+        }
+
+        foreach (var member in surface.Members)
+        {
+            if (omit.ContainsKey(member.Name)) continue;
+
+            if (!rows.TryGetValue(member.Name, out var row))
+            {
+                findings.Add($"{marker.File}:{marker.Line}: UNDOCUMENTED — `{type.Name}.{member.Name}` "
+                             + $"({member.TypeName}) is reader-facing and the table has no row for it. "
+                             + "Add the row, or declare `omit: " + member.Name + " — <why>`");
+                continue;
+            }
+
+            if (!string.Equals(row.Option, member.Name, StringComparison.Ordinal))
+                findings.Add($"{marker.File}:{row.Line}: WRONG SPELLING — the table writes `{row.Option}`; "
+                             + $"the reader types `{member.Name}`. Requirements §7.1: on a "
+                             + "constructor-driven type the option is the parameter, not the property");
+
+            if (!string.Equals(row.Type, member.TypeName, StringComparison.Ordinal))
+                findings.Add($"{marker.File}:{row.Line}: WRONG TYPE — `{member.Name}` is `{member.TypeName}`, "
+                             + $"the table says `{row.Type}`");
+
+            if (row.Description.Length == 0)
+                findings.Add($"{marker.File}:{row.Line}: EMPTY DESCRIPTION — `{member.Name}`");
+
+            if (row.Default.Length == 0)
+            {
+                findings.Add($"{marker.File}:{row.Line}: BLANK DEFAULT — `{member.Name}`. A blank cell is "
+                             + "indistinguishable from an unfinished row; write the value, or `none`");
+                continue;
+            }
+
+            if (declared.ContainsKey(member.Name))
+            {
+                if (member.Unreadable is null)
+                    findings.Add($"{marker.File}:{marker.Line}: MANUAL NOT NEEDED — `{member.Name}` is "
+                                 + $"declared `manual:` and the tool reads its default as `{member.Default}`. "
+                                 + "A `manual:` over a checkable default is an unchecked row");
+                continue;
+            }
+
+            if (member.Unreadable is not null)
+            {
+                findings.Add($"{marker.File}:{row.Line}: DEFAULT NOT DETERMINABLE — `{member.Name}`: "
+                             + $"{member.Unreadable}. The table says `{row.Default}` and the tool cannot "
+                             + $"confirm it. Declare `manual: {member.Name} — <why>`, which counts");
+                continue;
+            }
+
+            var accepted = Reflect.Accepted(member.Default!, member.TypeName.TrimEnd('?'));
+            if (!accepted.Contains(row.Default, StringComparer.Ordinal))
+                findings.Add($"{marker.File}:{row.Line}: WRONG DEFAULT — `{member.Name}` is "
+                             + $"`{member.Default}` on a constructed instance; the table says "
+                             + $"`{row.Default}`");
+        }
+
+        foreach (var row in marker.Rows)
+        {
+            if (row.Option.Length == 0) continue;
+            if (byName.ContainsKey(row.Option)) continue;
+            if (byName.Keys.Any(n => string.Equals(n, row.Option, StringComparison.OrdinalIgnoreCase))) continue;
+
+            findings.Add($"{marker.File}:{row.Line}: ROW NAMES NOTHING — `{row.Option}` is not a "
+                         + $"reader-facing member of `{type.Name}` at {Authority.Pin()}");
+        }
+
+        if (surface.Error is not null && surface.Members.All(m => m.Unreadable is not null))
+            findings.Add($"{marker.File}:{marker.Line}: CANNOT CONSTRUCT — `{type.Name}`: {surface.Error}. "
+                         + "Every default in this table is unchecked");
+    }
+
+    /// <summary>
+    /// The files a run reaches: `contents/` with no arguments, and exactly what
+    /// was named with them. A directory argument is walked; a file argument is
+    /// taken as given, so a fixture outside `contents/` is checkable.
+    /// </summary>
+    private static List<string> Files(string[] args, string? root)
+    {
+        if (args.Length == 0)
+            return Directory.GetFiles(Path.Combine(root!, "contents"), "*.md", SearchOption.AllDirectories)
+                .OrderBy(f => f, StringComparer.Ordinal)
+                .ToList();
+
+        var files = new List<string>();
+
+        foreach (var arg in args)
+        {
+            var path = Path.IsPathRooted(arg) ? arg : Path.Combine(Directory.GetCurrentDirectory(), arg);
+
+            if (Directory.Exists(path))
+                files.AddRange(Directory.GetFiles(path, "*.md", SearchOption.AllDirectories));
+            else if (File.Exists(path))
+                files.Add(path);
+            else
+                Console.Error.WriteLine($"optioncheck: no such file or directory: {arg}");
+        }
+
+        return files.Distinct(StringComparer.Ordinal).OrderBy(f => f, StringComparer.Ordinal).ToList();
+    }
+
+    /// <summary>
+    /// How a file is named in a finding: repository-relative where it is in the
+    /// repository, absolute where it is not. A `../../../..` path to `/tmp` is
+    /// not a location anyone can click.
+    /// </summary>
+    private static string Report(string? root, string file)
+    {
+        if (root is null) return file;
+
+        var relative = Path.GetRelativePath(root, file);
+        return relative.StartsWith("..", StringComparison.Ordinal) ? file : relative;
+    }
+
+    private static string? RepositoryRoot()
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+
+        while (directory is not null)
+        {
+            if (File.Exists(Path.Combine(directory.FullName, "SUMMARY.md"))
+                && Directory.Exists(Path.Combine(directory.FullName, "contents")))
+                return directory.FullName;
+
+            directory = directory.Parent;
+        }
+
+        return null;
+    }
+
+    private static string Count(int n, string singular, string? plural = null) =>
+        $"{n} {(n == 1 ? singular : plural ?? singular + "s")}";
+}

--- a/tools/optioncheck/Reflect.cs
+++ b/tools/optioncheck/Reflect.cs
@@ -67,7 +67,10 @@ internal static class Reflect
     {
         var properties = type
             .GetProperties(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly)
-            .Where(p => p.SetMethod is { IsPublic: true } && !p.SetMethod.IsStatic)
+            // An indexer is public, settable and not an option: it is called
+            // `Item`, there can be several of them, and no reader ever types it.
+            .Where(p => p.SetMethod is { IsPublic: true } && !p.SetMethod.IsStatic
+                        && p.GetIndexParameters().Length == 0)
             .ToList();
 
         var ctor = type.GetConstructors(BindingFlags.Public | BindingFlags.Instance)

--- a/tools/optioncheck/Reflect.cs
+++ b/tools/optioncheck/Reflect.cs
@@ -1,0 +1,275 @@
+using System.Collections;
+using System.Globalization;
+using System.Reflection;
+
+namespace Paramore.Docs.OptionCheck;
+
+/// <summary>
+/// Task 2.3 — the two routes, one per column (design §6.2).
+///
+///   Option (name) → ParameterInfo / PropertyInfo. The parameter carries the
+///                   spelling the reader types; the property does not.
+///   Type          → the same metadata, no instance required.
+///   Default       → AN INSTANTIATED OBJECT, READ BACK. ALWAYS.
+///
+/// Always, including where the parameter default would have been right.
+/// Choosing per parameter would make the tool's correctness depend on a
+/// judgement about which of requirements §5.1's three shapes a parameter is in
+/// — and shape three (`null` in the signature, 500 ms from the body) is
+/// precisely the one that LOOKS like shape two. One route for one column.
+///
+/// Which members are reader-facing is `survey.py`'s `max(props, ctor)`
+/// convention expressed as code: settable properties, or the widest
+/// constructor's parameters, whichever is the wider surface. Their UNION would
+/// double-count — on a subscription every property has a matching parameter and
+/// the two differ only in case, which is the hazard requirements §7.1 names,
+/// not two options.
+/// </summary>
+internal static class Reflect
+{
+    /// <summary>Where a type's reader-facing members came from.</summary>
+    internal enum Route
+    {
+        Properties,
+        Constructor,
+    }
+
+    /// <summary>
+    /// One reader-facing member. <paramref name="Default"/> is null when the
+    /// tool cannot determine it, and <paramref name="Unreadable"/> then says why
+    /// — that is the case `manual:` exists for, and it declares and counts
+    /// rather than passing.
+    /// </summary>
+    internal sealed record Member(string Name, string TypeName, string? Default, string? Unreadable);
+
+    internal sealed record Surface(Type Type, Route Route, IReadOnlyList<Member> Members, string? Error);
+
+    private static readonly NullabilityInfoContext Nullability = new();
+
+    /// <summary>
+    /// The type a marker names, found across every Brighter assembly in the
+    /// process. A marker binds a fully-qualified type, so a renamed type is
+    /// `THE TYPE IS GONE` rather than a silent pass — phase 1 found two of those
+    /// in design §7 before a table was ever written from them.
+    /// </summary>
+    public static Type? Resolve(string fullName)
+    {
+        foreach (var assembly in Authority.Loaded())
+        {
+            var type = assembly.GetType(fullName, throwOnError: false);
+            if (type is not null) return type;
+        }
+
+        return Type.GetType(fullName, throwOnError: false);
+    }
+
+    public static Surface Describe(Type type)
+    {
+        var properties = type
+            .GetProperties(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly)
+            .Where(p => p.SetMethod is { IsPublic: true } && !p.SetMethod.IsStatic)
+            .ToList();
+
+        var ctor = type.GetConstructors(BindingFlags.Public | BindingFlags.Instance)
+            .OrderByDescending(c => c.GetParameters().Length)
+            .FirstOrDefault();
+
+        var parameters = ctor?.GetParameters() ?? [];
+        var route = parameters.Length > properties.Count ? Route.Constructor : Route.Properties;
+
+        var built = Synthesise.Instance(type);
+
+        var members = route == Route.Constructor
+            ? parameters.Select(p => FromParameter(type, p, built)).ToList()
+            : properties.Select(p => FromProperty(p, built)).ToList();
+
+        return new Surface(type, route, members, built.Ok ? null : built.Error);
+    }
+
+    private static Member FromParameter(Type type, ParameterInfo parameter, Synthesise.Result built)
+    {
+        var name = parameter.Name ?? "?";
+        var declared = Annotated(parameter.ParameterType, Nullability.Create(parameter).ReadState);
+
+        // A parameter with no declared default has no default to read: whatever
+        // the instance holds is the argument the synthesiser passed in. `none`
+        // is standing obligation 1's word for it, and it is a fact about the
+        // parameter rather than a limit of the tool — so it is a value, not an
+        // `Unreadable`.
+        if (!parameter.HasDefaultValue)
+            return new Member(name, declared, "none", null);
+
+        if (!built.Ok)
+            return new Member(name, declared, null, $"the type could not be constructed: {built.Error}");
+
+        // A parameter the synthesiser had to supply a value for reads back the
+        // checker's own argument, not the product's default. Say so rather than
+        // print it: phase 1 measured thirteen constructors that reject their own
+        // declared defaults, and every one of them lands here.
+        if (built.Supplied.Contains(name))
+            return new Member(name, declared, null,
+                "the constructor rejects its own declared default for this parameter, so the "
+                + "checker had to supply a value — the instance would read back that value");
+
+        var property = type
+            .GetProperties(BindingFlags.Public | BindingFlags.Instance)
+            .FirstOrDefault(p => string.Equals(p.Name, name, StringComparison.OrdinalIgnoreCase)
+                                 && p.GetMethod is { IsPublic: true });
+
+        if (property is null)
+            return new Member(name, declared, null,
+                "no property of that name on the instance, so the default cannot be read back");
+
+        return WithValue(name, declared, () => property.GetValue(built.Instance));
+    }
+
+    private static Member FromProperty(PropertyInfo property, Synthesise.Result built)
+    {
+        var declared = Annotated(property.PropertyType, Nullability.Create(property).ReadState);
+
+        if (!built.Ok)
+            return new Member(property.Name, declared, null, $"the type could not be constructed: {built.Error}");
+
+        return WithValue(property.Name, declared, () => property.GetValue(built.Instance));
+    }
+
+    private static Member WithValue(string name, string declared, Func<object?> read)
+    {
+        object? value;
+        try
+        {
+            value = read();
+        }
+        catch (Exception ex)
+        {
+            var inner = ex.InnerException ?? ex;
+            return new Member(name, declared, null, $"reading it threw {inner.GetType().Name}: {inner.Message}");
+        }
+
+        var rendered = Render(value);
+        if (rendered is null)
+            return new Member(name, declared, null,
+                $"the value has no printable form ({Pretty(value!.GetType())})");
+
+        // The property is fed by a constructor argument the synthesiser supplied,
+        // so what came back is the checker's own sentinel. Reporting it as a
+        // default would be the tool documenting itself — the failure `manual:`
+        // exists to declare instead.
+        return Sentinel(rendered)
+            ? new Member(name, declared, null,
+                "the value on the instance is the argument the checker had to supply for a "
+                + "required constructor parameter, not a default")
+            : new Member(name, declared, rendered, null);
+    }
+
+    /// <summary>
+    /// The synthesiser's own arguments, deliberately distinctive so that a value
+    /// arriving back from an instance can be told apart from the product's.
+    /// </summary>
+    private static bool Sentinel(string rendered) =>
+        rendered.Contains("optioncheck", StringComparison.Ordinal)
+        || rendered.Contains(nameof(ProbeRequest), StringComparison.Ordinal);
+
+    /// <summary>
+    /// The canonical rendering of a default, and the forms a table may write it
+    /// in instead. Presentation is not the subject — a table saying `00:00:00.5`
+    /// where the canonical form is `500 ms` documents the same product.
+    /// </summary>
+    public static IReadOnlyList<string> Accepted(string canonical, string? typeName = null)
+    {
+        var forms = new List<string> { canonical };
+
+        if (canonical.EndsWith(" ms", StringComparison.Ordinal)
+            && double.TryParse(canonical[..^3], NumberStyles.Float, CultureInfo.InvariantCulture, out var ms))
+        {
+            var span = TimeSpan.FromMilliseconds(ms);
+            forms.Add(span.ToString());
+            forms.Add($"TimeSpan.FromMilliseconds({ms.ToString("0.###", CultureInfo.InvariantCulture)})");
+            if (ms % 1000 == 0)
+            {
+                var seconds = (ms / 1000).ToString("0.###", CultureInfo.InvariantCulture);
+                forms.Add($"{seconds} s");
+                forms.Add($"{seconds}s");
+                forms.Add($"TimeSpan.FromSeconds({seconds})");
+            }
+        }
+
+        if (canonical.StartsWith('"') && canonical.EndsWith('"') && canonical.Length >= 2)
+            forms.Add(canonical[1..^1]);
+
+        if (typeName is not null && canonical is not "null")
+            forms.Add($"{typeName}.{canonical}");
+
+        return forms;
+    }
+
+    /// <summary>
+    /// A default as a table would write it, or null where there is no honest way
+    /// to write it — an object whose `ToString` is its own type name says
+    /// nothing to a reader, and inventing a rendering for it would be the tool
+    /// documenting itself.
+    /// </summary>
+    public static string? Render(object? value) => value switch
+    {
+        null => "null",
+        bool b => b ? "true" : "false",
+        string s => $"\"{s}\"",
+        TimeSpan t => $"{t.TotalMilliseconds.ToString("0.###", CultureInfo.InvariantCulture)} ms",
+        Enum e => e.ToString(),
+        IFormattable f => f.ToString(null, CultureInfo.InvariantCulture),
+        IEnumerable e => e.Cast<object?>().Any() ? null : "empty",
+        _ => Printable(value),
+    };
+
+    private static string? Printable(object value)
+    {
+        var text = value.ToString();
+        return text is null || text == value.GetType().FullName || text == value.GetType().ToString()
+            ? null
+            : text;
+    }
+
+    /// <summary>The declared type with its nullable annotation: `TimeSpan?`, never `TimeSpan`.</summary>
+    private static string Annotated(Type type, NullabilityState state)
+    {
+        if (Nullable.GetUnderlyingType(type) is { } underlying)
+            return Pretty(underlying) + "?";
+
+        return state == NullabilityState.Nullable ? Pretty(type) + "?" : Pretty(type);
+    }
+
+    public static string Pretty(Type type)
+    {
+        if (Nullable.GetUnderlyingType(type) is { } underlying)
+            return Pretty(underlying) + "?";
+
+        if (Keywords.TryGetValue(type, out var keyword)) return keyword;
+
+        if (type.IsArray)
+            return Pretty(type.GetElementType()!) + "[]";
+
+        if (!type.IsGenericType) return type.Name;
+
+        var name = type.Name[..type.Name.IndexOf('`')];
+        return $"{name}<{string.Join(", ", type.GetGenericArguments().Select(Pretty))}>";
+    }
+
+    private static readonly Dictionary<Type, string> Keywords = new()
+    {
+        [typeof(bool)] = "bool",
+        [typeof(byte)] = "byte",
+        [typeof(sbyte)] = "sbyte",
+        [typeof(char)] = "char",
+        [typeof(decimal)] = "decimal",
+        [typeof(double)] = "double",
+        [typeof(float)] = "float",
+        [typeof(int)] = "int",
+        [typeof(uint)] = "uint",
+        [typeof(long)] = "long",
+        [typeof(ulong)] = "ulong",
+        [typeof(short)] = "short",
+        [typeof(ushort)] = "ushort",
+        [typeof(object)] = "object",
+        [typeof(string)] = "string",
+    };
+}

--- a/tools/optioncheck/Synthesise.cs
+++ b/tools/optioncheck/Synthesise.cs
@@ -1,0 +1,237 @@
+using System.Reflection;
+using Paramore.Brighter;
+
+namespace Paramore.Docs.OptionCheck;
+
+/// <summary>
+/// Task 2.4 — constructor arguments for the types that need them.
+///
+/// Reading a default off an instance (design §6.2) means building the instance
+/// first, and design §6.3 sizes that burden: strings, enums and the three
+/// subscription arguments cover most of it. Probe 1.4 then measured the running
+/// version of the same table and found **34 types and 70 required parameters**,
+/// not 24 and 48 — and one thing design does not name at all:
+///
+///   THIRTEEN CONSTRUCTORS REJECT THEIR OWN DEFAULTS. Every subscription type in
+///   the product requires a request type, and eleven also require
+///   `messagePumpType`, whose declared default of `Unknown` the body refuses.
+///
+/// That is why this class does not stop at "it constructed". A parameter the
+/// checker had to supply a value for is a parameter whose instance value is the
+/// checker's own argument — so reading a `Default` back off it would document
+/// the checker rather than the product. <see cref="Supplied"/> is that set, and
+/// <see cref="Program"/> requires a `manual:` declaration for every member in
+/// it rather than printing a value it made up.
+///
+/// NECESSITY IS MEASURED, NOT READ OFF WHAT WAS SUPPLIED. Probe 1.4's first
+/// draft read pass 2's supplied list as the constructors' required list and
+/// reported that all thirteen need `makeChannels`; not one of them does. So each
+/// supplied candidate is put back to its own declared default, one at a time,
+/// and kept only where its removal breaks construction.
+/// </summary>
+internal static class Synthesise
+{
+    internal sealed record Result(object? Instance, IReadOnlySet<string> Supplied, string? Error)
+    {
+        public bool Ok => Instance is not null;
+    }
+
+    private static readonly Dictionary<Type, Result> Cache = [];
+
+    public static Result Instance(Type type)
+    {
+        if (Cache.TryGetValue(type, out var cached)) return cached;
+        return Cache[type] = Build(type);
+    }
+
+    private static Result Build(Type type)
+    {
+        // The hand-written factories design §6.3 anticipated. Probe 1.4 measured
+        // which types genuinely need one: `AzureBlobArchiveProviderOptions` and
+        // `S3LuggageOptions` are the two that fail without one, and both are P2.
+        // `HandlerConfiguration` is the one of §6.3's four that is P0 — it is on
+        // D4, phase 3 — so it gets a factory here rather than a declaration.
+        if (Factory(type) is { } made)
+            return new Result(made, new HashSet<string>(StringComparer.Ordinal), null);
+
+        var ctor = Widest(type);
+        if (ctor is null)
+            return new Result(null, EmptySet, "no public constructor");
+
+        if (ctor.GetParameters().Length == 0)
+        {
+            try { return new Result(ctor.Invoke([]), EmptySet, null); }
+            catch (Exception ex) { return new Result(null, EmptySet, Explain(ex)); }
+        }
+
+        // Pass 1 — required parameters only. Every defaulted parameter keeps its
+        // own default, so if this works, every default the checker reads back is
+        // the product's own.
+        var pass1 = TryInvoke(ctor, supply: p => !p.HasDefaultValue);
+        if (pass1.Instance is not null)
+            return new Result(pass1.Instance, EmptySet, null);
+
+        // Pass 2 — supply defaulted parameters too, where there is a value to
+        // supply. Needed only where the constructor body validates a defaulted
+        // parameter, which no parse of a signature can see.
+        var pass2 = TryInvoke(ctor, supply: _ => true);
+        if (pass2.Instance is null)
+            return new Result(null, EmptySet, pass1.Error ?? pass2.Error);
+
+        // Necessity: put each defaulted parameter pass 2 supplied back to its own
+        // default and keep the removal if the type still builds.
+        var needed = new HashSet<string>(pass2.Supplied, StringComparer.Ordinal);
+        foreach (var candidate in pass2.Supplied.OrderBy(n => n, StringComparer.Ordinal))
+        {
+            var trial = new HashSet<string>(needed, StringComparer.Ordinal) { };
+            trial.Remove(candidate);
+
+            var attempt = TryInvoke(ctor, p => !p.HasDefaultValue || (p.Name is not null && trial.Contains(p.Name)));
+            if (attempt.Instance is not null) needed = trial;
+        }
+
+        var final = TryInvoke(ctor, p => !p.HasDefaultValue || (p.Name is not null && needed.Contains(p.Name)));
+
+        // Interaction effects: a set that is minimal one parameter at a time is
+        // not guaranteed to be minimal together. Where the minimised set does not
+        // build, fall back to pass 2's — a larger `manual:` obligation is honest;
+        // a value the checker invented is not.
+        return final.Instance is not null
+            ? new Result(final.Instance, needed, null)
+            : new Result(pass2.Instance, pass2.Supplied, null);
+    }
+
+    private static readonly IReadOnlySet<string> EmptySet = new HashSet<string>(StringComparer.Ordinal);
+
+    private sealed record Attempt(object? Instance, IReadOnlySet<string> Supplied, string? Error);
+
+    private static Attempt TryInvoke(ConstructorInfo ctor, Func<ParameterInfo, bool> supply)
+    {
+        var parameters = ctor.GetParameters();
+        var args = new object?[parameters.Length];
+        var supplied = new HashSet<string>(StringComparer.Ordinal);
+
+        foreach (var p in parameters)
+        {
+            if (!supply(p) && p.HasDefaultValue)
+            {
+                args[p.Position] = p.DefaultValue;
+                continue;
+            }
+
+            var value = Value(p.ParameterType, depth: 0);
+
+            if (value is null && p.HasDefaultValue)
+            {
+                // Nothing better to offer than the declared default, so this is
+                // not a parameter the checker supplied.
+                args[p.Position] = p.DefaultValue;
+                continue;
+            }
+
+            if (value is null && !IsNullable(p))
+                return new Attempt(null, supplied, $"cannot synthesise {Pretty(p.ParameterType)} {p.Name}");
+
+            args[p.Position] = value;
+            if (p.Name is not null && p.HasDefaultValue) supplied.Add(p.Name);
+        }
+
+        try { return new Attempt(ctor.Invoke(args), supplied, null); }
+        catch (Exception ex) { return new Attempt(null, supplied, Explain(ex)); }
+    }
+
+    /// <summary>A value for a parameter type, or null where the synthesiser has none.</summary>
+    private static object? Value(Type t, int depth)
+    {
+        var underlying = Nullable.GetUnderlyingType(t) ?? t;
+
+        if (underlying == typeof(string)) return "optioncheck";
+        if (underlying == typeof(Type)) return typeof(ProbeRequest);
+        if (underlying == typeof(bool)) return false;
+        if (underlying == typeof(int)) return 1;
+        if (underlying == typeof(long)) return 1L;
+        if (underlying == typeof(double)) return 1d;
+        if (underlying == typeof(TimeSpan)) return TimeSpan.FromMilliseconds(1);
+        if (underlying == typeof(Uri)) return new Uri("https://optioncheck.invalid");
+
+        if (underlying.IsEnum)
+        {
+            // `MessagePumpType.Unknown` is 0 and the Subscription constructor
+            // throws on it, so a zero-valued member named Unknown or None is
+            // exactly the wrong choice.
+            var usable = Enum.GetNames(underlying).FirstOrDefault(n => n is not ("Unknown" or "None"));
+            return usable is null ? Enum.GetValues(underlying).GetValue(0) : Enum.Parse(underlying, usable);
+        }
+
+        // Brighter's own types — the single-string value types first
+        // (SubscriptionName, ChannelName, RoutingKey; design §6.3's three
+        // subscription arguments are all of this shape), then, one level down,
+        // any Brighter class these same rules can build.
+        if (underlying.Namespace?.StartsWith("Paramore.Brighter") != true
+            || underlying.IsAbstract || underlying.IsInterface || depth >= 2)
+            return null;
+
+        var single = underlying.GetConstructors(BindingFlags.Public | BindingFlags.Instance)
+            .FirstOrDefault(c => c.GetParameters().Length == 1
+                                 && c.GetParameters()[0].ParameterType == typeof(string));
+
+        if (single is not null)
+        {
+            try { return single.Invoke(["optioncheck"]); }
+            catch { return null; }
+        }
+
+        var ctor = Widest(underlying);
+        if (ctor is null) return null;
+
+        var nested = TryInvoke(ctor, p => !p.HasDefaultValue);
+        return nested.Instance ?? TryInvoke(ctor, _ => true).Instance;
+    }
+
+    /// <summary>
+    /// The hand-written factories. `HandlerConfiguration` is the P0 one and the
+    /// reason this method exists: it takes two interfaces, and an interface is
+    /// exactly what the generic path cannot invent.
+    /// </summary>
+    private static object? Factory(Type type) => type.FullName switch
+    {
+        "Paramore.Brighter.HandlerConfiguration" =>
+            new HandlerConfiguration(new SubscriberRegistry(), new NullHandlerFactory()),
+        _ => null,
+    };
+
+    private static ConstructorInfo? Widest(Type type) =>
+        type.GetConstructors(BindingFlags.Public | BindingFlags.Instance)
+            .OrderByDescending(c => c.GetParameters().Length)
+            .FirstOrDefault();
+
+    private static bool IsNullable(ParameterInfo p) =>
+        !p.ParameterType.IsValueType || Nullable.GetUnderlyingType(p.ParameterType) is not null;
+
+    private static string Explain(Exception ex)
+    {
+        var inner = ex.InnerException ?? ex;
+        return $"{inner.GetType().Name}: {inner.Message}";
+    }
+
+    public static string Pretty(Type t) => Reflect.Pretty(t);
+}
+
+/// <summary>A request type with no behaviour, so a subscription has one to name.</summary>
+internal sealed class ProbeRequest : IRequest
+{
+    public Id Id { get; set; } = Id.Random();
+    public Id? CorrelationId { get; set; }
+}
+
+/// <summary>
+/// The handler factory `HandlerConfiguration` requires. It is never asked for a
+/// handler — the checker reads properties off the configuration object and
+/// dispatches nothing — so returning null is the whole implementation.
+/// </summary>
+internal sealed class NullHandlerFactory : IAmAHandlerFactorySync
+{
+    public IHandleRequests? Create(Type handlerType, IAmALifetime lifetime) => null;
+
+    public void Release(IHandleRequests handler, IAmALifetime lifetime) { }
+}

--- a/tools/optioncheck/optioncheck.csproj
+++ b/tools/optioncheck/optioncheck.csproj
@@ -1,0 +1,142 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <!-- net9.0, matching the runtime design §6.5 pins for the `options` CI job. -->
+    <TargetFramework>net9.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <RootNamespace>Paramore.Docs.OptionCheck</RootNamespace>
+    <AssemblyName>optioncheck</AssemblyName>
+    <!-- The checker loads every referenced package assembly by name. A package
+         whose types are never mentioned in source is otherwise trimmed out of
+         the output directory by the build, and the checker would then report
+         its authority as unreachable (exit 2) over a build artefact. -->
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+    <!-- It constructs types with obsolete members and reads defaults off them;
+         a warning is not a finding here. -->
+    <NoWarn>$(NoWarn);CS0618</NoWarn>
+  </PropertyGroup>
+
+  <!-- THE PIN, AND IT LIVES HERE AND NOWHERE ELSE.
+       Design §5.2: a version on every marker would be a hundred pins to bump
+       instead of one. `RELEASE_CHECKLIST.md` names this file (D3).
+
+       THE LIST IS PROBE 1.3'S, CARRIED FORWARD VERBATIM — task 2.1. Probe 1.3
+       assembled exactly this set and proved that all of it loads in one process
+       with one type instantiated from each (`spec/012-configuration_reference/
+       probes/README.md`). Re-deriving it here would put a second, unproven list
+       in the repository, and the difference between the two would be silent.
+
+       NO `.V4` PACKAGES. Requirements §8 puts them out of scope as separate
+       surfaces, and they are exactly the pairs that would put two AWS SDK
+       majors in one process (design §6.4). -->
+  <ItemGroup Label="Core — design §7.1">
+    <PackageReference Include="Paramore.Brighter" Version="10.7.0" />
+    <PackageReference Include="Paramore.Brighter.Extensions.DependencyInjection" Version="10.7.0" />
+    <PackageReference Include="Paramore.Brighter.ServiceActivator.Extensions.DependencyInjection" Version="10.7.0" />
+  </ItemGroup>
+
+  <ItemGroup Label="Transports — design §7.2">
+    <PackageReference Include="Paramore.Brighter.MessagingGateway.RMQ.Async" Version="10.7.0" />
+    <PackageReference Include="Paramore.Brighter.MessagingGateway.RMQ.Sync" Version="10.7.0" />
+    <PackageReference Include="Paramore.Brighter.MessagingGateway.Kafka" Version="10.7.0" />
+    <PackageReference Include="Paramore.Brighter.MessagingGateway.AWSSQS" Version="10.7.0" />
+    <PackageReference Include="Paramore.Brighter.MessagingGateway.AzureServiceBus" Version="10.7.0" />
+    <PackageReference Include="Paramore.Brighter.MessagingGateway.Postgres" Version="10.7.0" />
+    <PackageReference Include="Paramore.Brighter.MessagingGateway.GcpPubSub" Version="10.7.0" />
+    <PackageReference Include="Paramore.Brighter.MessagingGateway.Redis" Version="10.7.0" />
+    <PackageReference Include="Paramore.Brighter.MessagingGateway.RocketMQ" Version="10.7.0" />
+    <PackageReference Include="Paramore.Brighter.MessagingGateway.MQTT" Version="10.7.0" />
+    <PackageReference Include="Paramore.Brighter.MessagingGateway.MsSql" Version="10.7.0" />
+  </ItemGroup>
+
+  <ItemGroup Label="Outbox, inbox and box provisioning — design §7.3">
+    <PackageReference Include="Paramore.Brighter.Outbox.DynamoDB" Version="10.7.0" />
+    <PackageReference Include="Paramore.Brighter.Outbox.MongoDb" Version="10.7.0" />
+    <PackageReference Include="Paramore.Brighter.Outbox.Firestore" Version="10.7.0" />
+    <PackageReference Include="Paramore.Brighter.Outbox.MsSql" Version="10.7.0" />
+    <PackageReference Include="Paramore.Brighter.Outbox.MySql" Version="10.7.0" />
+    <PackageReference Include="Paramore.Brighter.Outbox.PostgreSql" Version="10.7.0" />
+    <PackageReference Include="Paramore.Brighter.Outbox.Spanner" Version="10.7.0" />
+    <PackageReference Include="Paramore.Brighter.Outbox.Sqlite" Version="10.7.0" />
+    <PackageReference Include="Paramore.Brighter.Outbox.Hosting" Version="10.7.0" />
+    <PackageReference Include="Paramore.Brighter.Inbox.DynamoDB" Version="10.7.0" />
+    <PackageReference Include="Paramore.Brighter.Inbox.MongoDb" Version="10.7.0" />
+    <PackageReference Include="Paramore.Brighter.Inbox.Firestore" Version="10.7.0" />
+    <PackageReference Include="Paramore.Brighter.Inbox.MsSql" Version="10.7.0" />
+    <PackageReference Include="Paramore.Brighter.Inbox.MySql" Version="10.7.0" />
+    <PackageReference Include="Paramore.Brighter.Inbox.Postgres" Version="10.7.0" />
+    <PackageReference Include="Paramore.Brighter.Inbox.Spanner" Version="10.7.0" />
+    <PackageReference Include="Paramore.Brighter.Inbox.Sqlite" Version="10.7.0" />
+    <PackageReference Include="Paramore.Brighter.BoxProvisioning" Version="10.7.0" />
+    <PackageReference Include="Paramore.Brighter.BoxProvisioning.MsSql" Version="10.7.0" />
+    <PackageReference Include="Paramore.Brighter.BoxProvisioning.MySql" Version="10.7.0" />
+    <PackageReference Include="Paramore.Brighter.BoxProvisioning.PostgreSql" Version="10.7.0" />
+    <PackageReference Include="Paramore.Brighter.BoxProvisioning.Spanner" Version="10.7.0" />
+    <PackageReference Include="Paramore.Brighter.BoxProvisioning.Sqlite" Version="10.7.0" />
+  </ItemGroup>
+
+  <ItemGroup Label="Relational configuration hosts — design §7.3 and §12.4">
+    <PackageReference Include="Paramore.Brighter.MsSql" Version="10.7.0" />
+    <PackageReference Include="Paramore.Brighter.MySql" Version="10.7.0" />
+    <PackageReference Include="Paramore.Brighter.PostgreSql" Version="10.7.0" />
+    <PackageReference Include="Paramore.Brighter.Spanner" Version="10.7.0" />
+    <PackageReference Include="Paramore.Brighter.Sqlite" Version="10.7.0" />
+    <PackageReference Include="Paramore.Brighter.MongoDb" Version="10.7.0" />
+    <PackageReference Include="Paramore.Brighter.Firestore" Version="10.7.0" />
+  </ItemGroup>
+
+  <ItemGroup Label="Locks — design §7.4">
+    <PackageReference Include="Paramore.Brighter.Locking.DynamoDB" Version="10.7.0" />
+    <PackageReference Include="Paramore.Brighter.Locking.Azure" Version="10.7.0" />
+    <PackageReference Include="Paramore.Brighter.Locking.PostgresSql" Version="10.7.0" />
+    <PackageReference Include="Paramore.Brighter.Locking.MongoDb" Version="10.7.0" />
+    <PackageReference Include="Paramore.Brighter.Locking.Firestore" Version="10.7.0" />
+    <PackageReference Include="Paramore.Brighter.Locking.MsSql" Version="10.7.0" />
+    <PackageReference Include="Paramore.Brighter.Locking.MySql" Version="10.7.0" />
+  </ItemGroup>
+
+  <ItemGroup Label="Schedulers — design §7.5">
+    <PackageReference Include="Paramore.Brighter.MessageScheduler.AWS" Version="10.7.0" />
+    <PackageReference Include="Paramore.Brighter.MessageScheduler.Azure" Version="10.7.0" />
+    <PackageReference Include="Paramore.Brighter.MessageScheduler.Hangfire" Version="10.7.0" />
+    <PackageReference Include="Paramore.Brighter.MessageScheduler.Quartz" Version="10.7.0" />
+    <PackageReference Include="Paramore.Brighter.MessageScheduler.TickerQ" Version="10.7.0" />
+  </ItemGroup>
+
+  <!-- Design §7.6 files these under P2 and 012 does not schedule their pages
+       (bar `AsyncAPISupport.md`, which task 8.4 owns). They are here because
+       §6.3's synthesis table counts their types — `AWSS3Connection` and
+       `S3LuggageOptions` are two of its four "objects the tool must build" —
+       so probe 1.4 cannot reproduce that table without them. They also carry
+       three more third-party SDKs into the process, which is what probe 1.3
+       is looking for. -->
+  <ItemGroup Label="Luggage, archive and AsyncAPI — design §7.6">
+    <PackageReference Include="Paramore.Brighter.Transformers.AWS" Version="10.7.0" />
+    <PackageReference Include="Paramore.Brighter.Transformers.Azure" Version="10.7.0" />
+    <PackageReference Include="Paramore.Brighter.Transformers.Gcp" Version="10.7.0" />
+    <PackageReference Include="Paramore.Brighter.Transformers.MongoGridFS" Version="10.7.0" />
+    <PackageReference Include="Paramore.Brighter.Archive.Azure" Version="10.7.0" />
+    <PackageReference Include="Paramore.Brighter.AsyncAPI" Version="10.7.0" />
+  </ItemGroup>
+
+  <!-- Exit 2 is "the authority is unreachable", and it has to be reachable as a
+       verdict rather than as a `dotnet restore` failure — a failed restore never
+       runs this program at all. So the pinned list is written into the assembly
+       at build time and checked against what actually loaded at run time
+       (`Program.Authority`). Embedding it rather than parsing this file at run
+       time is what lets the AC5 red-proof copy the built output somewhere else,
+       remove one assembly, and still be measuring the checker rather than a
+       missing csproj. -->
+  <Target Name="WritePinnedPackages" BeforeTargets="PrepareForBuild">
+    <WriteLinesToFile File="$(IntermediateOutputPath)pinned-packages.txt"
+                      Lines="@(PackageReference->'%(Identity) %(Version)')"
+                      Overwrite="true" WriteOnlyWhenDifferent="true" />
+    <ItemGroup>
+      <EmbeddedResource Include="$(IntermediateOutputPath)pinned-packages.txt"
+                        LogicalName="pinned-packages.txt" />
+    </ItemGroup>
+  </Target>
+
+</Project>


### PR DESCRIPTION
Phase 2 of spec 012, 11/11 tasks. **D1, D2 and D3.**

## What this is

`tools/optioncheck` — a C# console gate that reflects over the Brighter packages pinned in its own `csproj` and diffs every option table under `contents/` against the type its `<!-- optioncheck: <type> -->` marker names.

```bash
dotnet run --project tools/optioncheck              # every page under contents/
dotnet run --project tools/optioncheck -- <paths>   # just these files
```

- **Name and type** from `ParameterInfo` / `PropertyInfo`; **`Default` from an instantiated object, read back, always** — including where the parameter default would have been right, because the shape that says `null` in the signature and 500 ms in the body is precisely the one that *looks* checkable from the signature.
- **It prints its scope before its verdict.** `0 mismatches` across 0 tables and `0 mismatches` across 628 must not print the same line.
- **`omit:` and `manual:` declare and count; they never silence.** An escape with no reason is a finding, and so is an escape naming a member the type no longer has.
- Exit **0** clean, **1** a finding, **2** the authority is unreachable — which is not a pass.

## Six files where design §3.1 lists five

`Authority.cs` is the sixth. Exit 2 has to be reachable as a *verdict* rather than as a `dotnet restore` failure — a failed restore never runs the program at all — so the `csproj` writes its own `PackageReference` list into the assembly at build time and the checker holds what loaded against what was pinned. No design decision moved; §6.5's exit codes are unchanged.

## Task 2.6 — the seed marker exits 0, and the task was right to refuse to predict it

`SweeperCircuitBreaking.md`'s single row says `CooldownCount`, `int`, `10`, and so does the type. **The corpus's one already-well-shaped table is correct** — a result, not an absence, and the first line of task 11.3's ledger either way. The row was normalised to the §7.1 shape (the spelling a reader types, in backticks; a backticked default; a description that ends).

## Three red-proofs, eight branches, all eight fired

`python3 spec/012-configuration_reference/redproof/redproof_optioncheck.py`

| Branch | Expected | Got |
|---|---:|---:|
| 0. Baseline — green, and its scope asserted first | 0 | 0 |
| 1. **AC3** — a *constructor* default changed 1 → 10 | 1 | 1 |
| 2. **AC3b** — a body-coalesced default written as `null` | 1 | 1 |
| 3. The property spelling where the reader types the parameter | 1 | 1 |
| 4. `omit:` with no reason | 1 | 1 |
| 5. The type is gone | 1 | 1 |
| 6a. **AC5 control** — the output copied elsewhere, nothing removed | 0 | 0 |
| 6b. **AC5** — one pinned assembly deleted from that copy | 2 | 2 |

Branch 2 fires saying the value is **500 ms**, which is phase 1's measurement arriving as a verdict. Branch 5 is the mechanised form of the two type names phase 1 found in design §7 — `RocketMqSubscription` and `MQTTMessagingGatewayConfiguration` name types that do not exist, and each would have produced it. **6a is not padding**: copying the output somewhere else is itself a change, and without the control an exit 2 from the copy proves nothing about the missing package.

## A third instrument agrees with the other two

Twelve representative types run through the checker and **every count matches phase 1's**, including the five where design §7 is superseded — `ProducersConfiguration` 22 not 26, `Publication` 10 not 8, `InMemorySubscription` 17 not 2, `RmqMessagingGatewayConnection` 11 not 19. None failed to construct; none produced an unprintable default. `QuartzSchedulerFactory` enumerates its 4 — the marker binds a *type*, so phase 9's schedulers are checkable on the same terms as everything else, though `survey.py` cannot see them.

## CI

A third job, `options`, unguarded and **with no `schedule:` trigger** — AC4's schedule clause was struck at design review, and a pinned checker on a schedule can only repeat yesterday's verdict or exit 2 on a NuGet outage. `RELEASE_CHECKLIST.md` gains the pin-bump step, stating the trigger, because `versioncheck.py` and `optioncheck` are the same family with **opposite** triggers.

## Gates

Unmoved to the digit: link 150, pagelint 0/790/148, shape 147/12/widest 10 of 20, redirects 77/7858, versioncheck 0 stale of 18 across 5, `--verify` 147/147/147. `pagelint --changed` reaches **0 code blocks and says so** — the one page edited is a table, not a fence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0146UueHL6H3zGBGTYwz7GtL