### PR TITLE
spec: 012 phase 4 — D15, the relational options documented once

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -34,6 +34,7 @@
 * [Basic Configuration](/contents/BrighterBasicConfiguration.md)
   * [Command Processor Configuration Reference](/contents/CommandProcessorConfigurationReference.md)
   * [Dispatcher Configuration Reference](/contents/DispatcherConfigurationReference.md)
+  * [Relational Database Configuration Reference](/contents/RelationalDatabaseConfigurationReference.md)
 * [InMemory Options for Development and Testing](/contents/InMemoryOptions.md)
 * [Test Double Options for Command Processor](/contents/TestDoubleOptions.md)
 * [Analyzer Support](/contents/AnalyzerSupport.md)

--- a/contents/RelationalDatabaseConfigurationReference.md
+++ b/contents/RelationalDatabaseConfigurationReference.md
@@ -1,0 +1,112 @@
+---
+description: "RelationalDatabaseConfiguration is the one type that configures every relational Outbox, Inbox, provisioner and queue-table transport Brighter ships."
+layout:
+  description:
+    visible: false
+---
+
+# Relational Database Configuration Reference
+
+> **Reference** · Applies to **Brighter V10** · Prerequisites: [Basic Configuration](/contents/BrighterBasicConfiguration.md)
+
+`RelationalDatabaseConfiguration` is the one type that configures every relational Outbox,
+Inbox, provisioner and queue-table transport Brighter ships. Seventeen components take it,
+and none of them adds an option of its own.
+
+That is why this page exists. A table repeated on seventeen pages is seventeen chances for
+one of them to be wrong, and the wrong one is indistinguishable from the right ones to a
+reader who only opens the page for the store they are using.
+
+## Relational Database Configuration Options
+
+The options are constructor parameters, so **the option is the parameter you type**; the
+property you read back is the same word capitalised.
+
+<!-- optioncheck: Paramore.Brighter.RelationalDatabaseConfiguration -->
+
+| Option | Type | Default | Description |
+|---|---|---|---|
+| `connectionString` | `string` | `none` | Connects to the database, in the provider's own format. |
+| `databaseName` | `string?` | `"Brighter"` | Names the database holding the tables. |
+| `outBoxTableName` | `string?` | `"Outbox"` | Names the Outbox table. |
+| `inboxTableName` | `string?` | `"Inbox"` | Names the Inbox table; the property is `InBoxTableName`. |
+| `queueStoreTable` | `string?` | `"Queue"` | Names the queue table the MSSQL and PostgreSQL transports read. |
+| `schemaName` | `string?` | `null` | Qualifies the tables with a schema; the provider's own default applies when null. |
+| `binaryMessagePayload` | `bool` | `false` | Stores the message body as bytes rather than as UTF-8 text. |
+| `jsonMessagePayload` | `bool` | `false` | Stores the message body in the database's native JSON type. |
+
+Only `connectionString` is required. The three table names default to `Outbox`, `Inbox` and
+`Queue`, so a component that uses one of them needs no configuration beyond the connection.
+
+`binaryMessagePayload` and `jsonMessagePayload` change the column the payload is written to,
+so **changing either against an existing table is a migration, not a setting**. See
+[Database Provisioning](/contents/BoxProvisioning.md).
+
+## Which Components Take the Relational Configuration
+
+Seventeen, across four families, measured at `10.7.0` by looking for
+`IAmARelationalDatabaseConfiguration` in each package.
+
+| Family | Provider | Page |
+|---|---|---|
+| Outbox | MSSQL | [MSSQL Outbox](/contents/MSSQLOutbox.md) |
+| Outbox | MySQL | [MySQL Outbox](/contents/MySQLOutbox.md) |
+| Outbox | PostgreSQL | [PostgreSQL Outbox](/contents/PostgresOutbox.md) |
+| Outbox | SQLite | [SQLite Outbox](/contents/SqliteOutbox.md) |
+| Outbox | Spanner | not yet documented |
+| Inbox | MSSQL | [MSSQL Inbox](/contents/MSSQLInbox.md) |
+| Inbox | MySQL | [MySQL Inbox](/contents/MySQLInbox.md) |
+| Inbox | PostgreSQL | [PostgreSQL Inbox](/contents/PostgresInbox.md) |
+| Inbox | SQLite | [SQLite Inbox](/contents/SqliteInbox.md) |
+| Inbox | Spanner | not yet documented |
+| Box provisioning | MSSQL, MySQL, PostgreSQL, SQLite, Spanner | [Configuring Box Provisioning](/contents/BoxProvisioningConfiguration.md) |
+| Transport | PostgreSQL | [PostgreSQL Message Broker](/contents/PostgreSQLMessageBroker.md) |
+| Transport | MSSQL | not yet documented |
+
+**The two transports are the entries to know about.** A queue-table transport is not an
+Outbox, and it is easy to assume the relational configuration reaches only the box packages —
+it does not. `queueStoreTable` exists for those two and for nothing else.
+
+## Registering the Relational Configuration
+
+The components that take this type do not resolve it from the container by themselves:
+Brighter's provisioning and sweeper hosted services do. So it is registered **once**, as a
+singleton against the interface, and passed **explicitly** to each component that needs it.
+
+```csharp
+using Microsoft.Extensions.DependencyInjection;
+using Paramore.Brighter;
+using Paramore.Brighter.Extensions.DependencyInjection;
+using Paramore.Brighter.Outbox.PostgreSql;
+using Paramore.Brighter.PostgreSql;
+
+public void ConfigureServices(IServiceCollection services)
+{
+    var configuration = new RelationalDatabaseConfiguration(
+        connectionString: DbConnectionString(),
+        outBoxTableName: "Outbox");
+
+    // Registered once, against the interface: this is what the provisioner reads
+    services.AddSingleton<IAmARelationalDatabaseConfiguration>(configuration);
+
+    services.AddBrighter()
+        .AddProducers(configure =>
+        {
+            // ... your producer registry
+            configure.Outbox = new PostgreSqlOutbox(configuration);   // passed explicitly too
+            configure.ConnectionProvider = typeof(PostgreSqlConnectionProvider);
+        })
+        .AutoFromAssemblies();
+}
+```
+
+Passing the same object twice — once to the container and once to the component — is the
+shape every relational page shows, and [PostgreSQL Outbox](/contents/PostgresOutbox.md) shows
+it in full.
+
+## Further Reading
+
+- [Basic Configuration](/contents/BrighterBasicConfiguration.md) — where the registration above fits in a whole application
+- [Command Processor Configuration Reference](/contents/CommandProcessorConfigurationReference.md) — the producers configuration that takes the Outbox this type configures
+- [Database Provisioning](/contents/BoxProvisioning.md) — who creates the tables these options name
+- [Outbox Support](/contents/BrighterOutboxSupport.md) — why a relational Outbox is worth the table

