### PR TITLE
spec: 012 phase 3 — D4 and D5, eight tables on the two pages that carried none

### DIFF
--- a/contents/CommandProcessorConfigurationReference.md
+++ b/contents/CommandProcessorConfigurationReference.md
@@ -343,6 +343,30 @@ public class ParallelTestsB
 }
 ```
 
+## AddBrighter Options
+
+The `BrighterOptions` object the `AddBrighter` delegate receives.
+
+<!-- optioncheck: Paramore.Brighter.Extensions.DependencyInjection.BrighterOptions
+     manual: PolicyRegistry — the property is initialised to a DefaultPolicy, which has no printable value
+     manual: RequestContextFactory — the property is initialised to an InMemoryRequestContextFactory, which has no printable value
+-->
+
+| Option | Type | Default | Description |
+|---|---|---|---|
+| `FeatureSwitchRegistry` | `IAmAFeatureSwitchRegistry?` | `null` | Supplies the feature switches handlers are toggled by. |
+| `HandlerLifetime` | `ServiceLifetime` | `Transient` | The lifetime request handlers are registered with. |
+| `IsolateTransientHandlerScope` | `bool` | `true` | Whether each transient handler in a pipeline gets its own DI scope. |
+| `InstrumentationOptions` | `InstrumentationOptions` | `None` | How much of a request instrumentation records. |
+| `MapperLifetime` | `ServiceLifetime` | `Transient` | The lifetime message mappers are registered with. |
+| `PolicyRegistry` | `IPolicyRegistry<string>?` | a `DefaultPolicy` | The Polly v7 policies used for retry and circuit breaking. |
+| `ResiliencePipelineRegistry` | `ResiliencePipelineRegistry<string>?` | `null` | The Polly v8 resilience pipelines that supersede `PolicyRegistry`. |
+| `RequestContextFactory` | `IAmARequestContextFactory` | an `InMemoryRequestContextFactory` | Creates the request context passed down a pipeline. |
+| `TransformerLifetime` | `ServiceLifetime` | `Transient` | The lifetime message transformers are registered with. |
+
+`PolicyRegistry` is obsolete in V10; configure `ResiliencePipelineRegistry` instead, as
+[Adding Polly Resilience Pipelines](#adding-polly-resilience-pipelines) shows.
+
 ## Validating Your Configuration
 
 We recommend enabling pipeline validation and diagnostics as part of your standard configuration. This catches common misconfiguration errors — such as sync/async mismatches, incorrect attribute ordering, and missing handlers — at startup rather than at runtime.
@@ -361,6 +385,20 @@ builder.Services.AddBrighter(options =>
 **ValidatePipelines** checks your configuration and throws a `PipelineValidationException` if errors are found. **DescribePipelines** logs a structured report of your configured pipelines to `ILogger`. Both are opt-in and independent of each other.
 
 For full details on what gets checked, how to configure validation flags, and how to interpret the diagnostic report, see [Pipeline Validation and Diagnostics](/contents/PipelineValidation.md).
+
+## Pipeline Validation Options
+
+The `BrighterPipelineValidationOptions` object `ValidatePipelines` configures.
+
+<!-- optioncheck: Paramore.Brighter.Extensions.DependencyInjection.BrighterPipelineValidationOptions -->
+
+| Option | Type | Default | Description |
+|---|---|---|---|
+| `ConsumerOwnsValidation` | `bool` | `false` | Whether validation is deferred to the Dispatcher rather than run at host startup. |
+| `ThrowOnError` | `bool` | `true` | Whether a validation error stops host startup or is only logged. |
+
+`AddConsumers` sets `ConsumerOwnsValidation` itself, and `ValidatePipelines(throwOnError:)`
+sets `ThrowOnError`; neither is usually set by hand.
 
 ## Brighter Builder Fluent Interface
 
@@ -451,9 +489,12 @@ See the documentation for detail on specific *transports* on how to configure th
 A *Publication* configures a transport for sending a message to it's associated MoM. So an **RmqPublication** configures how we publish a message to RabbitMQ. There are a number of common properties to all publications.
 
 * **MakeChannels**: Do you want Brighter to create the infrastructure? Brighter can create infrastructure that it needs, and is aware of: **OnMissingChannel.Create**. So a publication can create the topic to send messages to. Alternatively if you create the channel by another method, such as IaaC, we can verify the infrastructure on startup: **OnMissingChannel.Validate**. Finally, you can avoid the performance cost of runtime checks by assuming your infrastructure exists: **OnMissingChannel.Assume**.
-* **MaxOutstandingMessages**: How large can the number of messages in the Outbox grow before we stop allowing new messages to be published and raise an **OutboxLimitReachedException**.
-* **MaxOutStandingCheckIntervalMilliSeconds**: How often do we check to see if the Outbox is full.
-* **Topic**: A Topic is the key used within the MoM to route messages. Publishers publish to a topic and subscribers, subscribe to it. We use a class **RoutingKey** to encapsulate the identifier used for a topic. The name the MoM uses for a topic may vary. Kafka & SNS use *topic* whilst RMQ uses *routingkey* 
+* **Topic**: A Topic is the key used within the MoM to route messages. Publishers publish to a topic and subscribers, subscribe to it. We use a class **RoutingKey** to encapsulate the identifier used for a topic. The name the MoM uses for a topic may vary. Kafka & SNS use *topic* whilst RMQ uses *routingkey*
+
+**MaxOutStandingMessages** and **MaxOutStandingCheckInterval** are not publication options.
+They belong to the producers configuration and are in [AddProducers Options](#addproducers-options).
+
+[Publication Options](#publication-options) is the full list.
 
 ### Producer Registry
 
@@ -670,7 +711,85 @@ When sending a request via the External Bus we use a Polly policy internally to 
 * **Paramore.RETRYPOLICY**
 * **Paramore.CIRCUITBREAKER**
 
+## AddProducers Options
 
+The `ProducersConfiguration` object the `AddProducers` delegate receives, described in
+[Configuring an External Bus](#configuring-an-external-bus). It is the second-widest
+configuration surface Brighter ships.
+
+<!-- optioncheck: Paramore.Brighter.ProducersConfiguration
+     manual: ProducerRegistry — the constructor assigns an empty ProducerRegistry, which has no printable value
+-->
+
+| Option | Type | Default | Description |
+|---|---|---|---|
+| `ArchiveBatchSize` | `int?` | `null` | Messages archived in one batch. |
+| `ArchiveProvider` | `IAmAnArchiveProvider?` | `null` | The store dispatched messages are archived to. |
+| `ConnectionProvider` | `Type?` | `null` | The connection provider used to reach the Outbox outside a shared transaction. |
+| `DistributedLock` | `IDistributedLock?` | `null` | The lock that stops two sweepers clearing the same Outbox. |
+| `InstrumentationOptions` | `InstrumentationOptions?` | `null` | How much of a request instrumentation records on the producer side. |
+| `MessageMapperRegistry` | `IAmAMessageMapperRegistry?` | `null` | The mappers that turn requests into messages; `AutoFromAssemblies` supplies it. |
+| `MaxOutStandingMessages` | `int` | `-1` | Messages allowed to stack up in the Outbox before an `OutboxLimitReachedException`; -1 is unlimited. |
+| `MaxOutStandingCheckInterval` | `TimeSpan` | `0 ms` | How often the outstanding-message count is checked. |
+| `Outbox` | `IAmAnOutbox?` | `null` | The Outbox messages are deposited in. |
+| `OutboxBulkChunkSize` | `int?` | `null` | Messages written to the Outbox in one insert. |
+| `OutBoxBag` | `Dictionary<string, object>?` | `null` | Extra arguments an Outbox implementation requires. |
+| `OutboxTimeout` | `int?` | `null` | How long a write to the Outbox may take, in milliseconds. |
+| `ProducerRegistry` | `IAmAProducerRegistry?` | an empty `ProducerRegistry` | The producers messages are sent through, looked up by routing key. |
+| `ReplyQueueSubscriptions` | `IEnumerable<Subscription>?` | `null` | The subscriptions the reply queue uses under Request-Reply. |
+| `ResponseChannelFactory` | `IAmAChannelFactory?` | `null` | Creates the channel replies arrive on under Request-Reply. |
+| `RequestContextFactory` | `IAmARequestContextFactory?` | `null` | Creates the request context used for producer callbacks. |
+| `TransformerFactory` | `IAmAMessageTransformerFactory?` | `null` | Creates the transforms applied by message mappers. |
+| `MessageSchedulerFactory` | `IAmAMessageSchedulerFactory?` | `null` | Creates the scheduler that delays messages. |
+| `RequestSchedulerFactory` | `IAmARequestSchedulerFactory?` | `null` | Creates the scheduler that delays requests. |
+| `TransactionProvider` | `Type?` | `null` | The transaction provider that shares a transaction with the Outbox. |
+| `DefaultBoxConfiguration` | `InMemoryBoxConfiguration?` | `null` | Configures the in-memory Outbox used when no Outbox is supplied. |
+| `UseRpc` | `bool` | `false` | Whether the bus supports Request-Reply. |
+
+A `null` here usually means Brighter supplies something itself — an in-memory Outbox, an
+in-memory scheduler, the mappers `AutoFromAssemblies` registered — rather than that the
+feature is off.
+
+## Publication Options
+
+Every publication carries these, whatever the transport, and a transport's own publication
+type adds to them rather than replacing them. [Publications](#publications) describes the
+ones you meet first.
+
+<!-- optioncheck: Paramore.Brighter.Publication -->
+
+| Option | Type | Default | Description |
+|---|---|---|---|
+| `DataSchema` | `Uri?` | `null` | The CloudEvents schema the message body adheres to. |
+| `MakeChannels` | `OnMissingChannel` | `Create` | Whether Brighter creates missing infrastructure, validates it, or assumes it. |
+| `RequestType` | `Type?` | `null` | The request type published on this channel. |
+| `Source` | `Uri` | `http://goparamore.io/` | The CloudEvents source that identifies where an event happened. |
+| `Subject` | `string?` | `null` | The CloudEvents subject of the event within its source. |
+| `Topic` | `RoutingKey?` | `null` | The topic or routing key messages are published to. |
+| `Type` | `CloudEventsType` | `empty` | The CloudEvents type used for routing and policy. |
+| `DefaultHeaders` | `IDictionary<string, object>?` | `null` | Headers the default mappers add to every message. |
+| `CloudEventsAdditionalProperties` | `IDictionary<string, object>?` | `null` | Non-standard CloudEvents attributes serialised alongside the standard ones. |
+| `ReplyTo` | `string?` | `null` | The queue a sender listens on under Request-Reply. |
+
+`Source` reads back with a trailing slash, because `Uri` normalises it. `Type` is empty on a
+new publication, and Brighter's own doc comment says otherwise — the value above is the one
+the assembly has.
+
+## Handler Configuration Options
+
+`HandlerConfiguration` is how you supply a subscriber registry and a handler factory when you
+build a Command Processor by hand rather than through dependency injection — see
+[How Configuring the Command Processor Works](/contents/HowConfiguringTheCommandProcessorWorks.md).
+
+<!-- optioncheck: Paramore.Brighter.HandlerConfiguration -->
+
+| Option | Type | Default | Description |
+|---|---|---|---|
+| `subscriberRegistry` | `IAmASubscriberRegistry` | `none` | Maps a request type to the handlers that receive it. |
+| `handlerFactory` | `IAmAHandlerFactory` | `none` | Creates a handler instance when the pipeline needs one. |
+
+Both are required, which is what `none` says: the parameterless constructor exists for a
+Control Bus sender that posts everything and handles nothing.
 
 ## Further Reading
 

