### PR TITLE
012 ledger: six published examples set a publication property that does not exist

### DIFF
--- a/contents/BrighterBasicConfiguration.md
+++ b/contents/BrighterBasicConfiguration.md
@@ -54,6 +54,15 @@ each is documented on that same reference page.
 Putting all this together, a typical configuration might looks as follows:
 
 ``` csharp
+using System;
+using Microsoft.Extensions.DependencyInjection;
+using Paramore.Brighter;
+using Paramore.Brighter.Extensions.DependencyInjection;
+using Paramore.Brighter.MessagingGateway.RMQ.Async;
+using Paramore.Brighter.MySql;
+using Paramore.Brighter.Outbox.Hosting;
+using Paramore.Brighter.Outbox.MySql;
+
 public void ConfigureServices(IServiceCollection services)
 {
 
@@ -82,12 +91,14 @@ public void ConfigureServices(IServiceCollection services)
                     new RmqPublication
                 {
                     Topic = new RoutingKey("GreetingMade"),
-                    MaxOutStandingMessages = 5,
-                    MaxOutStandingCheckIntervalMilliSeconds = 500,
                     WaitForConfirmsTimeOutInMilliseconds = 1000,
                     MakeChannels = OnMissingChannel.Create
                 }}
             ).Create();
+
+           // Outbox thresholds are producers configuration, not publication
+           configure.MaxOutStandingMessages = 5;
+           configure.MaxOutStandingCheckInterval = TimeSpan.FromMilliseconds(500);
            configure.Outbox = new MySqlOutbox(outboxConfiguration);
            configure.TransactionProvider = typeof(MySqlEntityFrameworkConnectionProvider<GreetingsEntityGateway>);
            configure.ConnectionProvider = typeof(MySqlConnectionProvider);

--- a/contents/CommandProcessorConfigurationReference.md
+++ b/contents/CommandProcessorConfigurationReference.md
@@ -521,8 +521,6 @@ var producerRegistry = new RmqProducerRegistryFactory(
         new RmqPublication
         {
             Topic = new RoutingKey("GreetingMade"),
-            MaxOutStandingMessages = 5,
-            MaxOutStandingCheckIntervalMilliSeconds = 500,
             WaitForConfirmsTimeOutInMilliseconds = 1000,
             MakeChannels = OnMissingChannel.Create
         }
@@ -552,12 +550,14 @@ public void ConfigureServices(IServiceCollection services)
                     new RmqPublication
                 {
                     Topic = new RoutingKey("GreetingMade"),
-                    MaxOutStandingMessages = 5,
-                    MaxOutStandingCheckIntervalMilliSeconds = 500,
                     WaitForConfirmsTimeOutInMilliseconds = 1000,
                     MakeChannels = OnMissingChannel.Create
                 }}
             ).Create();
+
+            // Outbox thresholds are producers configuration, not publication
+            configure.MaxOutStandingMessages = 5;
+            configure.MaxOutStandingCheckInterval = TimeSpan.FromMilliseconds(500);
         })
         .AutoFromAssemblies()
 

--- a/contents/RabbitMQConfiguration.md
+++ b/contents/RabbitMQConfiguration.md
@@ -106,6 +106,12 @@ Missing a confirm will cause the *Outbox Sweeper* to resend a message, as it wil
 The following code creates a *Publication* for RabbitMQ when configuring an *External Bus*
 
 ``` csharp
+using System;
+using Microsoft.Extensions.DependencyInjection;
+using Paramore.Brighter;
+using Paramore.Brighter.Extensions.DependencyInjection;
+using Paramore.Brighter.MessagingGateway.RMQ.Async;
+
 public void ConfigureServices(IServiceCollection services)
 {
     services.AddBrighter(...)
@@ -119,12 +125,14 @@ public void ConfigureServices(IServiceCollection services)
                     new RmqPublication
                 {
                     Topic = new RoutingKey("GreetingMade"),
-                    MaxOutStandingMessages = 5,
-                    MaxOutStandingCheckIntervalMilliSeconds = 500,
                     WaitForConfirmsTimeOutInMilliseconds = 1000,
                     MakeChannels = OnMissingChannel.Create
                 }}
             ).Create();