--- a/spec/011-authoring_conventions/pagetypes.tsv
+++ b/spec/011-authoring_conventions/pagetypes.tsv
@@ -146,3 +146,4 @@ contents/TutorialFirstMessage.md	Tutorial	high	"spec 009 D2, rung 2; tutorial by
 contents/TutorialDurableOutbox.md	Tutorial	high	"spec 009 D3, rung 3; tutorial by construction — one path, numbered steps, measured happy-path and failure-path runs"	Tutorial	Brighter V10
 contents/GetStarted.md	Tutorial	medium	"spec 009 D10, the ladder's landing page; not itself a build, but the entry point to the three tutorials and typed with them"	Tutorial	Brighter V10
 contents/TutorialStreamingWithKafka.md	Tutorial	high	"spec 009 D8, rung 4; tutorial by construction — one path, numbered steps, measured single-consumer and rebalanced two-consumer runs"	Tutorial	Brighter V10
+contents/RelationalDatabaseConfigurationReference.md	Reference	high	"spec 012 D15, the relational options documented once for seventeen components; consulted, not read through"	Reference	Brighter V10

--- a/spec/012-configuration_reference/tasks.md
+++ b/spec/012-configuration_reference/tasks.md
@@ -910,7 +910,7 @@ and each failed — `BrighterOutboxSupport.md` and `BrighterInboxSupport.md` are
 `BrighterBasicConfiguration.md` is **How-to**, and `PostgresOutbox.md` privileges one of five
 providers (design §8.4).
 
-- [ ] **Task 4.1:** Write `contents/RelationalDatabaseConfigurationReference.md`
+- [x] **Task 4.1:** Write `contents/RelationalDatabaseConfigurationReference.md`
   - Input: design §8.4's outline; `RelationalDatabaseConfiguration` (8 options); §7.3's
     seventeen components across four families
   - Output: the page — banner, opening sentence, front matter, four sections:
@@ -927,7 +927,7 @@ providers (design §8.4).
     and are not this page's argument to make. Budget ~140 lines — a prose budget, not a
     prediction.
 
-- [ ] **Task 4.2:** Land the entry, the row, and the checks
+- [x] **Task 4.2:** Land the entry, the row, and the checks
   - Input: design §9.1's first diff
   - Output: the `SUMMARY.md` entry **nested under *Basic Configuration*** beside the two
     Reference pages it joins; a `pagetypes.tsv` row; the six gates and `optioncheck`
@@ -935,6 +935,44 @@ providers (design §8.4).
     and the entry text is what reaches `/llms.txt` — write it equal to the H1. Expect link,
     pagelint, shape and (after publication) `--verify` each to move by one, and
     **`--check-redirects` not to move at all**; assert that rather than assuming it.