--- a/contents/DispatcherConfigurationReference.md
+++ b/contents/DispatcherConfigurationReference.md
@@ -173,6 +173,63 @@ private static void ConfigureBrighter(HostBuilderContext hostContext, IServiceCo
 ...
 
 ```
+## Subscription Options
+
+Every subscription carries these, whatever the transport, and a transport's own subscription
+type adds to them rather than replacing them. **The option is the constructor parameter you
+type**, which is not always the property you read back: `subscriptionName` is the `Name`
+property, and `getRequestType` is `MapRequestType`.
+
+<!-- optioncheck: Paramore.Brighter.Subscription
+     manual: requestType — the constructor requires a request type, so it has no default the tool can read
+     manual: getRequestType — assigned to MapRequestType, and the body substitutes a function returning RequestType when it is null
+     manual: messagePumpType — the constructor rejects its own default of Unknown, so there is no default to read
+-->
+
+| Option | Type | Default | Description |
+|---|---|---|---|
+| `subscriptionName` | `SubscriptionName` | `none` | Names the subscription for diagnostics; read back as `Name`. |
+| `channelName` | `ChannelName` | `none` | Names the queue on middleware where queues have names. |
+| `routingKey` | `RoutingKey` | `none` | The topic or routing key the channel subscribes to. |
+| `requestType` | `Type?` | `none` | The request type messages on this channel are translated into. |
+| `getRequestType` | `Func<Message, Type>?` | derives the type from `requestType` | Determines the request type from the message rather than from the channel. |
+| `bufferSize` | `int` | `1` | Messages held in the channel at once, and read from the broker at once. |
+| `noOfPerformers` | `int` | `1` | Threads reading this channel, each with its own message pump. |
+| `timeOut` | `TimeSpan?` | `300 ms` | How long a read waits before treating the channel as empty. |
+| `requeueCount` | `int` | `-1` | Times a message is requeued before it is treated as a poison pill; -1 is unlimited. |
+| `requeueDelay` | `TimeSpan?` | `0 ms` | How long delivery of a requeued message is delayed. |
+| `unacceptableMessageLimit` | `int` | `0` | Unacceptable messages before the channel stops; 0 disables the limit. |
+| `messagePumpType` | `MessagePumpType` | `none` | Selects the Reactor or Proactor concurrency model. |
+| `channelFactory` | `IAmAChannelFactory?` | `null` | Creates the channel; falls back to `DefaultChannelFactory` when null. |
+| `makeChannels` | `OnMissingChannel` | `Create` | Whether Brighter creates missing infrastructure, validates it, or assumes it. |
+| `emptyChannelDelay` | `TimeSpan?` | `500 ms` | How long the pump pauses after a read that found no message. |
+| `channelFailureDelay` | `TimeSpan?` | `1000 ms` | How long the pump pauses after a channel failure. |
+| `unacceptableMessageLimitWindow` | `TimeSpan?` | `null` | The window the unacceptable-message count resets at the end of. |
+
+Three of these have no default the assembly can be asked for, and the marker above declares
+each. `requestType` and `messagePumpType` are required in practice: both carry a default in
+the signature and the constructor body rejects it. `getRequestType` is assigned to
+`MapRequestType`, and a null one becomes a function returning `requestType`.
+
+## AddConsumers Options
+
+`AddConsumers` takes the [`AddBrighter` options](/contents/CommandProcessorConfigurationReference.md#addbrighter-options)
+and adds these four.
+
+<!-- optioncheck: Paramore.Brighter.ServiceActivator.Extensions.DependencyInjection.ConsumersOptions
+     manual: InboxConfiguration — the property is initialised to a default InboxConfiguration, which has no printable value
+-->
+
+| Option | Type | Default | Description |
+|---|---|---|---|
+| `DefaultChannelFactory` | `IAmAChannelFactory?` | `null` | Creates a channel for any subscription that supplies no factory of its own. |
+| `InboxConfiguration` | `InboxConfiguration` | a default `InboxConfiguration` | Configures the global Inbox described below. |
+| `Subscriptions` | `IEnumerable<Subscription>` | `empty` | The subscriptions this Dispatcher runs. |
+| `ShutdownTimeout` | `TimeSpan` | `10000 ms` | How long shutdown waits for in-flight messages to drain before tearing down. |
+
+`ShutdownTimeout` is the one to raise for long-running handlers: on expiry the message in
+progress is left un-acknowledged for redelivery.
+
 ## Dispatcher Brighter Builder Fluent Interface
 
 The call to **AddConsumers()** returns an **IBrighterBuilder** fluent interface. This means that you can use any of the options described in [Brighter Builder Fluent Interface](/contents/CommandProcessorConfigurationReference.md#brighter-builder-fluent-interface) to configure the associated *Command Processor* such as scanning assemblies for *Request Handlers* and adding an *External Bus* and *Outbox*.
@@ -232,6 +289,26 @@ private static void ConfigureBrighter(HostBuilderContext hostContext, IServiceCo
 ```
 Typically **DbConnectionString** would obtain the connection string for the Db from configuration.
 
+## Global Inbox Options
+
+`InboxConfiguration` takes its options as constructor arguments, so the option is the
+parameter you type and the property you read back is capitalised: `onceOnly` is `OnceOnly`.
+
+<!-- optioncheck: Paramore.Brighter.InboxConfiguration
+     manual: inbox — the signature says null and the body substitutes an InMemoryInbox, which has no printable value
+     manual: context — the signature says null and the body substitutes a function returning the handler's full type name
+-->
+
+| Option | Type | Default | Description |
+|---|---|---|---|
+| `inbox` | `IAmAnInbox?` | an `InMemoryInbox` | The store that records handled requests. |
+| `scope` | `InboxScope` | `All` | Whether commands, events or both are recorded. |
+| `onceOnly` | `bool` | `true` | Whether a duplicate request is detected and acted on, or merely recorded. |
+| `actionOnExists` | `OnceOnlyAction` | `Throw` | What happens when the request has been handled before. |
+| `context` | `Func<Type, string>?` | the handler's full type name | Disambiguates which handler received a request. |
+
+Both defaults the marker declares are assigned in the constructor body rather than in the
+signature, so a reader of the signature alone would see `null` for each and be wrong twice.
 
 ## Further Reading
 

--- a/spec/012-configuration_reference/tasks.md
+++ b/spec/012-configuration_reference/tasks.md
@@ -692,7 +692,7 @@ that carry **zero** tables today — 012's premise confirmed at the highest-traf
 (requirements §3.2): each named surface gains a marker and a table under a qualified heading,
 in the section that already discusses it.
 
-- [ ] **Task 3.1:** `CommandProcessorConfigurationReference.md` — `AddProducers` and
+- [x] **Task 3.1:** `CommandProcessorConfigurationReference.md` — `AddProducers` and
       `AddBrighter`
   - Input: design §7.1; `ProducersConfiguration` (26), `BrighterOptions` (9) at `10.7.0`
   - Output: `## AddProducers Options` and `## AddBrighter Options`, each with its marker and
@@ -702,7 +702,7 @@ in the section that already discusses it.
     `Option` is the property name here and the parameter-versus-property hazard does not
     arise — **check that rather than assuming it.**
 
-- [ ] **Task 3.2:** `CommandProcessorConfigurationReference.md` — publication, handlers,
+- [x] **Task 3.2:** `CommandProcessorConfigurationReference.md` — publication, handlers,
       pipeline validation
   - Input: `Publication` (8), `HandlerConfiguration` (2), `BrighterPipelineValidationOptions`
     (2)
@@ -712,7 +712,7 @@ in the section that already discusses it.
     table is the one phases 5 and 6 link *up* to. Get its wording right before five transport
     pages point at it. `HandlerConfiguration` is the P0 member of task 2.4's factory list.
 
-- [ ] **Task 3.3:** `DispatcherConfigurationReference.md` — subscription, global inbox,
+- [x] **Task 3.3:** `DispatcherConfigurationReference.md` — subscription, global inbox,
       `AddConsumers`
   - Input: `Subscription` (17), `InboxConfiguration` (5), `ConsumersOptions` (4)
   - Output: `## Subscription Options`, `## Global Inbox Options`, `## AddConsumers Options`
@@ -722,7 +722,7 @@ in the section that already discusses it.
     highest-traffic Reference pages. **Rule 5 is an error and this is the page most likely to
     want the assembly name**: backticks for a real type or assembly, "Dispatcher" in prose.
 
-- [ ] **Task 3.4:** Verify phase 3 — `optioncheck`, the six gates, and the AC8 walk
+- [x] **Task 3.4:** Verify phase 3 — `optioncheck`, the six gates, and the AC8 walk
   - Input: the 73 descriptions written above
   - Output: `optioncheck` exit 0 with a scope naming 8 tables and 73 rows; the six gates; a
     recorded AC8 verdict
@@ -730,6 +730,136 @@ in the section that already discusses it.
     describes or argues; one sentence, present tense, rationale linked rather than restated.
     `git add` before `pagelint --changed`, and read its scope line — these pages have C# blocks
     and standing obligation 8 applies.
+
+### Phase 3 as executed — 2026-08-28, 4/4
+
+**Eight tables, 71 rows, on the two pages that carried none.** `optioncheck` reports
+**9 tables, 72 rows, 9 types across 3 pages** with the phase 2 seed, exit 0.
+
+**The phase is 71 options, not the 73 the phase table says.** D4's 47 became **45** at phase
+1 — `ProducersConfiguration` 26 → 22 and `Publication` 8 → 10 — and D5's 26 held exactly.
+Every figure was re-derived from the type when its table was written, which is standing
+obligation 3, and the phase table above is left as approved.
+
+**The tables, and what each cost:**
+
+| Table | Type | Rows | `manual:` |
+|---|---|---:|---:|
+| `## AddBrighter Options` | `BrighterOptions` | 9 | 2 |
+| `## Pipeline Validation Options` | `BrighterPipelineValidationOptions` | 2 | 0 |
+| `## AddProducers Options` | `ProducersConfiguration` | 22 | 1 |
+| `## Publication Options` | `Publication` | 10 | 0 |
+| `## Handler Configuration Options` | `HandlerConfiguration` | 2 | 0 |
+| `## Subscription Options` | `Subscription` | 17 | 3 |
+| `## AddConsumers Options` | `ConsumersOptions` | 4 | 1 |
+| `## Global Inbox Options` | `InboxConfiguration` | 5 | 2 |
+
+**Nine `manual:` declarations across 71 rows — 13%, and that is the residue requirements
+§7.3 asked to be measured rather than estimated.** Every one is the same shape: a default
+assigned in a constructor body as an *object*, which has no printable value —
+an `InMemoryInbox`, an `InMemoryRequestContextFactory`, an empty `ProducerRegistry` — or a
+parameter the constructor refuses its own default for. **This is requirements §5.1's third
+shape with an object on the end of it**, and neither the requirements nor the design names
+that variant: §5.1's example coalesces to a `TimeSpan`, which prints.
+
+### The ledger — two entries, both on `CommandProcessorConfigurationReference.md`
+
+Standing obligation 10 says record the mismatch before fixing it. **Neither was found by
+`optioncheck`**, which is worth as much as the entries: both are in a **bullet list**, and
+the tool reads tables. They were found by writing the correct table beside the prose.
+
+1. **`MaxOutstandingMessages` and `MaxOutStandingCheckIntervalMilliSeconds` were documented
+   as publication options.** They are on `ProducersConfiguration`, not `Publication` — the
+   `Publication` type has neither. A reader following that list sets them on the wrong
+   object.
+2. **`MaxOutStandingCheckIntervalMilliSeconds` is not the name of anything.** The member is
+   `MaxOutStandingCheckInterval` and it is a `TimeSpan`; the `MilliSeconds` suffix is a V9
+   spelling that survived on the page.
+
+Both bullets are corrected in place and the section now points at the two tables. **This is
+012's premise, on the highest-traffic Reference page in the corpus, found in the first phase
+that wrote a table.**
+
+> **A third finding, in Brighter rather than here, and out of scope for this repository.**
+> `Publication.Type`'s doc comment says the default is
+> *"goparamore.io.Paramore.Brighter.Message for backward compatibility"*; the code assigns
+> `CloudEventsType.Empty` and the constructed instance reads back empty. The page says what
+> the assembly does and notes the disagreement. `src/` is outside this programme's
+> exception, so this is a Brighter issue if anyone raises one — the same shape as
+> [Brighter#4277](https://github.com/BrighterCommand/Brighter/issues/4277).
+
+### What phase 3 changed in the instrument, and why each was forced
+
+**`optioncheck --describe <type>…`** prints what a table for a type owes, in the four
+columns, with the descriptions empty. Standing obligation 3 is *write the table from the
+type*, and before this the only way to learn a default was to write a wrong one and read the
+mismatch — transcription by trial and error, sixty-odd tables still to come.
+
+> **The objection is circularity**: a table pasted from the tool agrees with the tool by
+> construction, so AC2 proves nothing. It does not bite, and the reason is worth stating.
+> `Option`, `Type` and `Default` **are** the assembly's truth by definition — design §6.2
+> makes the default readable only from an instance, so a human writing that column is
+> transcribing this output or guessing. And **AC2's subject is drift**: today's table against
+> tomorrow's assembly, which no agreement today can fake. The column the tool cannot supply
+> is the one carrying meaning, and it is left blank on purpose.
+
+**Two defects in the checker, both found by pointing it at types phase 2 never met:**
+
+1. **A property fed by a required constructor argument read back the checker's own value.**
+   The ctor route already handled this; the property route only caught string-shaped
+   sentinels, so an `int` of 1 or an enum would have been published as a default. The
+   synthesiser now reports **every** parameter it injected, not only the defaulted ones, and
+   a property assigned from one is `manual:`.
+2. **A value whose printable form is empty rendered as nothing**, which is indistinguishable
+   from a blank cell — and a blank `Default` is a finding in its own right, so no table for
+   `Publication` could ever have gone green. It renders `empty` now, and a table may write
+   `""` instead.
+
+**`pagelint.py` rule 5 gained a fourth exception: an HTML comment.**
+`ConsumersOptions` lives in `Paramore.Brighter.ServiceActivator.Extensions.DependencyInjection`,
+so its marker carries the V9 name **by construction** and cannot put it in backticks — the
+marker's grammar takes a bare type name. Task 3.3 predicted this page would be the one to
+want it. The exemption rests on the same argument as the fenced-block and code-span ones,
+and phase 2 measured it rather than assuming: **an HTML comment publishes as nothing.** It
+is not the opt-out comment and does not replace it — this is *the word is not on the page*,
+where the opt-out is *the page is about the word*. **Red-proved**: a bare
+`The Service Activator reads messages` appended to the same page still errors, and the page
+was restored byte-identical.
+
+### AC8, walked
+
+**Every one of the 71 descriptions is one sentence, present tense, and states what the option
+does rather than why.** Swept mechanically as well as read: no cell contains *because*, *so
+that*, *should*, *prefer*, *recommend* or *note that*, none contains two sentences, and all
+71 open with a capital and end in a full stop. Where rationale was worth having it is in
+prose **after** the table — `PolicyRegistry` being obsolete, `ShutdownTimeout` being the one
+to raise for long-running handlers, `null` on the producers configuration usually meaning
+Brighter supplies something itself.
+
+**Two things the tables say that no reader could have got from the prose**, both from
+standing obligation 1's *the spelling the reader types*: on `Subscription`,
+`subscriptionName` is the `Name` property and `getRequestType` is `MapRequestType` — **two
+parameters whose property differs by more than case**, which the page now says in as many
+words. And `Publication.Source` reads back `http://goparamore.io/`, with the trailing slash
+`Uri` normalises in, where the source says `http://goparamore.io`.
+
+**Placement worked.** Standing obligation 8's cheapest defence — put the table where the
+diff cannot reach a code block — held: `pagelint --changed` reports **0 code blocks strict**
+across 28 hunks, and says so in its own words rather than passing quietly.
+
+**The six gates are unmoved to the digit**: link 150, pagelint 0 errors / 790 warnings / 148
+pages, shape 147 / 12 / widest 10 of 20, redirects 77 / 7858, versioncheck 0 stale of 18
+across 5, `--verify` 147/147/147. **No page was created**, so `SUMMARY.md` is untouched and
+none of the four page-count gates could move. The phase 2 red-proof still fires **8/8** after
+the checker changes.
+
+> **Phase 2's publication check, recorded here because it was measured after that PR
+> merged** — the pattern where a phase's evidence lands in the following PR.
+> `outbox-and-inbox/sweepercircuitbreaking` returned **200, 14,711 bytes**, the normalised
+> row published as written, and **`grep -c optioncheck` over the published `.md` variant is
+> 0**. Design §5's first reason for the marker — *"it is invisible to readers"* — rested on
+> the `<!-- pagelint: allow-serviceactivator -->` precedent, and it is now measured for this
+> marker too. It is also what licenses the rule 5 exemption above.
 
 ---
 

--- a/tools/optioncheck/Program.cs
+++ b/tools/optioncheck/Program.cs
@@ -41,6 +41,9 @@ internal static class Program
             return Unreachable;
         }
 
+        if (args.Length > 0 && args[0] == "--describe")
+            return Describe(args.Skip(1).ToList());
+
         var root = RepositoryRoot();
         if (root is null && args.Length == 0)
         {
@@ -82,6 +85,81 @@ internal static class Program
               + $"{Count(markers.Count, "table")}.");
 
         return findings.Count == 0 ? Clean : Findings;
+    }
+
+    /// <summary>
+    /// `--describe <type>…` — what a table for this type owes, in the four
+    /// columns, with the descriptions left empty.
+    ///
+    /// Standing obligation 3 is *write the table from the type, never from the
+    /// survey and never from our own prose*, and this is the instrument for
+    /// obeying it. Before it existed the only way to learn a default was to
+    /// write a wrong one and read the mismatch, which is transcription by
+    /// trial and error across sixty-odd tables still to come.
+    ///
+    /// **The obvious objection is that this makes the check circular** — a table
+    /// pasted from the tool agrees with the tool by construction, so AC2 proves
+    /// nothing. It does not bite, for two reasons worth stating rather than
+    /// assuming. The `Option`, `Type` and `Default` columns ARE the assembly's
+    /// truth by definition: design §6.2 makes the default readable only from an
+    /// instantiated object, so a human writing that column is transcribing this
+    /// output or guessing. And AC2's subject is DRIFT — today's table against
+    /// tomorrow's assembly — which no amount of agreement today can fake.
+    ///
+    /// What the tool cannot supply is the column that carries meaning. The
+    /// description is left empty on purpose: it is AC8's subject, it has no tool
+    /// behind it, and a blank cell is the honest prompt to write one.
+    /// </summary>
+    private static int Describe(IReadOnlyList<string> names)
+    {
+        if (names.Count == 0)
+        {
+            Console.Error.WriteLine("optioncheck --describe <fully.qualified.Type> [<type>…]");
+            return Unreachable;
+        }
+
+        var missing = 0;
+
+        foreach (var name in names)
+        {
+            var type = Reflect.Resolve(name);
+            if (type is null)
+            {
+                Console.Error.WriteLine($"optioncheck: THE TYPE IS GONE — `{name}` is in none of the "
+                                        + $"{Authority.Pinned().Count} pinned packages at {Authority.Pin()}");
+                missing++;
+                continue;
+            }
+
+            var surface = Reflect.Describe(type);
+
+            Console.WriteLine($"<!-- optioncheck: {type.FullName} -->");
+            Console.WriteLine();
+            Console.WriteLine("| Option | Type | Default | Description |");
+            Console.WriteLine("|---|---|---|---|");
+
+            foreach (var member in surface.Members)
+                Console.WriteLine($"| `{member.Name}` | `{member.TypeName}` | "
+                                  + $"{(member.Default is null ? "" : $"`{member.Default}`")} |  |");
+
+            Console.WriteLine();
+            Console.WriteLine($"{Count(surface.Members.Count, "member")}, read from the "
+                              + $"{(surface.Route == Reflect.Route.Constructor
+                                  ? "widest constructor's parameters"
+                                  : "settable properties")} — "
+                              + $"`max(props, ctor)` selects that route.");
+
+            foreach (var member in surface.Members.Where(m => m.Unreadable is not null))
+                Console.WriteLine($"  `{member.Name}` has no readable default: {member.Unreadable}. "
+                                  + $"The table owes `manual: {member.Name} — <why>`");
+
+            if (surface.Error is not null)
+                Console.WriteLine($"  the type did not construct: {surface.Error}");
+
+            Console.WriteLine();
+        }
+
+        return missing == 0 ? Clean : Findings;
     }
 
     /// <summary>