+
+            // Outbox thresholds are producers configuration, not publication
+            configure.MaxOutStandingMessages = 5;
+            configure.MaxOutStandingCheckInterval = TimeSpan.FromMilliseconds(500);
 }
 ```
 
@@ -133,6 +141,12 @@ public void ConfigureServices(IServiceCollection services)
 Our combined code for the *Connection*  with a single *Publication* looks like this
 
 ``` csharp
+using System;
+using Microsoft.Extensions.DependencyInjection;
+using Paramore.Brighter;
+using Paramore.Brighter.Extensions.DependencyInjection;
+using Paramore.Brighter.MessagingGateway.RMQ.Async;
+
 public void ConfigureServices(IServiceCollection services)
 {
     services.AddBrighter(...)
@@ -148,12 +162,14 @@ public void ConfigureServices(IServiceCollection services)
                     new RmqPublication
                 {
                     Topic = new RoutingKey("GreetingMade"),
-                    MaxOutStandingMessages = 5,
-                    MaxOutStandingCheckIntervalMilliSeconds = 500,
                     WaitForConfirmsTimeOutInMilliseconds = 1000,
                     MakeChannels = OnMissingChannel.Create
                 }}
             ).Create();
+
+            // Outbox thresholds are producers configuration, not publication
+            configure.MaxOutStandingMessages = 5;
+            configure.MaxOutStandingCheckInterval = TimeSpan.FromMilliseconds(500);
         }
 }
 ```
@@ -282,13 +298,15 @@ services.AddBrighter(...)
                 new RmqPublication
                 {
                     Topic = new RoutingKey("GreetingMade"),
-                    MaxOutStandingMessages = 5,
-                    MaxOutStandingCheckIntervalMilliSeconds = 500,
                     WaitForConfirmsTimeOutInMilliseconds = 1000,
                     MakeChannels = OnMissingChannel.Create
                 }
             }
         ).Create();
+
+        // Outbox thresholds are producers configuration, not publication
+        configure.MaxOutStandingMessages = 5;
+        configure.MaxOutStandingCheckInterval = TimeSpan.FromMilliseconds(500);
     });
 
 // Consumer Configuration

--- a/spec/012-configuration_reference/tasks.md
+++ b/spec/012-configuration_reference/tasks.md
@@ -861,6 +861,42 @@ the checker changes.
 > the `<!-- pagelint: allow-serviceactivator -->` precedent, and it is now measured for this
 > marker too. It is also what licenses the rule 5 exemption above.
 
+### The ledger — a third entry, and it does not compile
+
+**Found after phase 3 merged**, by reading the two pages as published rather than as
+written — which is the check `--verify` exists to prompt. Recorded here because task 11.3
+aggregates this section, and fixed in its own PR because it is a correction to code rather
+than a table.
+
+**Six code examples across three published pages set two properties on an `RmqPublication`
+that `RmqPublication` does not have.** `MaxOutStandingMessages` and
+`MaxOutStandingCheckIntervalMilliSeconds` belong to `ProducersConfiguration` — the second
+under a name it has not had since V9, and as a `TimeSpan` rather than an `int` of
+milliseconds. The pages are `BrighterBasicConfiguration.md` (**the page the whole corpus
+links to as the one path that works**), `RabbitMQConfiguration.md` (three of the six) and
+`CommandProcessorConfigurationReference.md` (two).
+
+**Proved with the compiler, not with reflection**, which is 009's method and the reason it
+is worth keeping: the block pasted verbatim into a project referencing the pinned packages
+fails with **`CS0117` twice** — *'RmqPublication' does not contain a definition for
+'MaxOutStandingMessages'* and *…for 'MaxOutStandingCheckIntervalMilliSeconds'*. The
+corrected form — the two settings moved onto `configure`, with
+`MaxOutStandingCheckInterval` taking a `TimeSpan` — builds clean.
+
+**A second defect fell out of compiling the corrected block**, and no reflection pass would
+have found it: `BrighterBasicConfiguration.md`'s example calls `UseOutboxSweeper()`, which
+lives in `Paramore.Brighter.Outbox.Hosting` — a package and namespace the page never names.
+`CS1061` until that `using` is added. Rule 6 turning strict on the three blocks this edit
+touched is what forced them to carry `using` directives at all, so **the defect was found by
+a convention, not by looking for it**; the repo-wide debt goes 790 → **787** as a result.
+
+**Why `optioncheck` did not catch any of this, and should not be changed to:** it reads
+tables. A code block is prose to it. The instrument for a code block is the compiler, and
+009's standing lesson is to *extract the page's own fences into a project and build them*
+rather than diffing after the fact. **All three ledger entries so far were found by a human
+writing a table beside prose that was already there** — which is what requirements §11 means
+by *transcribing existing documentation propagates whatever drift is already there*.
+
 ---
 
 ## Phase 4 — D15, the relational reference page (Docs PR)


### PR DESCRIPTION
A drift-ledger correction found by reading phase 3's pages **as published**. Not a phase — one defect, one PR.

## The defect

Six code examples across three published pages set two properties on an `RmqPublication`:

```csharp
new RmqPublication
{
    Topic = new RoutingKey("GreetingMade"),
    MaxOutStandingMessages = 5,                      // not on a publication
    MaxOutStandingCheckIntervalMilliSeconds = 500,   // not the name of anything since V9
    WaitForConfirmsTimeOutInMilliseconds = 1000,
    MakeChannels = OnMissingChannel.Create
}
```

Both belong to `ProducersConfiguration`, and the second under a name it has not had since V9 — the member is `MaxOutStandingCheckInterval` and it is a **`TimeSpan`**, not an `int` of milliseconds.

**Proved with the compiler, not by reflection.** Pasted verbatim into a project referencing the pinned packages:

```text
error CS0117: 'RmqPublication' does not contain a definition for 'MaxOutStandingMessages'
error CS0117: 'RmqPublication' does not contain a definition for 'MaxOutStandingCheckIntervalMilliSeconds'
```

The corrected form — both settings moved onto `configure`, with a `TimeSpan` — builds clean.

## Where

- `BrighterBasicConfiguration.md` — **the page the whole corpus links to as the one path that works**
- `RabbitMQConfiguration.md` — three of the six
- `CommandProcessorConfigurationReference.md` — two

## A second defect, found by compiling the correction

`BrighterBasicConfiguration.md`'s example calls `UseOutboxSweeper()`, which lives in `Paramore.Brighter.Outbox.Hosting` — a package and namespace the page never names. `CS1061` until the `using` is added.

**Rule 6 turning strict on the three blocks this edit touched is what forced them to carry `using` directives at all**, so the defect was found by a convention rather than by looking for it. The repo-wide using-directive debt goes **790 → 787**.

## Why `optioncheck` did not catch this, and should not be changed to

It reads tables; a code block is prose to it. The instrument for a code block is the compiler, and 009's standing lesson is to extract the page's own fences into a project and build them. All three ledger entries so far were found by a human writing a correct table beside prose that was already there — which is what requirements §11 means by *transcribing existing documentation propagates whatever drift is already there*.

## Gates

link 150, pagelint **0 errors / 787 warnings** / 148 pages, shape 147/12/widest 10 of 20, redirects 77/7858, versioncheck 0 stale of 18 across 5, optioncheck 0 mismatches across 9 tables and 72 rows. `pagelint --changed`: **5 code blocks strict, 0 errors** — not a vacuous run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0146UueHL6H3zGBGTYwz7GtL