+
+### Phase 4 as executed — 2026-08-28, 2/2
+
+**`contents/RelationalDatabaseConfigurationReference.md` exists — 112 lines, the first page
+012 creates**, and with it the first `SUMMARY.md` entry, the first `pagetypes.tsv` row, and
+the first movement in the page-count gates this spec has caused.
+
+**The eight options are eight, and the type is constructor-driven** — `optioncheck` selects
+the constructor route, so the option is the parameter and the property is the same word
+capitalised. One member is worth the note the page gives it: `inboxTableName` reads back as
+**`InBoxTableName`**, with a capital B in the middle.
+
+**Only `connectionString` has no default.** The three table names default to `Outbox`,
+`Inbox` and `Queue`, which is why thirteen pages can link this table and say nothing further.
+
+**Two of the seventeen rows have no link, deliberately.** `SpannerOutbox.md`,
+`SpannerInbox.md` and `MSSQLMessageBroker.md` do not exist yet — they are phases 7, 7 and 6 —
+and a link to a page that does not exist is `linkcheck.py` MISSING FILE. They read *not yet
+documented*. **Phases 6 and 7 owe the link back**, which is 009's *link down the ladder,
+never up* arriving in a different spec: the page that exists last is the page that adds the
+link.
+
+**The gates moved exactly as task 4.2 predicted, and the one that did not move is the
+result:** link 150 → **151**, pagelint 148 → **149 pages**, shape 147 → **148**, and
+`--check-redirects` **did not move** — 77 entries, 7,858 bytes — because slugs are
+filename-derived and adding to a section moves no URL. That is §2.1's claim holding for a
+**sixth** time, asserted rather than assumed. `--verify` moves to 148 once GitBook publishes.
+
+**The using-directive debt did not move either**, and that is also a result: the page's one
+C# block carries its five `using` directives, so a new page added **nothing** to the 787.
+`pagelint --changed` reached **1 code block strict, 0 errors** — a real strict run, not a
+vacuous one.
+
+**The block was compiled, not eyeballed** — requirements §11's obligation for the ten new
+pages, and 009's method. Pasted into a project referencing
+`Paramore.Brighter.Extensions.DependencyInjection`, `Outbox.PostgreSql` and `PostgreSql` at
+`10.7.0`: **build succeeded**, which is what says `PostgreSqlOutbox` and
+`PostgreSqlConnectionProvider` are spelled the way the page spells them.
 
 ---
 


### PR DESCRIPTION
Phase 4 of spec 012, 2/2 tasks. **D15.** 22/57 overall.

**`contents/RelationalDatabaseConfigurationReference.md`, 112 lines — the first page 012 creates**, and with it the first `SUMMARY.md` entry, the first `pagetypes.tsv` row, and the first movement this spec has caused in the page-count gates.

## Why a page rather than a host

`RelationalDatabaseConfiguration` is taken by **seventeen components across four families** and none of them adds an option of its own. A table repeated seventeen times is seventeen chances for one of them to be wrong — and the wrong one is indistinguishable from the right ones to a reader who only opens the page for the store they use. Every candidate host failed on mode discipline (design §8.4): the two Support pages are *Explanation*, Basic Configuration is *How-to*, and `PostgresOutbox.md` privileges one of five providers.

## What the table says

Constructor-driven, so **the option is the parameter you type** and the property is the same word capitalised — except `inboxTableName`, which reads back as **`InBoxTableName`**, with a capital B in the middle.

**Only `connectionString` has no default.** The three table names default to `Outbox`, `Inbox` and `Queue`, which is why thirteen pages can link this table and say nothing further.

**The two transports are the entries to know about**: a queue-table transport is not an Outbox, and `queueStoreTable` exists for MSSQL and PostgreSQL and for nothing else.

## Two rows carry no link, deliberately

`SpannerOutbox.md`, `SpannerInbox.md` and `MSSQLMessageBroker.md` do not exist until phases 7 and 6, and a link to a page that does not exist is `linkcheck.py` MISSING FILE. They read *not yet documented*, and **the later phases owe the link back** — 009's *link down the ladder, never up*, arriving in a different spec.

## Gates

Moved exactly as task 4.2 predicted: link 150 → **151**, pagelint 148 → **149 pages**, shape 147 → **148**. `--verify` moves to 148 once GitBook publishes.

**`--check-redirects` did not move** — 77 entries, 7,858 bytes — because slugs are filename-derived and adding to a section moves no URL. §2.1's claim holding for a **sixth** time, asserted rather than assumed.

**The using-directive debt did not move either**, and that is a result too: the page's one C# block carries its five `using` directives, so a new page added **nothing** to the 787. `pagelint --changed` reached **1 code block strict, 0 errors** — a real strict run.

`optioncheck`: **0 mismatches across 10 tables and 80 rows**.

**The block was compiled, not eyeballed** — requirements §11's obligation for the ten new pages. Pasted into a project referencing the pinned packages: build succeeded, which is what says `PostgreSqlOutbox` and `PostgreSqlConnectionProvider` are spelled the way the page spells them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0146UueHL6H3zGBGTYwz7GtL