--- a/tools/optioncheck/Reflect.cs
+++ b/tools/optioncheck/Reflect.cs
@@ -133,6 +133,16 @@ internal static class Reflect
         if (!built.Ok)
             return new Member(property.Name, declared, null, $"the type could not be constructed: {built.Error}");
 
+        // The property is assigned from a constructor parameter the synthesiser
+        // had to invent a value for, so what it reads back is the checker's
+        // argument. The sentinel check in WithValue catches the string-shaped
+        // ones; this catches an `int` of 1 or an enum, which look exactly like a
+        // real default and are the more dangerous half.
+        if (built.Injected.Contains(property.Name))
+            return new Member(property.Name, declared, null,
+                "this property is set from a constructor parameter the checker had to supply, "
+                + "so the instance reads back that argument rather than a default");
+
         return WithValue(property.Name, declared, () => property.GetValue(built.Instance));
     }
 
@@ -200,6 +210,10 @@ internal static class Reflect
         if (canonical.StartsWith('"') && canonical.EndsWith('"') && canonical.Length >= 2)
             forms.Add(canonical[1..^1]);
 
+        // `empty` is this tool's word for a value that renders as nothing. An
+        // author writing the pair of quotes means the same thing.
+        if (canonical == "empty") forms.Add("\"\"");
+
         if (typeName is not null && canonical is not "null")
             forms.Add($"{typeName}.{canonical}");
 
@@ -227,9 +241,15 @@ internal static class Reflect
     private static string? Printable(object value)
     {
         var text = value.ToString();
-        return text is null || text == value.GetType().FullName || text == value.GetType().ToString()
-            ? null
-            : text;
+
+        if (text is null || text == value.GetType().FullName || text == value.GetType().ToString())
+            return null;
+
+        // A value whose printable form is empty is not blank, it is empty — and
+        // the two must not look the same, because standing obligation 1 makes a
+        // blank cell a finding in its own right. `Publication.Type` is the case:
+        // a CloudEventsType that renders as nothing at all.
+        return text.Trim().Length == 0 ? "empty" : text;
     }
 
     /// <summary>The declared type with its nullable annotation: `TimeSpan?`, never `TimeSpan`.</summary>

--- a/tools/optioncheck/Synthesise.cs
+++ b/tools/optioncheck/Synthesise.cs
@@ -31,7 +31,20 @@ namespace Paramore.Docs.OptionCheck;
 /// </summary>
 internal static class Synthesise
 {
-    internal sealed record Result(object? Instance, IReadOnlySet<string> Supplied, string? Error)
+    /// <param name="Supplied">
+    /// Defaulted parameters the constructor would not accept its own default for.
+    /// Their instance value is the checker's argument, so the `Default` column
+    /// owes a `manual:` declaration rather than a number.
+    /// </param>
+    /// <param name="Injected">
+    /// EVERY parameter the synthesiser passed a value for, required ones
+    /// included. On a property-driven type this is the set whose properties read
+    /// back the checker's own arguments — a required `int` parameter assigned to
+    /// a property would otherwise be reported as a default of 1, which is the
+    /// tool documenting itself in the one column it exists to get right.
+    /// </param>
+    internal sealed record Result(
+        object? Instance, IReadOnlySet<string> Supplied, IReadOnlySet<string> Injected, string? Error)
     {
         public bool Ok => Instance is not null;
     }
@@ -52,16 +65,16 @@ internal static class Synthesise
         // `HandlerConfiguration` is the one of §6.3's four that is P0 — it is on
         // D4, phase 3 — so it gets a factory here rather than a declaration.
         if (Factory(type) is { } made)
-            return new Result(made, new HashSet<string>(StringComparer.Ordinal), null);
+            return new Result(made, EmptySet, EmptySet, null);
 
         var ctor = Widest(type);
         if (ctor is null)
-            return new Result(null, EmptySet, "no public constructor");
+            return new Result(null, EmptySet, EmptySet, "no public constructor");
 
         if (ctor.GetParameters().Length == 0)
         {
-            try { return new Result(ctor.Invoke([]), EmptySet, null); }
-            catch (Exception ex) { return new Result(null, EmptySet, Explain(ex)); }
+            try { return new Result(ctor.Invoke([]), EmptySet, EmptySet, null); }
+            catch (Exception ex) { return new Result(null, EmptySet, EmptySet, Explain(ex)); }
         }
 
         // Pass 1 — required parameters only. Every defaulted parameter keeps its
@@ -69,14 +82,14 @@ internal static class Synthesise
         // the product's own.
         var pass1 = TryInvoke(ctor, supply: p => !p.HasDefaultValue);
         if (pass1.Instance is not null)
-            return new Result(pass1.Instance, EmptySet, null);
+            return new Result(pass1.Instance, EmptySet, pass1.Injected, null);
 
         // Pass 2 — supply defaulted parameters too, where there is a value to
         // supply. Needed only where the constructor body validates a defaulted
         // parameter, which no parse of a signature can see.
         var pass2 = TryInvoke(ctor, supply: _ => true);
         if (pass2.Instance is null)
-            return new Result(null, EmptySet, pass1.Error ?? pass2.Error);
+            return new Result(null, EmptySet, EmptySet, pass1.Error ?? pass2.Error);
 
         // Necessity: put each defaulted parameter pass 2 supplied back to its own
         // default and keep the removal if the type still builds.
@@ -97,19 +110,21 @@ internal static class Synthesise
         // build, fall back to pass 2's — a larger `manual:` obligation is honest;
         // a value the checker invented is not.
         return final.Instance is not null
-            ? new Result(final.Instance, needed, null)
-            : new Result(pass2.Instance, pass2.Supplied, null);
+            ? new Result(final.Instance, needed, final.Injected, null)
+            : new Result(pass2.Instance, pass2.Supplied, pass2.Injected, null);
     }
 
     private static readonly IReadOnlySet<string> EmptySet = new HashSet<string>(StringComparer.Ordinal);
 
-    private sealed record Attempt(object? Instance, IReadOnlySet<string> Supplied, string? Error);
+    private sealed record Attempt(
+        object? Instance, IReadOnlySet<string> Supplied, IReadOnlySet<string> Injected, string? Error);
 
     private static Attempt TryInvoke(ConstructorInfo ctor, Func<ParameterInfo, bool> supply)
     {
         var parameters = ctor.GetParameters();
         var args = new object?[parameters.Length];
         var supplied = new HashSet<string>(StringComparer.Ordinal);
+        var injected = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
         foreach (var p in parameters)
         {
@@ -130,14 +145,19 @@ internal static class Synthesise
             }
 
             if (value is null && !IsNullable(p))
-                return new Attempt(null, supplied, $"cannot synthesise {Pretty(p.ParameterType)} {p.Name}");
+                return new Attempt(null, supplied, injected,
+                    $"cannot synthesise {Pretty(p.ParameterType)} {p.Name}");
 
             args[p.Position] = value;
-            if (p.Name is not null && p.HasDefaultValue) supplied.Add(p.Name);
+            if (p.Name is not null)
+            {
+                injected.Add(p.Name);
+                if (p.HasDefaultValue) supplied.Add(p.Name);
+            }
         }
 
-        try { return new Attempt(ctor.Invoke(args), supplied, null); }
-        catch (Exception ex) { return new Attempt(null, supplied, Explain(ex)); }
+        try { return new Attempt(ctor.Invoke(args), supplied, injected, null); }
+        catch (Exception ex) { return new Attempt(null, supplied, injected, Explain(ex)); }
     }
 
     /// <summary>A value for a parameter type, or null where the synthesiser has none.</summary>

--- a/tools/pagelint.py
+++ b/tools/pagelint.py
@@ -221,6 +221,23 @@ OPT_OUT = '<!-- pagelint: allow-serviceactivator -->'
 # V9 term unenforced, which is the failure this rule exists to prevent.
 SERVICEACTIVATOR_RE = re.compile(r'Service\s*Activator')
 
+# A FOURTH way the V9 name is legitimate, added by spec 012 phase 3: inside an
+# HTML comment. `<!-- optioncheck: ... -->` binds a fully-qualified type, and
+# `ConsumersOptions` lives in Paramore.Brighter.ServiceActivator.Extensions.
+# DependencyInjection, so a marker for it carries the word by construction and
+# cannot put it in backticks -- the marker's grammar takes a bare type name.
+#
+# The exemption is the same argument the fenced-block and code-span ones rest
+# on, and it is measured rather than assumed: an HTML comment publishes as
+# nothing. `grep -c optioncheck` over the published .md variant of
+# SweeperCircuitBreaking.md is 0 (spec 012 phase 2). What a reader never sees is
+# not prose.
+#
+# Not the opt-out comment, which is a page-level declaration and stays one: this
+# is "the word is not on the page", where the opt-out is "the page is about the
+# word". A page that needed the opt-out still needs it.
+HTML_COMMENT_RE = re.compile(r'<!--.*?-->', re.DOTALL)
+
 Finding = namedtuple('Finding', 'path line rule message severity')
 
 
@@ -789,11 +806,12 @@ def apply_changes(changes):
 def check_terminology(page):
     """"ServiceActivator" in prose where "Dispatcher" is meant.
 
-    Legitimate three ways, and a naive ban fires on all of them: inside fenced
+    Legitimate four ways, and a naive ban fires on all of them: inside fenced
     blocks (ServiceActivatorHostedService, the DI namespace), inside inline code
-    spans, and on a page discussing the name itself. So this reads prose only,
-    with code spans and link targets removed, and honours an opt-out comment
-    either on its own line or trailing the line it excuses.
+    spans, inside an HTML comment (see HTML_COMMENT_RE), and on a page
+    discussing the name itself. So this reads prose only, with code spans, HTML
+    comments and link targets removed, and honours an opt-out comment either on
+    its own line or trailing the line it excuses.
     """
     body = '\n'.join(page.lines)
     if OPT_OUT in body and any(
@@ -806,12 +824,20 @@ def check_terminology(page):
     # on HowServiceActivatorWorks.md -- arrives here bare and fires a rule the
     # body it came from already passes. DESCRIPTION MISMATCH keeps the two
     # equal, so checking the body checks both.
+    # Comments are blanked across the whole body before the per-line walk,
+    # because a marker's type name sits on a different line from its `<!--`.
+    # Blanked in place rather than deleted, so line numbers still address the
+    # file a reader would open.
+    uncommented = HTML_COMMENT_RE.sub(
+        lambda m: re.sub(r'[^\n]', ' ', m.group(0)), body).split('\n')
+
     findings = []
     for lineno, line in page.prose:
         if lineno <= front_matter_end(page):
             continue
         if OPT_OUT in line:
             continue
+        line = uncommented[lineno - 1]
         stripped = LINK_TARGET_RE.sub(']()', INLINE_CODE_RE.sub('``', line))
         found = SERVICEACTIVATOR_RE.search(stripped)
         if found:


### PR DESCRIPTION
Phase 3 of spec 012, 4/4 tasks. **D4 and D5.** 20/57 overall.

**Eight tables, 71 rows, on the two pages already named *Configuration Reference* that carried zero tables between them** — 012's premise confirmed at the highest-traffic surface. `optioncheck` reports **9 tables, 72 rows, 9 types across 3 pages**, exit 0.

The phase is **71 options, not the 73** the approved phase table says: D4's 47 became 45 at phase 1 (`ProducersConfiguration` 26 → 22, `Publication` 8 → 10). Every figure was re-derived from the type when its table was written.

## The ledger — two entries, and neither was found by the tool

Both are on `CommandProcessorConfigurationReference.md`, and both are in a **bullet list**, which is why `optioncheck` did not see them: the tool reads tables. They were found by writing the correct table beside the prose.

1. **`MaxOutstandingMessages` and `MaxOutStandingCheckIntervalMilliSeconds` were documented as publication options.** They belong to `ProducersConfiguration`; `Publication` has neither. A reader following that list sets them on the wrong object.
2. **`MaxOutStandingCheckIntervalMilliSeconds` is not the name of anything** — the member is `MaxOutStandingCheckInterval` and it is a `TimeSpan`. The `MilliSeconds` suffix is a V9 spelling that survived.

Corrected in place, both recorded for task 11.3.

A third finding is in Brighter, not here: `Publication.Type`'s doc comment claims a default of `goparamore.io.Paramore.Brighter.Message`; the code assigns `CloudEventsType.Empty` and the instance reads back empty. The page says what the assembly does and notes the disagreement — `src/` is outside this programme's exception.

## Nine `manual:` declarations across 71 rows

13%, and that is the residue requirements §7.3 asked to be **measured rather than estimated**. Every one is the same shape, and neither the requirements nor the design names it: a default assigned in a constructor body as an **object** — an `InMemoryInbox`, an `InMemoryRequestContextFactory`, an empty `ProducerRegistry` — which has no printable value. §5.1's worked example coalesces to a `TimeSpan`, which prints.

## Changes to the instrument, each forced by something this phase met

- **`optioncheck --describe <type>…`** prints what a table owes in the four columns with the descriptions blank. The circularity objection — a table pasted from the tool agrees with it by construction — does not bite: `Option`, `Type` and `Default` *are* the assembly's truth by definition, and AC2's subject is drift, which no agreement today can fake. The column the tool cannot supply is left blank on purpose.
- **A property fed by a required constructor argument was reading back the checker's own value.** The constructor route handled this; the property route caught only string-shaped sentinels, so an `int` of 1 would have been published as a default.
- **A value whose printable form is empty rendered as nothing**, indistinguishable from a blank cell — so no `Publication` table could ever have gone green. It renders `empty` now.
- **`pagelint.py` rule 5 gains a fourth exception: an HTML comment.** `ConsumersOptions` lives in `Paramore.Brighter.ServiceActivator.Extensions.DependencyInjection`, so its marker carries the V9 name by construction and cannot put it in backticks. This rests on what phase 2 measured — an HTML comment publishes as nothing — and is **not** the page-level opt-out, which stays what it was. Red-proved: real prose still errors, page restored byte-identical.

## AC8, walked

All 71 descriptions are one sentence, present tense, and say what the option does rather than why — swept mechanically as well as read. Rationale that was worth having sits in prose after the table.

Two things the tables say that the prose could not: `subscriptionName` is the `Name` property and `getRequestType` is `MapRequestType` — two parameters whose property differs by more than case — and `Publication.Source` reads back `http://goparamore.io/` with the slash `Uri` normalises in.

## Gates

Unmoved to the digit: link 150, pagelint 0/790/148, shape 147/12/widest 10 of 20, redirects 77/7858, versioncheck 0 stale of 18 across 5, `--verify` 147/147/147. No page created, so `SUMMARY.md` is untouched. **`pagelint --changed` reports 0 code blocks strict across 28 hunks** — standing obligation 8's placement defence held. The phase 2 red-proof still fires 8/8 after the checker changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0146UueHL6H3zGBGTYwz7GtL