### PR TITLE
spec: 012 phase 5 — D6, the five documented transports

### DIFF
--- a/contents/AWSSQSConfiguration.md
+++ b/contents/AWSSQSConfiguration.md
@@ -59,6 +59,40 @@ For more on a *Publication* see the material on an *Add Producers* in [Command P
 
 Brighter's **Routing Key** represents the [SNS Topic Name](https://docs.aws.amazon.com/sns/latest/api/API_CreateTopic.html) or [SQS Queue Name](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_CreateQueue.html).
 
+### SNS Publication Options
+
+`SnsPublication` publishes to an SNS topic. It adds these three to the
+[base publication options](/contents/CommandProcessorConfigurationReference.md#publication-options),
+which it inherits.
+
+<!-- optioncheck: Paramore.Brighter.MessagingGateway.AWSSQS.SnsPublication -->
+
+| Option | Type | Default | Description |
+|---|---|---|---|
+| `FindTopicBy` | `TopicFindBy` | `Convention` | How Brighter resolves the topic from the routing key. |
+| `TopicAttributes` | `SnsAttributes?` | `null` | The attributes of the SNS topic Brighter creates. |
+| `TopicArn` | `string?` | `null` | The topic ARN, used when `FindTopicBy` is `Arn`. |
+
+### SQS Publication Options
+
+`SqsPublication` publishes to an SQS queue directly, with no SNS topic in front of it. It
+takes a channel name as a constructor argument and the rest as properties.
+
+<!-- optioncheck: Paramore.Brighter.MessagingGateway.AWSSQS.SqsPublication
+     manual: ChannelName — the constructor requires a channel name and rejects an empty one, so there is no default to read
+     manual: QueueAttributes — the property is initialised to SqsAttributes.Empty, which has no printable value
+-->
+
+| Option | Type | Default | Description |
+|---|---|---|---|
+| `ChannelName` | `ChannelName?` | `none` | Names the SQS queue this publication writes to. |
+| `ChannelType` | `ChannelType` | `PointToPoint` | Whether the publication writes to a queue or to a topic. |
+| `FindQueueBy` | `QueueFindBy` | `Name` | Whether `ChannelName` is read as a queue name or as a queue URL. |
+| `QueueAttributes` | `SqsAttributes` | `SqsAttributes.Empty` | The attributes of the SQS queue Brighter creates. |
+
+`ChannelName` is a constructor argument rather than a property with a default: the
+constructor throws when it is empty, so a publication always names its queue.
+
 ### Finding and Creating Topics
 
 Depending on the option you choose for how we handle required messaging infrastructure (Create, Validate, Assume), we will need to determine if a **Topic** already exists, when we want to create it if missing, or validate it. 
@@ -352,6 +386,58 @@ var subscriptions = new Subscription[]
     )
 };
 ```
+
+### SQS Subscription Options
+
+`SqsSubscription` takes its options as constructor arguments, so the option is the parameter
+you type. The seventeen it shares with
+[`Subscription`](/contents/DispatcherConfigurationReference.md#subscription-options) behave
+the same way here; the other seven are AWS's own.
+
+<!-- optioncheck: Paramore.Brighter.MessagingGateway.AWSSQS.SqsSubscription
+     manual: requestType — the constructor rejects its own default, so there is no default to read
+     manual: getRequestType — assigned to MapRequestType, and the body substitutes a function returning RequestType when it is null
+     manual: messagePumpType — the constructor rejects its own default of Unknown, so there is no default to read
+     manual: queueAttributes — the body substitutes SqsAttributes.Empty, which has no printable value
+     manual: topicAttributes — the body substitutes SnsAttributes.Empty, which has no printable value
+-->
+
+| Option | Type | Default | Description |
+|---|---|---|---|
+| `subscriptionName` | `SubscriptionName` | `none` | Names the subscription for diagnostics; read back as `Name`. |
+| `channelName` | `ChannelName` | `none` | Names the SQS queue this subscription reads. |
+| `channelType` | `ChannelType` | `none` | Whether the subscription reads a queue directly or through an SNS topic. |
+| `routingKey` | `RoutingKey` | `none` | The SNS topic the queue subscribes to. |
+| `requestType` | `Type?` | `none` | The request type messages on this queue are translated into. |
+| `getRequestType` | `Func<Message, Type>?` | derives the type from `requestType` | Determines the request type from the message rather than from the queue. |
+| `bufferSize` | `int` | `1` | Messages read from the queue at once and held in the channel. |
+| `noOfPerformers` | `int` | `1` | Threads reading this queue, each with its own message pump. |
+| `timeOut` | `TimeSpan?` | `300 ms` | How long a read waits before treating the queue as empty. |
+| `requeueCount` | `int` | `-1` | Times a message is requeued before it is treated as a poison pill; -1 is unlimited. |
+| `requeueDelay` | `TimeSpan?` | `0 ms` | How long delivery of a requeued message is delayed. |
+| `unacceptableMessageLimit` | `int` | `0` | Unacceptable messages before the channel stops; 0 disables the limit. |
+| `unacceptableMessageLimitWindow` | `TimeSpan?` | `null` | The window the unacceptable-message count resets at the end of. |
+| `messagePumpType` | `MessagePumpType` | `none` | Selects the Reactor or Proactor concurrency model. |
+| `channelFactory` | `IAmAChannelFactory?` | `null` | Creates the channel; falls back to `DefaultChannelFactory` when null. |
+| `emptyChannelDelay` | `TimeSpan?` | `500 ms` | How long the pump pauses after a read that found no message. |
+| `channelFailureDelay` | `TimeSpan?` | `1000 ms` | How long the pump pauses after a channel failure. |
+| `findTopicBy` | `TopicFindBy` | `Convention` | How Brighter resolves the SNS topic from the routing key. |
+| `findQueueBy` | `QueueFindBy` | `Name` | Whether `channelName` is read as a queue name or as a queue URL. |
+| `queueAttributes` | `SqsAttributes?` | `SqsAttributes.Empty` | The attributes of the SQS queue Brighter creates. |
+| `topicAttributes` | `SnsAttributes?` | `SnsAttributes.Empty` | The attributes of the SNS topic Brighter creates. |
+| `deadLetterRoutingKey` | `RoutingKey?` | `null` | The topic messages are dead-lettered to. |
+| `invalidMessageRoutingKey` | `RoutingKey?` | `null` | The topic unacceptable messages are routed to. |
+| `makeChannels` | `OnMissingChannel` | `Create` | Whether Brighter creates the queue and topic, validates them, or assumes them. |
+
+`channelType` has no default on this constructor: every subscription states whether it is
+point-to-point or publish-subscribe. `queueAttributes` and `topicAttributes` default to the
+empty attribute sets, whose members are listed under
+[SQS attributes](#sqs-attributes) and [SNS Attributes](#sns-attributes).
+
+The generic form `SqsSubscription<T>`, which every example below uses, takes the same options
+and supplies five defaults the table cannot: `requestType` is `T`, `subscriptionName`,
+`channelName` and `routingKey` are `T`'s full name, `channelType` is `PubSub`, and
+`messagePumpType` is `Proactor`.
 
 ### Ack and Nack
 

--- a/contents/AzureServiceBusConfiguration.md
+++ b/contents/AzureServiceBusConfiguration.md
@@ -27,9 +27,28 @@ The connection to ASB id defined by an **IServiceBusClientProvider**, Brighter p
 
 In Brighter's implementation of the Messaging Gateway *Publications* and *Subscriptions* have their own Individual configuration.
 
+## Azure Service Bus Connection Options
+
+`AzureServiceBusConfiguration` is what the producer and consumer factories take when you
+supply a connection string rather than a client provider. It takes both options as
+constructor arguments, so the option is the parameter you type.
+
+<!-- optioncheck: Paramore.Brighter.MessagingGateway.AzureServiceBus.AzureServiceBusConfiguration -->
+
+| Option | Type | Default | Description |
+|---|---|---|---|
+| `connectionString` | `string` | `none` | The connection string the client authenticates and connects with. |
+| `bulkSendBatchSize` | `int` | `10` | Messages sent in one transmission when the producer sends more than one. |
+
+Both are read back capitalised — `ConnectionString` and `BulkSendBatchSize` — and both are
+get-only, so they are set once at construction.
+
 ## Azure Service Bus Publication
 
-No custom properties are supported for ASB
+`AzureServiceBusPublication` adds no properties to the
+[base publication options](/contents/CommandProcessorConfigurationReference.md#publication-options).
+It does add one public *field*, `UseServiceBusQueue`, which defaults to `false` and sends to a
+Service Bus queue instead of a topic.
 
 Basic Brighter configutarion publications is as follows
 
@@ -58,20 +77,77 @@ For more on a *Publication* see the material on an *Add Producers* in [Command P
 
 For more on a *Subscription* see the material on configuring the *Dispatcher* in [Basic Configuration](/contents/BrighterBasicConfiguration.md#configuring-the-dispatcher).
 
-When 
+A subscription has two configuration surfaces: `AzureServiceBusSubscription`, which is the
+Brighter subscription, and `AzureServiceBusSubscriptionConfiguration`, which describes the
+Service Bus entity and is passed to the subscription as `subscriptionConfiguration`.
 
-We support a number of ASB specific *Subscription* options:
+## Azure Service Bus Entity Options
 
-* **MaxDeliveryCount**: The Maximum amount of times that a Message can be delivered before it is dead Lettered. This differs from **requeue count** as this is used by the transport in the event of lock expiry (in the event of process failure or processing taking too long) **default:** 5
+`AzureServiceBusSubscriptionConfiguration` takes its options as properties, so the option is
+the property you set.
 
-* **DeadLetteringOnMessageExpiration**: Dead letter a message when it expires **default:** true
+<!-- optioncheck: Paramore.Brighter.MessagingGateway.AzureServiceBus.AzureServiceBusSubscriptionConfiguration -->
 
-* **LockDuration**: How long message locks are held for **default:** true
+| Option | Type | Default | Description |
+|---|---|---|---|
+| `MaxDeliveryCount` | `int` | `5` | Deliveries the transport attempts before dead-lettering a message. |
+| `DeadLetteringOnMessageExpiration` | `bool` | `true` | Whether an expired message is dead-lettered rather than dropped. |
+| `LockDuration` | `TimeSpan` | `60000 ms` | How long a message lock is held while a handler runs. |
+| `DefaultMessageTimeToLive` | `TimeSpan` | `259200000 ms` | How long a message sits on the entity before it expires. |
+| `QueueIdleBeforeDelete` | `TimeSpan` | `TimeSpan.MaxValue` | How long a queue is idle before Service Bus deletes it. |
+| `RequireSession` | `bool` | `false` | Whether the subscription is session-enabled. |
 
-* **DefaultMessageTimeToLive**: How long messages sit in the queue before they expire **default:** 1 minute
+`MaxDeliveryCount` is the transport's own count and is not Brighter's `requeueCount`: it fires
+on lock expiry, which is what a slow or crashed handler looks like to Service Bus.
+`LockDuration` is one minute and `DefaultMessageTimeToLive` is three days.
 
-* **SqlFilter**: A Sql Filter to apply to the *subscription* see [Topic Filters](https://docs.microsoft.com/en-us/azure/service-bus-messaging/topic-filters) **default:** none
+**Two further options are public fields rather than properties**, so they are not on the table
+above: `SqlFilter` (default `""`), a [Topic Filter](https://docs.microsoft.com/en-us/azure/service-bus-messaging/topic-filters)
+applied to the subscription, and `UseServiceBusQueue` (default `false`), which reads a Service
+Bus queue instead of a topic subscription.
 
+## Azure Service Bus Subscription Options
+
+`AzureServiceBusSubscription` takes its options as constructor arguments, so the option is the
+parameter you type. The seventeen it shares with
+[`Subscription`](/contents/DispatcherConfigurationReference.md#subscription-options) behave the
+same way here; `subscriptionConfiguration` is the one it adds.
+
+<!-- optioncheck: Paramore.Brighter.MessagingGateway.AzureServiceBus.AzureServiceBusSubscription
+     manual: requestType — the constructor rejects its own default, so there is no default to read
+     manual: getRequestType — assigned to MapRequestType, and the body substitutes a function returning RequestType when it is null
+     manual: messagePumpType — the constructor rejects its own default of Unknown, so there is no default to read
+     manual: subscriptionConfiguration — read back as Configuration, and the body substitutes a default AzureServiceBusSubscriptionConfiguration when it is null
+-->
+
+| Option | Type | Default | Description |
+|---|---|---|---|
+| `subscriptionName` | `SubscriptionName` | `none` | Names the subscription for diagnostics; read back as `Name`. |
+| `channelName` | `ChannelName` | `none` | Names the Service Bus subscription or queue this reads. |
+| `routingKey` | `RoutingKey` | `none` | The Service Bus topic the subscription is created on. |
+| `requestType` | `Type?` | `none` | The request type messages on this channel are translated into. |
+| `getRequestType` | `Func<Message, Type>?` | derives the type from `requestType` | Determines the request type from the message rather than from the channel. |
+| `bufferSize` | `int` | `1` | Messages read from the entity at once and held in the channel. |
+| `noOfPerformers` | `int` | `1` | Threads reading this channel, each with its own message pump. |
+| `timeOut` | `TimeSpan?` | `300 ms` | How long a read waits before treating the entity as empty. |
+| `requeueCount` | `int` | `-1` | Times a message is requeued before it is treated as a poison pill; -1 is unlimited. |
+| `requeueDelay` | `TimeSpan?` | `0 ms` | How long delivery of a requeued message is delayed. |
+| `unacceptableMessageLimit` | `int` | `0` | Unacceptable messages before the channel stops; 0 disables the limit. |
+| `unacceptableMessageLimitWindow` | `TimeSpan?` | `null` | The window the unacceptable-message count resets at the end of. |
+| `messagePumpType` | `MessagePumpType` | `none` | Selects the Reactor or Proactor concurrency model. |
+| `channelFactory` | `IAmAChannelFactory?` | `null` | Creates the channel; falls back to `DefaultChannelFactory` when null. |
+| `makeChannels` | `OnMissingChannel` | `Create` | Whether Brighter creates the topic and subscription, validates them, or assumes them. |
+| `subscriptionConfiguration` | `AzureServiceBusSubscriptionConfiguration?` | a default `AzureServiceBusSubscriptionConfiguration` | Describes the Service Bus entity Brighter creates; read back as `Configuration`. |
+| `emptyChannelDelay` | `TimeSpan?` | `500 ms` | How long the pump pauses after a read that found no message. |
+| `channelFailureDelay` | `TimeSpan?` | `1000 ms` | How long the pump pauses after a channel failure. |
+
+Leaving `subscriptionConfiguration` null gives you the defaults in the table above it, so the
+entity is created with a one-minute lock and a three-day time to live.
+
+The generic form `AzureServiceBusSubscription<T>`, which every example below uses, takes the
+same options and supplies four defaults the table cannot: `requestType` is `T`,
+`subscriptionName`, `channelName` and `routingKey` are `T`'s full name, and `messagePumpType`
+is `Proactor`.
 
 This is a typical *Subscription* configuration in a Consumer application:
 

--- a/contents/InMemoryTransport.md
+++ b/contents/InMemoryTransport.md
@@ -84,6 +84,47 @@ services.AddBrighter(options =>
 .AddHostedService<ServiceActivatorHostedService>();
 ```
 
+## InMemory Subscription Options
+
+`InMemorySubscription` takes seventeen constructor arguments, and every one of them is
+[`Subscription`'s](/contents/DispatcherConfigurationReference.md#subscription-options): the
+in-memory transport adds no option of its own, because there is no broker to configure. The
+table is here so that the claim is checked rather than asserted — the day a parameter is
+added, it appears as a row this page does not have.
+
+<!-- optioncheck: Paramore.Brighter.InMemorySubscription
+     manual: requestType — the constructor rejects its own default, so there is no default to read
+     manual: getRequestType — assigned to MapRequestType, and the body substitutes a function returning RequestType when it is null
+     manual: messagePumpType — the constructor rejects its own default of Unknown, so there is no default to read
+-->
+
+| Option | Type | Default | Description |
+|---|---|---|---|
+| `subscriptionName` | `SubscriptionName` | `none` | Names the subscription for diagnostics; read back as `Name`. |
+| `channelName` | `ChannelName` | `none` | Names the channel on the `InternalBus` this subscription reads. |
+| `routingKey` | `RoutingKey` | `none` | The topic the channel subscribes to on the `InternalBus`. |
+| `requestType` | `Type?` | `none` | The request type messages on this channel are translated into. |
+| `getRequestType` | `Func<Message, Type>?` | derives the type from `requestType` | Determines the request type from the message rather than from the channel. |
+| `bufferSize` | `int` | `1` | Messages held in the channel at once, and read from the bus at once. |
+| `noOfPerformers` | `int` | `1` | Threads reading this channel, each with its own message pump. |
+| `timeOut` | `TimeSpan?` | `300 ms` | How long a read waits before treating the channel as empty. |
+| `requeueCount` | `int` | `-1` | Times a message is requeued before it is treated as a poison pill; -1 is unlimited. |
+| `requeueDelay` | `TimeSpan?` | `0 ms` | How long delivery of a requeued message is delayed. |
+| `unacceptableMessageLimit` | `int` | `0` | Unacceptable messages before the channel stops; 0 disables the limit. |
+| `unacceptableMessageLimitWindow` | `TimeSpan?` | `null` | The window the unacceptable-message count resets at the end of. |
+| `messagePumpType` | `MessagePumpType` | `none` | Selects the Reactor or Proactor concurrency model. |
+| `channelFactory` | `IAmAChannelFactory?` | `null` | Creates the channel; supply an `InMemoryChannelFactory` over the same `InternalBus`. |
+| `makeChannels` | `OnMissingChannel` | `Create` | Whether Brighter creates missing infrastructure, validates it, or assumes it. |
+| `emptyChannelDelay` | `TimeSpan?` | `500 ms` | How long the pump pauses after a read that found no message. |
+| `channelFailureDelay` | `TimeSpan?` | `1000 ms` | How long the pump pauses after a channel failure. |
+
+**Two options are set as properties after construction rather than as constructor
+arguments**, so they are not on the table above: `DeadLetterRoutingKey` and
+`InvalidMessageRoutingKey`, both `RoutingKey?` and both `null`.
+
+The generic form `InMemorySubscription<T>` supplies `requestType` from `T` and still requires
+a subscription name, a channel name and a routing key.
+
 ## InMemory Transport Complete Example
 
 ```csharp

--- a/contents/KafkaConfiguration.md
+++ b/contents/KafkaConfiguration.md
@@ -28,19 +28,43 @@ In addition to the Producer API and Consumer API Kafka streams have features suc
 
 ## Kafka Connection
 
-The Connection to Kafka is provided by an **KafkaMessagingGatewayConnection** which allows you to configure the following:
+The Connection to Kafka is provided by a `KafkaMessagingGatewayConfiguration` which allows you to configure the following:
 
-- **BootstrapServers**: A **bootstrap** server is a well-known broker through which we discover the servers in the Kafka cluster that we can connect to. You should supply a comma-separated list of host and port pairs. These are the addresses of the Kafka brokers in the "bootstrap" Kafka cluster.
+- **BootStrapServers**: A **bootstrap** server is a well-known broker through which we discover the servers in the Kafka cluster that we can connect to. You should supply a comma-separated list of host and port pairs. These are the addresses of the Kafka brokers in the "bootstrap" Kafka cluster.
 - **Debug**: A comma-separated list of debug contexts to enable.  Producer: broker, topic, msg. Consumer: consumer, cgrp, topic, fetch.
 - **Name**: An identifier to use for the client.
 - **SaslMechanisms**: If any, what is the protocol used for authenticated connection to the Kafka broker: plain, scram-sha-256, scram-sha-256, gssapi (kerberos), oauthbearer
-- **SaslKerberosName**: If using kerberos, what is the connection name.
+- **SaslKerberosPrincipal**: If using kerberos, what is the connection name.
 - **SaslUsername**: SASL username for use with PLAIN and SASL-SCRAM
 - **SaslPassword**: SASL password for use with PLAIN and SASL-SCRAM
 - **SecurityProtocol**: How are messages between client and server encrypted, if at all: plaintext, ssl, saslplaintext, saslssl
 - **SslCaLocation**: Where is the CA certificate located (see [here](https://docs.confluent.io/platform/current/tutorials/examples/clients/docs/csharp.html) for guidance).
 - **SslKeystoreLocation**: Path to the client's keystore
 - **SslKeystorePassword**: Password for the client's keystore
+
+## Kafka Connection Options
+
+The type is `KafkaMessagingGatewayConfiguration`, which is the name every example on this
+page uses. It takes its options as properties, so the option is the property you set.
+
+<!-- optioncheck: Paramore.Brighter.MessagingGateway.Kafka.KafkaMessagingGatewayConfiguration -->
+
+| Option | Type | Default | Description |
+|---|---|---|---|
+| `BootStrapServers` | `string[]` | `null` | Host and port pairs for the brokers the client discovers the cluster through. |
+| `Debug` | `string?` | `null` | A comma-separated list of librdkafka debug contexts to enable. |
+| `Name` | `string?` | `null` | Identifies the client to the broker. |
+| `SaslMechanisms` | `SaslMechanism?` | `null` | The SASL mechanism used to authenticate to the broker. |
+| `SaslKerberosPrincipal` | `string?` | `null` | The Kerberos principal used when the mechanism is GSSAPI. |
+| `SaslUsername` | `string?` | `null` | The SASL username used with PLAIN and SCRAM. |
+| `SaslPassword` | `string?` | `null` | The SASL password used with PLAIN and SCRAM. |
+| `SecurityProtocol` | `SecurityProtocol?` | `null` | How traffic between client and broker is encrypted. |
+| `SslCaLocation` | `string?` | `null` | Path to the CA certificate that signs the broker's certificate. |
+| `SslKeystoreLocation` | `string?` | `null` | Path to the client's keystore. |
+| `SslKeystorePassword` | `string?` | `null` | Password for the client's keystore. |
+
+Two spellings are easy to get wrong: `BootStrapServers` carries a capital `S` in the middle,
+and the Kerberos option is `SaslKerberosPrincipal`.
 
 The following code connects to a local Kafka instance (for development):
 
@@ -94,7 +118,7 @@ For more on a *Publication* see the material on an *Add Producers* in [Command P
 We allow you to configure properties for both Brighter and the Confluent .NET client. Because there are many properties on the Confluent .NET Client we also configure a callback to let you inspect and modify the configuration that we will pass to the client if you so desire. This can be used to add properties we do not support or adjust how we set them.
 
 - **Replication**: how many ISR nodes must receive the record before the producer can consider the write successful. Default is Acks.All.
-- **BatchNumberMessages**: Maximum number of messages batched in one MessageSet. Default is 10.
+- **BatchNumberMessages**: Maximum number of messages batched in one MessageSet. Default is 10000.
 - **EnableIdempotence**: Messages are produced once only. Will adjust the following if not set: `max.in.flight.requests.per.connection=5` (must be less than or equal to 5), `retries=INT32_MAX` (must be greater than 0), `acks=all`, `queuing.strategy=fifo`. Default is true.
 - **LingerMs**: Maximum time, in milliseconds, for buffering data on the producer queue. Default is 5.
 - **MessageSendMaxRetries**: How many times to retry sending a failing MessageSet. Note: retrying may cause reordering, set the  max in flight to 1 if you need ordering by when sent. Default is 3.
@@ -102,13 +126,48 @@ We allow you to configure properties for both Brighter and the Confluent .NET cl
 - **MaxInFlightRequestsPerConnection**: Maximum number of in-flight requests the  client will send. We default this to 1, so as to allow retries to not de-order the stream.
 - **NumPartitions**: How many partitions for this topic. We default to 1.
 - **Partitioner**: How do we map a partition key to a partition? Defaults to Partitioner.ConsistentRandom, but we recommend Partitioner.Murmur2Random for a more even distribution of messages across partitions. See [Kafka Hash Partitioning](#kafka-hash-partitioning) below for the supported values and the differences between them.
-- **QueueBufferingMaxMessages**: Maximum number of messages allowed on the producer queue. Defaults to 10.
+- **QueueBufferingMaxMessages**: Maximum number of messages allowed on the producer queue. Defaults to 100000.
 - **QueueBufferingMaxKbytes**: Maximum total message size sum allowed on the producer queue. Defaults to 1048576 bytes (so for 10 messages about 104Kb per message).
 - **ReplicationFactor**: What is the replication factor? How many nodes is the topic copied to on the broker? Defaults to 1.
 - **RetryBackoff**: The backoff time before retrying a message send. Defaults to 100.
 - **RequestTimeoutMs**: The ack timeout of the producer request. This value is only enforced by the broker and relies on Replication being != AcksEnum.None. Defaults to 500.
 - **TopicFindTimeoutMs**: How long to wait when asking for topic metadata. Defaults to 5000.
 - **TransactionalId**: The unique identifier for this producer, used with transactions
+
+## Kafka Publication Options
+
+`KafkaPublication` takes its options as properties and adds these seventeen to the
+[base publication options](/contents/CommandProcessorConfigurationReference.md#publication-options),
+which it inherits.
+
+<!-- optioncheck: Paramore.Brighter.MessagingGateway.Kafka.KafkaPublication
+     manual: MessageHeaderBuilder — the property is initialised to a KafkaDefaultMessageHeaderBuilder, which has no printable value
+-->
+
+| Option | Type | Default | Description |
+|---|---|---|---|
+| `Replication` | `Acks` | `All` | In-sync replicas that must acknowledge a write before it is complete. |
+| `BatchNumberMessages` | `int` | `10000` | Messages batched into one MessageSet. |
+| `EnableIdempotence` | `bool` | `true` | Whether the producer guarantees each message is written once. |
+| `LingerMs` | `int` | `5` | Milliseconds data is buffered on the producer queue before it is sent. |
+| `MessageSendMaxRetries` | `int` | `3` | Times a failing MessageSet is retried. |
+| `MessageTimeoutMs` | `int` | `5000` | Milliseconds a produced message waits locally for successful delivery; 0 is infinite. |
+| `MaxInFlightRequestsPerConnection` | `int` | `1` | Requests the client sends before waiting for a response. |
+| `NumPartitions` | `int` | `1` | Partitions given to the topic when Brighter creates it. |
+| `Partitioner` | `Partitioner` | `ConsistentRandom` | Maps a partition key to a partition. |
+| `QueueBufferingMaxMessages` | `int` | `100000` | Messages allowed on the producer queue. |
+| `QueueBufferingMaxKbytes` | `int` | `1048576` | Total size in kilobytes allowed on the producer queue. |
+| `ReplicationFactor` | `short` | `1` | Broker nodes the topic is copied to when Brighter creates it. |
+| `RetryBackoff` | `int` | `100` | Milliseconds before a failed send is retried. |
+| `RequestTimeoutMs` | `int` | `500` | Milliseconds the broker waits to acknowledge a producer request. |
+| `TopicFindTimeoutMs` | `int` | `5000` | Milliseconds a request for topic metadata waits. |
+| `TransactionalId` | `string?` | `null` | Identifies this producer across restarts when using transactions. |
+| `MessageHeaderBuilder` | `IKafkaMessageHeaderBuilder` | a `KafkaDefaultMessageHeaderBuilder` | Maps a Brighter message's headers onto Kafka headers. |
+
+`MaxInFlightRequestsPerConnection` is `1` rather than the Confluent client's own `5`, so that
+a retry cannot re-order the stream; raising it trades ordering for throughput.
+`MessageHeaderBuilder` is the extension point for the mapping between a Brighter message's
+headers and Kafka's.
 
 The following example shows how a *Publication* might be configured:
 
@@ -243,6 +302,70 @@ We support a number of Kafka specific *Subscription* options:
 - **ReplicationFactor**: What is the replication factor? How many nodes is the topic copied to on the broker? Defaults to 1. Used for topic creation if required.
 - **SessionTimeout**: If Kafka does not receive a heartbeat from the consumer within this time window, trigger a re-balance. Defaults to 10000ms (10 seconds). **Deprecated**: set `SessionTimeout` on a `ClassicGroupProtocol` via **GroupProtocol** instead.
 - **SweepUncommittedOffsetsInterval**: The interval at which we sweep, looking for offsets that have not been flushed (see [below](#offset-management)). Defaults to 30000ms (30 seconds).
+
+## Kafka Subscription Options
+
+`KafkaSubscription` takes its options as constructor arguments, so the option is the parameter
+you type. The seventeen it shares with
+[`Subscription`](/contents/DispatcherConfigurationReference.md#subscription-options) behave
+the same way here; the other thirteen are Kafka's own, and this is the widest subscription
+table in the documentation.
+
+<!-- optioncheck: Paramore.Brighter.MessagingGateway.Kafka.KafkaSubscription
+     manual: requestType — the constructor rejects its own default, so there is no default to read
+     manual: getRequestType — assigned to MapRequestType, and the body substitutes a function returning RequestType when it is null
+     manual: messagePumpType — the constructor rejects its own default of Unknown, so there is no default to read
+     manual: numOfPartitions — assigned to NumPartitions, a spelling that differs by more than case, so the default cannot be read back
+-->
+
+| Option | Type | Default | Description |
+|---|---|---|---|
+| `subscriptionName` | `SubscriptionName` | `none` | Names the subscription for diagnostics; read back as `Name`. |
+| `channelName` | `ChannelName` | `none` | Names the channel this subscription reads. |
+| `routingKey` | `RoutingKey` | `none` | The Kafka topic the consumer subscribes to. |
+| `requestType` | `Type?` | `none` | The request type messages on this topic are translated into. |
+| `getRequestType` | `Func<Message, Type>?` | derives the type from `requestType` | Determines the request type from the message rather than from the topic. |
+| `groupId` | `string?` | `null` | The consumer group this consumer joins. |
+| `bufferSize` | `int` | `1` | Messages read from the topic at once and held in the channel. |
+| `noOfPerformers` | `int` | `1` | Threads reading this topic, each with its own message pump. |
+| `timeOut` | `TimeSpan?` | `300 ms` | How long a read waits before treating the topic as empty. |
+| `requeueCount` | `int` | `-1` | Times a message is requeued before it is treated as a poison pill; -1 is unlimited. |
+| `requeueDelay` | `TimeSpan?` | `0 ms` | How long delivery of a requeued message is delayed. |
+| `unacceptableMessageLimit` | `int` | `0` | Unacceptable messages before the channel stops; 0 disables the limit. |
+| `unacceptableMessageLimitWindow` | `TimeSpan?` | `null` | The window the unacceptable-message count resets at the end of. |
+| `offsetDefault` | `AutoOffsetReset` | `Earliest` | Where the consumer starts when the group has no stored offset. |
+| `commitBatchSize` | `long` | `10` | Completed messages whose offsets are committed in one batch. |
+| `sessionTimeout` | `TimeSpan?` | `10000 ms` | How long Kafka waits for a heartbeat before rebalancing the group. |
+| `maxPollInterval` | `TimeSpan?` | `300000 ms` | How long Kafka waits for a poll before rebalancing the group. |
+| `sweepUncommittedOffsetsInterval` | `TimeSpan?` | `30000 ms` | How often offsets that never reached a batch are swept and committed. |
+| `isolationLevel` | `IsolationLevel` | `ReadCommitted` | Whether uncommitted messages are read. |
+| `messagePumpType` | `MessagePumpType` | `none` | Selects the Reactor or Proactor concurrency model. |
+| `numOfPartitions` | `int` | `1` | Partitions given to the topic when Brighter creates it; read back as `NumPartitions`. |
+| `replicationFactor` | `short` | `1` | Broker nodes the topic is copied to when Brighter creates it. |
+| `channelFactory` | `IAmAChannelFactory?` | `null` | Creates the channel; falls back to `DefaultChannelFactory` when null. |
+| `makeChannels` | `OnMissingChannel` | `Create` | Whether Brighter creates the topic, validates it, or assumes it. |
+| `emptyChannelDelay` | `TimeSpan?` | `500 ms` | How long the pump pauses after a read that found no message. |
+| `channelFailureDelay` | `TimeSpan?` | `1000 ms` | How long the pump pauses after a channel failure. |
+| `partitionAssignmentStrategy` | `PartitionAssignmentStrategy` | `RoundRobin` | How partitions are assigned across the consumer group. |
+| `configHook` | `Action<ConsumerConfig>?` | `null` | Modifies the Confluent `ConsumerConfig` before the consumer is created. |
+| `deadLetterRoutingKey` | `RoutingKey?` | `null` | The topic messages are dead-lettered to. |
+| `invalidMessageRoutingKey` | `RoutingKey?` | `null` | The topic unacceptable messages are routed to. |
+
+`makeChannels` is `Create`, so Brighter creates a topic it cannot find, using
+`numOfPartitions` and `replicationFactor`; set it to `Validate` where the topic is declared by
+your infrastructure. `sessionTimeout` and `partitionAssignmentStrategy` are deprecated in
+favour of the same settings on a `ClassicGroupProtocol`, as the bullets above record.
+
+**Four options are set as properties after construction rather than as constructor
+arguments**, so they are not on the table above: `GroupProtocol`,
+`ReadCommittedOffsetsTimeOut` (5000 ms), `TopicFindTimeout` (5000 ms) and `TimeProvider`. The
+bullets above cover the first two.
+
+The generic form `KafkaSubscription<T>`, which every example below uses, takes the same
+options and supplies four defaults the table cannot: `requestType` is `T`,
+`subscriptionName`, `channelName` and `routingKey` are `T`'s full name, and `messagePumpType`
+is `Reactor` — Kafka is the one transport here whose generic subscription defaults to the
+Reactor rather than the Proactor.
 
 The following example shows how a subscription might be configured:
 

--- a/contents/PostgreSQLMessageBroker.md
+++ b/contents/PostgreSQLMessageBroker.md
@@ -221,37 +221,87 @@ public class OrderCreatedEventHandler : RequestHandlerAsync<OrderCreatedEvent>
 
 ## PostgreSQL Message Broker Configuration Options
 
-### PostgresPublication
+Three of the four settings below default to `null`, and a `null` is not "unset": the schema, the
+queue store table and the payload format each fall back to the same setting on the
+[relational database configuration](/contents/RelationalDatabaseConfigurationReference.md#relational-database-configuration-options)
+the connection carries, and the schema falls back once more to `public`.
 
-| Property | Type | Description | Default |
-|----------|------|-------------|---------|
-| `Topic` | `RoutingKey` | Message routing key (queue name) | Required |
-| `SchemaName` | `string?` | Database schema name | `"public"` |
-| `QueueStoreTable` | `string?` | Queue store table name | From configuration |
-| `BinaryMessagePayload` | `bool?` | Use JSONB instead of JSON | From configuration |
+### PostgresPublication Options
 
-### PostgresSubscription
+`PostgresPublication` takes its options as properties and adds these three to the
+[base publication options](/contents/CommandProcessorConfigurationReference.md#publication-options),
+which carry `Topic`.
 
-| Property | Type | Description | Default |
-|----------|------|-------------|---------|
-| `ChannelName` | `ChannelName` | Consumer channel name | Required |
-| `RoutingKey` | `RoutingKey` | Message routing key (queue name) | Required |
-| `BufferSize` | `int` | Messages to retrieve per poll | `1` |
-| `NoOfPerformers` | `int` | Concurrent consumer threads | `1` |
-| `VisibleTimeout` | `TimeSpan` | Message visibility timeout | `30 seconds` |
-| `SchemaName` | `string?` | Database schema name | `"public"` |
-| `QueueStoreTable` | `string?` | Queue store table name | From configuration |
-| `BinaryMessagePayload` | `bool?` | Expect JSONB payloads | From configuration |
-| `TableWithLargeMessage` | `bool` | Support for large messages as streams | `false` |
+<!-- optioncheck: Paramore.Brighter.MessagingGateway.Postgres.PostgresPublication -->
 
-### RelationalDatabaseConfiguration
+| Option | Type | Default | Description |
+|---|---|---|---|
+| `SchemaName` | `string?` | `null` | The schema the queue store table lives in. |
+| `QueueStoreTable` | `string?` | `null` | The table messages are written to. |
+| `BinaryMessagePayload` | `bool?` | `null` | Whether the payload column is written as JSONB rather than JSON. |
 
-| Property | Type | Description |
-|----------|------|-------------|
-| `ConnectionString` | `string` | PostgreSQL connection string |
-| `QueueStoreTable` | `string` | Default queue store table name |
-| `SchemaName` | `string` | Default schema name |
-| `BinaryMessagePayload` | `bool` | Default to JSONB |
+### PostgresSubscription Options
+
+`PostgresSubscription` takes its options as constructor arguments, so the option is the
+parameter you type. The seventeen it shares with
+[`Subscription`](/contents/DispatcherConfigurationReference.md#subscription-options) behave
+the same way here; the other seven are PostgreSQL's own.
+
+<!-- optioncheck: Paramore.Brighter.MessagingGateway.Postgres.PostgresSubscription
+     manual: dataType — assigned to RequestType, and the constructor rejects its own default, so there is no default to read
+     manual: getRequestType — assigned to MapRequestType, and the body substitutes a function returning RequestType when it is null
+     manual: messagePumpType — the constructor rejects its own default of Unknown, so there is no default to read
+-->
+
+| Option | Type | Default | Description |
+|---|---|---|---|
+| `subscriptionName` | `SubscriptionName` | `none` | Names the subscription for diagnostics; read back as `Name`. |
+| `channelName` | `ChannelName` | `none` | Names the queue this subscription reads. |
+| `routingKey` | `RoutingKey` | `none` | The routing key messages are written under. |
+| `dataType` | `Type?` | `none` | The request type messages on this queue are translated into; read back as `RequestType`. |
+| `getRequestType` | `Func<Message, Type>?` | derives the type from `dataType` | Determines the request type from the message rather than from the queue. |
+| `bufferSize` | `int` | `1` | Messages read from the queue at once and held in the channel. |
+| `noOfPerformers` | `int` | `1` | Threads reading this queue, each with its own message pump. |
+| `timeOut` | `TimeSpan?` | `300 ms` | How long a read waits before treating the queue as empty. |
+| `requeueCount` | `int` | `-1` | Times a message is requeued before it is treated as a poison pill; -1 is unlimited. |
+| `requeueDelay` | `TimeSpan?` | `0 ms` | How long delivery of a requeued message is delayed. |
+| `unacceptableMessageLimit` | `int` | `0` | Unacceptable messages before the channel stops; 0 disables the limit. |
+| `unacceptableMessageLimitWindow` | `TimeSpan?` | `null` | The window the unacceptable-message count resets at the end of. |
+| `messagePumpType` | `MessagePumpType` | `none` | Selects the Reactor or Proactor concurrency model. |
+| `channelFactory` | `IAmAChannelFactory?` | `null` | Creates the channel; falls back to `DefaultChannelFactory` when null. |
+| `makeChannels` | `OnMissingChannel` | `Create` | Whether Brighter creates the queue store table, validates it, or assumes it. |
+| `emptyChannelDelay` | `TimeSpan?` | `500 ms` | How long the pump pauses after a read that found no message. |
+| `channelFailureDelay` | `TimeSpan?` | `1000 ms` | How long the pump pauses after a channel failure. |
+| `schemaName` | `string?` | `null` | The schema the queue store table lives in. |
+| `queueStoreTable` | `string?` | `null` | The table messages are read from. |
+| `visibleTimeout` | `TimeSpan?` | `30000 ms` | How long a read message stays invisible to other consumers. |
+| `tableWithLargeMessage` | `bool` | `false` | Whether payloads are read as streams to support large messages. |
+| `binaryMessagePayload` | `bool?` | `null` | Whether the payload column is read as JSONB rather than JSON. |
+| `deadLetterRoutingKey` | `RoutingKey?` | `null` | The routing key messages are dead-lettered to. |
+| `invalidMessageRoutingKey` | `RoutingKey?` | `null` | The routing key unacceptable messages are routed to. |
+
+The request type parameter is `dataType` here rather than `requestType`, which is what every
+other transport in this documentation calls it, and it is read back as `RequestType`.
+
+The generic form `PostgresSubscription<T>`, which every example above uses, takes the same
+options and supplies four defaults the table cannot: `dataType` is `T`, and
+`subscriptionName`, `channelName` and `routingKey` are `T`'s full name. It leaves
+`messagePumpType` required, so state Reactor or Proactor on every subscription.
+
+### PostgresMessagingGatewayConnection Options
+
+The connection wraps the relational database configuration rather than adding settings of its
+own.
+
+<!-- optioncheck: Paramore.Brighter.MessagingGateway.Postgres.PostgresMessagingGatewayConnection -->
+
+| Option | Type | Default | Description |
+|---|---|---|---|
+| `configuration` | `RelationalDatabaseConfiguration` | `none` | The connection string, schema and table names for the queue store; read back as `Configuration`. |
+
+The eight options on that configuration are documented once, at
+[Relational Database Configuration Reference](/contents/RelationalDatabaseConfigurationReference.md),
+because seventeen Brighter components share them.
 
 ---
 

--- a/contents/RabbitMQConfiguration.md
+++ b/contents/RabbitMQConfiguration.md
@@ -54,6 +54,35 @@ The Connection to RabbitMQ is provided by an **RmqMessagingGatewayConnection** w
 
 In RabbitMQ, recreating an exiting primitive is a no-op provided the definition does not change.
 
+## RabbitMQ Connection Options
+
+`RmqMessagingGatewayConnection` takes its options as properties, so the option is the
+property you set. The property is spelled `AmpqUri`, not `AmqpUri` — the transposition is in
+Brighter's own API and a reader who types the protocol's spelling does not compile.
+
+<!-- optioncheck: Paramore.Brighter.MessagingGateway.RMQ.Async.RmqMessagingGatewayConnection
+     manual: Name — the default is Environment.MachineName, so there is no value a table can print
+-->
+
+| Option | Type | Default | Description |
+|---|---|---|---|
+| `Name` | `string` | the machine name | Names the connection in the broker's connection list. |
+| `AmpqUri` | `AmqpUriSpecification?` | `null` | The AMQP URI the client connects with, and its retry settings. |
+| `Exchange` | `Exchange?` | `null` | The exchange messages are published to and queues bind against. |
+| `DeadLetterExchange` | `Exchange?` | `null` | The exchange dead-lettered messages are routed to. |
+| `Heartbeat` | `ushort` | `20` | Seconds between heartbeats before the broker treats the connection as dead. |
+| `PersistMessages` | `bool` | `false` | Whether published messages are written to disk. |
+| `ContinuationTimeout` | `ushort` | `20` | Seconds a protocol operation waits for its reply. |
+| `ClientCertificate` | `X509Certificate2?` | `null` | The client certificate presented for mutual TLS. |
+| `ClientCertificatePath` | `string?` | `null` | Path to a client certificate file, loaded when no certificate is supplied directly. |
+| `ClientCertificatePassword` | `string?` | `null` | Password for the certificate file at `ClientCertificatePath`. |
+| `TrustServerSelfSignedCertificate` | `bool` | `false` | Whether a self-signed certificate from the broker is accepted. |
+
+`Name` is the one row with no default a table can state: it is `Environment.MachineName`, so
+it differs on every machine the process runs on. Set it explicitly when you want to recognise
+the connection in the management console. The four certificate options configure a TLS
+connection to the broker and are not exercised by any example on this page.
+
 The following code creates a typical RabbitMQ connection (here shown as part of configuring an External Bus):
 
 ``` csharp
@@ -93,15 +122,25 @@ the ones your network obliges you to; for how to choose values, see
 
 For more on a *Publication* see the material on an *Add Producers* in [Command Processor Configuration Reference](/contents/CommandProcessorConfigurationReference.md#using-an-external-bus).
 
-We only support one custom property on RabbitMQ which configures shutdown delay to await pending confirmations. 
-
-* **WaitForConfirmsTimeOutInMilliseconds**
+We only support one custom property on RabbitMQ which configures shutdown delay to await pending confirmations.
 
 Under the hood, Brighter uses [Publisher Confirms](https://www.rabbitmq.com/confirms.html) to update its Outbox for the dispatch time. This means that when publishing a message we allow RabbitMQ to confirm delivery of a message to all available nodes asynchronously, and then call us back, over blocking. This allows for higher throughput. But it means that we cannot update the Outbox to show a message as dispatched, until we receive the callback, which may occur after your handler pipeline for that message has completed and the message has been acknowledged.  
 
 When shutting down a producer, it is possible that not all confirms have yet been received from RabbitMQ. The delay instructs Brighter to wait for a period of time, in order to allow the confirms to arrive. 
 
 Missing a confirm will cause the *Outbox Sweeper* to resend a message, as it will not be marked as dispatched. (This is why we refer to Guaranteed *At Least Once* because there are many opportunities where messages may be duplicated in order to guarantee they were sent).  
+
+## RabbitMQ Publication Options
+
+`RmqPublication` adds one option to the
+[base publication options](/contents/CommandProcessorConfigurationReference.md#publication-options),
+which it inherits and which are set the same way.
+
+<!-- optioncheck: Paramore.Brighter.MessagingGateway.RMQ.Async.RmqPublication -->
+
+| Option | Type | Default | Description |
+|---|---|---|---|
+| `WaitForConfirmsTimeOutInMilliseconds` | `int` | `500` | Milliseconds a producer waits at shutdown for outstanding publisher confirms. |
 
 The following code creates a *Publication* for RabbitMQ when configuring an *External Bus*
 
@@ -185,6 +224,55 @@ We support a number of RabbitMQ specific *Subscription* options:
 - **HighAvailability**: [Deprecated] Not used on versions of RabbitMQ 3+. Prior to this, configuring that a queue should be mirrored was an API option, now it is a configuration management option on the broker.
 - **IsDurable**: Should subscription definitions survive a restart of nodes in the broker.
 - **MaxQueueLength**: [Deprecated] Prefer to use policy to set this instead (see [RabbitMQ docs](https://www.rabbitmq.com/maxlength.html)). The maximum length a RabbitMQ queue can grow to, before new messages are rejected (and sent to a DLQ if there is one).
+
+## RabbitMQ Subscription Options
+
+`RmqSubscription` takes its options as constructor arguments, so the option is the parameter
+you type. The first seventeen are
+[`Subscription`'s](/contents/DispatcherConfigurationReference.md#subscription-options) and
+behave the same way here; the rest are RabbitMQ's own.
+
+<!-- optioncheck: Paramore.Brighter.MessagingGateway.RMQ.Async.RmqSubscription
+     manual: requestType — the constructor rejects its own default, so there is no default to read
+     manual: getRequestType — assigned to MapRequestType, and the body substitutes a function returning RequestType when it is null
+     manual: messagePumpType — the constructor rejects its own default of Unknown, so there is no default to read
+-->
+
+| Option | Type | Default | Description |
+|---|---|---|---|
+| `subscriptionName` | `SubscriptionName` | `none` | Names the subscription for diagnostics; read back as `Name`. |
+| `channelName` | `ChannelName` | `none` | Names the RabbitMQ queue this subscription reads. |
+| `routingKey` | `RoutingKey` | `none` | The routing key the queue binds to on the exchange. |
+| `requestType` | `Type?` | `none` | The request type messages on this queue are translated into. |
+| `getRequestType` | `Func<Message, Type>?` | derives the type from `requestType` | Determines the request type from the message rather than from the queue. |
+| `bufferSize` | `int` | `1` | Messages read from the queue at once and held in the channel. |
+| `noOfPerformers` | `int` | `1` | Threads reading this queue, each with its own message pump. |
+| `timeOut` | `TimeSpan?` | `300 ms` | How long a read waits before treating the queue as empty. |
+| `requeueCount` | `int` | `-1` | Times a message is requeued before it is treated as a poison pill; -1 is unlimited. |
+| `requeueDelay` | `TimeSpan?` | `0 ms` | How long delivery of a requeued message is delayed. |
+| `unacceptableMessageLimit` | `int` | `0` | Unacceptable messages before the channel stops; 0 disables the limit. |
+| `unacceptableMessageLimitWindow` | `TimeSpan?` | `null` | The window the unacceptable-message count resets at the end of. |
+| `isDurable` | `bool` | `false` | Whether the queue definition survives a broker restart. |
+| `messagePumpType` | `MessagePumpType` | `none` | Selects the Reactor or Proactor concurrency model. |
+| `channelFactory` | `IAmAChannelFactory?` | `null` | Creates the channel; falls back to `DefaultChannelFactory` when null. |
+| `highAvailability` | `bool` | `false` | Mirrors the queue across nodes on brokers before RabbitMQ 3. |
+| `deadLetterChannelName` | `ChannelName?` | `null` | Names the queue bound to the dead letter exchange for this subscription. |
+| `deadLetterRoutingKey` | `RoutingKey?` | `null` | The routing key binding the dead letter queue to the dead letter exchange. |
+| `ttl` | `TimeSpan?` | `null` | How long a message stays on the queue before RabbitMQ discards it. |
+| `makeChannels` | `OnMissingChannel` | `Create` | Whether Brighter creates the queue and binding, validates them, or assumes them. |
+| `emptyChannelDelay` | `TimeSpan?` | `500 ms` | How long the pump pauses after a read that found no message. |
+| `channelFailureDelay` | `TimeSpan?` | `1000 ms` | How long the pump pauses after a channel failure. |
+| `maxQueueLength` | `int?` | `null` | Messages the queue holds before new ones are rejected. |
+| `queueType` | `QueueType` | `Classic` | Selects a classic or quorum queue. |
+
+`queueType` is the one option the two clients do not share: the `RMQ.Sync` package's
+`RmqSubscription` takes 23 parameters and has no `queueType` among them, so quorum queues are
+available only on `RMQ.Async`. `highAvailability` and `maxQueueLength` are both deprecated,
+as the bullets above record.
+
+The generic form `RmqSubscription<T>`, which every example below uses, takes the same options
+and supplies four defaults the table cannot: `requestType` is `T`, `subscriptionName`,
+`channelName` and `routingKey` are `T`'s full name, and `messagePumpType` is `Proactor`.
 
 This is a typical *Subscription* configuration in a Consumer application:
 

--- a/spec/012-configuration_reference/redproof/fixture_connection.md
+++ b/spec/012-configuration_reference/redproof/fixture_connection.md
@@ -1,0 +1,28 @@
+# Fixture — a type with an environment-derived default
+
+Not a documentation page. `redproof_optioncheck.py` mutates this file; it lives
+outside `contents/` so no gate in this repository reads it, and `optioncheck`
+sees it only because it takes path arguments.
+
+`RmqMessagingGatewayConnection.Name` is `= Environment.MachineName`. The checker
+can read that value and cannot determine the default, because the value is this
+machine's hostname and the CI runner's is different — so the row is `manual:`,
+and deleting the declaration must be a finding rather than a pass.
+
+<!-- optioncheck: Paramore.Brighter.MessagingGateway.RMQ.Async.RmqMessagingGatewayConnection
+     manual: Name — the default is Environment.MachineName, which differs on every machine
+-->
+
+| Option | Type | Default | Description |
+|---|---|---|---|
+| `Name` | `string` | the machine name | Names the connection in broker diagnostics. |
+| `AmpqUri` | `AmqpUriSpecification?` | `null` | The AMQP URI the client connects with. |
+| `Exchange` | `Exchange?` | `null` | The exchange messages are published to. |
+| `DeadLetterExchange` | `Exchange?` | `null` | The exchange dead-lettered messages are routed to. |
+| `Heartbeat` | `ushort` | `20` | Seconds between heartbeats. |
+| `PersistMessages` | `bool` | `false` | Whether published messages are written to disk. |
+| `ContinuationTimeout` | `ushort` | `20` | Seconds a protocol operation waits for its reply. |
+| `ClientCertificate` | `X509Certificate2?` | `null` | The client certificate presented for mutual TLS. |
+| `ClientCertificatePath` | `string?` | `null` | Path to the client certificate file. |
+| `ClientCertificatePassword` | `string?` | `null` | Password for the client certificate file. |
+| `TrustServerSelfSignedCertificate` | `bool` | `false` | Whether a self-signed broker certificate is accepted. |

--- a/spec/012-configuration_reference/redproof/redproof_optioncheck.py
+++ b/spec/012-configuration_reference/redproof/redproof_optioncheck.py
@@ -6,8 +6,15 @@
 Requirements §12 AC3 asks for "a red-proof that a changed ctor default is
 caught -- NOT merely that the tool runs", AC3b for one on a body-coalesced
 default, and AC5 for exit 2 being distinguishable from exit 0. This is all
-three, in 009's `redproof_versioncheck.py` shape, and the discipline is that
-file's:
+three, in 009's `redproof_versioncheck.py` shape.
+
+Branch 7 was added at phase 5 and is the only one here about a GREEN build:
+`RmqMessagingGatewayConnection.Name` is `= Environment.MachineName`, so the
+checker read a real value and a table printing it passed on the author's machine
+and would have failed on the CI runner. It uses a second fixture, because the
+subscription one has no environment-derived member to declare.
+
+The discipline is 009's:
 
   * print a BASELINE first and require it GREEN. A probe that starts at its
     first mutation cannot tell a rule that fires from a tool that is broken.
@@ -37,6 +44,7 @@ HERE = os.path.dirname(os.path.abspath(__file__))
 REPO = os.path.dirname(os.path.dirname(os.path.dirname(HERE)))
 
 FIXTURE = os.path.join(HERE, 'fixture_subscription.md')
+CONNECTION = os.path.join(HERE, 'fixture_connection.md')
 PROJECT = os.path.join(REPO, 'tools', 'optioncheck')
 BIN = os.path.join(PROJECT, 'bin', 'Debug', 'net9.0')
 DLL = os.path.join(BIN, 'optioncheck.dll')
@@ -64,23 +72,26 @@ def digest(path):
         return hashlib.sha256(handle.read()).hexdigest()
 
 
-def read():
-    with open(FIXTURE, encoding='utf-8') as handle:
+def read(path=None):
+    with open(path or FIXTURE, encoding='utf-8') as handle:
         return handle.read()
 
 
-def write(text):
-    with open(FIXTURE, 'w', encoding='utf-8') as handle:
+def write(text, path=None):
+    with open(path or FIXTURE, 'w', encoding='utf-8') as handle:
         handle.write(text)
 
 
-def mutate(original, old, new):
+def mutate(original, old, new, path=None):
     """Replace `old` with `new`, asserting the substitution actually happened."""
     assert old in original, f'the fixture does not contain {old!r} -- it has moved'
     text = original.replace(old, new, 1)
     assert text != original, 'the mutation changed nothing'
-    write(text)
-    assert new in read(), f'the mutated fixture does not contain {new!r}'
+    write(text, path)
+    if new:
+        assert new in read(path), f'the mutated fixture does not contain {new!r}'
+    else:
+        assert old not in read(path), f'the mutated fixture still contains {old!r}'
     return text
 
 
@@ -182,6 +193,48 @@ def main():
 
     assert digest(FIXTURE) == original, 'the fixture did not survive the probe'
     print(f'\nfixture restored byte-identical: sha256 {digest(FIXTURE)}')
+
+    # ------------------------------- 7. a default the product takes from the box
+    # Phase 5's finding, and the one branch here that is about a green build
+    # rather than a red one. `RmqMessagingGatewayConnection.Name` is
+    # `Environment.MachineName`: the checker reads a real value, so before the
+    # fix a table printing this machine's hostname PASSED here and would have
+    # failed on the CI runner, where the hostname is different. The row is
+    # `manual:`; deleting the declaration must be a finding.
+    #
+    # The mutation deletes a line rather than writing a value, on purpose. A
+    # branch that wrote this machine's name into the fixture would itself be
+    # machine-dependent, which is the defect it is proving.
+    connection = digest(CONNECTION)
+    spare = os.path.join(tempfile.mkdtemp(), 'fixture_connection.md')
+    shutil.copy2(CONNECTION, spare)
+    assert digest(spare) == connection, 'the copy aside is not the file'
+
+    text = read(CONNECTION)
+    code, out = run([CONNECTION])
+    assert 'scope: 1 table, 11 rows, 1 type' in out, (
+        'branch 7 precondition: the connection fixture must be IN SCOPE:\n' + out)
+    assert code == 0, f'branch 7 needs a green baseline for its own fixture:\n{out}'
+    print('\nconnection fixture baseline green: 1 table, 11 rows, 1 type')
+
+    try:
+        mutate(text,
+               '\n     manual: Name — the default is Environment.MachineName, '
+               'which differs on every machine',
+               '', CONNECTION)
+        assert 'manual: Name' not in read(CONNECTION), (
+            'the mutation must remove the declaration, not merely edit it')
+        code, out = run([CONNECTION])
+        report('7. AN ENVIRONMENT-DERIVED DEFAULT', 1, code, out,
+               'the `manual: Name` declaration is gone; the row still names a value')
+        assert 'DEFAULT NOT DETERMINABLE' in out and 'Environment.MachineName' in out, (
+            'exit 1 is only correct if the finding says WHY the value is not a '
+            'default -- a row read off this machine is green here and red in CI')
+    finally:
+        write(text, CONNECTION)
+
+    assert digest(CONNECTION) == connection, 'the connection fixture did not survive the probe'
+    print(f'connection fixture restored byte-identical: sha256 {digest(CONNECTION)}')
 
     # -------------------------------------- 6. AC5, the authority unreachable
     # Exit 2 has to be reachable as a VERDICT rather than as a restore failure:

--- a/spec/012-configuration_reference/tasks.md
+++ b/spec/012-configuration_reference/tasks.md
@@ -985,7 +985,7 @@ exist and already have configuration prose; what they lack is a table with a def
 `Subscription`'s 17 or `Publication`'s 8 — a transport table lists what the transport **adds or
 overrides** and links up to phase 3's tables (design §3.2).
 
-- [ ] **Task 5.1:** `RabbitMQConfiguration.md` — 44 options, 3 tables
+- [x] **Task 5.1:** `RabbitMQConfiguration.md` — 44 options, 3 tables
   - Input: `RmqSubscription` 24, `RmqMessagingGatewayConnection` 19, `RmqPublication` 1
   - Output: three marked tables
   - Notes: **One table, the Async client's** — ruled at design §13.3. `RMQ.Async`'s
@@ -994,7 +994,7 @@ overrides** and links up to phase 3's tables (design §3.2).
     two counts. **`queueType`'s row says the Sync client has no such parameter.** Two tables
     would be 23 near-duplicate rows for a one-parameter difference.
 
-- [ ] **Task 5.2:** `KafkaConfiguration.md` — 58 options, 3 tables
+- [x] **Task 5.2:** `KafkaConfiguration.md` — 58 options, 3 tables
   - Input: `KafkaSubscription` 30, `KafkaPublication` 17, `KafkaMessagingGatewayConfiguration`
     11
   - Output: three marked tables
@@ -1004,21 +1004,21 @@ overrides** and links up to phase 3's tables (design §3.2).
     the corpus mentions `MakeChannels` 23 times across 11 pages **without once pairing it with
     the word "default"** — this row is where that ends.
 
-- [ ] **Task 5.3:** `AWSSQSConfiguration.md` — 31 options, 3 tables
+- [x] **Task 5.3:** `AWSSQSConfiguration.md` — 31 options, 3 tables
   - Input: `SqsSubscription` 24, `SqsPublication` 4, `SnsPublication` 3
   - Output: three marked tables
   - Notes: `SqsSubscription` is the one type in task 1.4's table needing a **fourth**
     constructor argument, `channelType`. If task 2.4's synthesiser handles it generically this
     is unremarkable; if it does not, this is where that shows.
 
-- [ ] **Task 5.4:** `AzureServiceBusConfiguration.md` — 26 options, 3 tables
+- [x] **Task 5.4:** `AzureServiceBusConfiguration.md` — 26 options, 3 tables
   - Input: `AzureServiceBusSubscription` 18, `AzureServiceBusSubscriptionConfiguration` 6,
     `AzureServiceBusConfiguration` 2
   - Output: three marked tables
   - Notes: two configuration-shaped types on one page, one nested inside the subscription.
     **Qualify both headings by what they configure**, not by the type name alone.
 
-- [ ] **Task 5.5:** `PostgreSQLMessageBroker.md` — 27 options, three existing tables replaced
+- [x] **Task 5.5:** `PostgreSQLMessageBroker.md` — 27 options, three existing tables replaced
   - Input: `PostgresSubscription` 24, `PostgresPublication` 3,
     `PostgresMessagingGatewayConnection` **1†, and task 1.5's real figure**
   - Output: three marked tables replacing the three that are there
@@ -1029,7 +1029,7 @@ overrides** and links up to phase 3's tables (design §3.2).
     ruling is a rule. `PostgresMessagingGatewayConnection` is a `†` row: **absent from the 67
     entirely** because it has a primary constructor. Write it from the type.
 
-- [ ] **Task 5.6:** `InMemoryTransport.md` — one table, and it is **17 rows, not 2**
+- [x] **Task 5.6:** `InMemoryTransport.md` — one table, and it is **17 rows, not 2**
   - Input: `InMemorySubscription` — **2 by the unfixed survey, 17 primary-constructor
     parameters by the type** (design §12.5); task 1.5's re-run
   - Output: one marked table
@@ -1037,13 +1037,196 @@ overrides** and links up to phase 3's tables (design §3.2).
     design §7.2's column would write a two-row table and every gate in this repository would be
     green on it — `optioncheck` included, until it enumerates the type. Write it from the type.
 
-- [ ] **Task 5.7:** Verify phase 5 — `optioncheck`, the six gates, and the AC8 walk
+- [x] **Task 5.7:** Verify phase 5 — `optioncheck`, the six gates, and the AC8 walk
   - Input: the tables written above
   - Output: exit 0 with a scope naming 16 tables; the six gates; a recorded AC8 verdict
   - Notes: **No page is created, so link, pagelint, shape and `--verify` should not move.**
     The one that can move is pagelint's **warning count**, if a table lands beside a C# block
     with no `using` directives — standing obligation 8. Read `--changed`'s scope line to see
     whether it reached one.
+
+### Phase 5 as executed — 2026-08-28, 7/7
+
+**Sixteen tables and 196 rows across six pages that already existed**, taking the corpus to
+`26 tables, 276 rows, 26 types, on 10 pages of 148 files scanned`, exit 0.
+
+**The phase is 196 options, not the 186 the phase table says**, and both moves were
+predictable from phase 1. `RmqMessagingGatewayConnection` is **11, not 19** — the survey
+counted properties per *file* and that file declares three classes, which is one of the five
+defects session 39 fixed — so RabbitMQ is 36 rather than 44. `PostgresSubscription` plus
+`PostgresPublication` plus `PostgresMessagingGatewayConnection` is 28 rather than 27, and
+`InMemorySubscription` contributes its **17** rather than design §7.2's 2. Every figure was
+re-derived from the type with `--describe` when its table was written.
+
+| Page | Tables | Rows | `manual:` |
+|---|---:|---:|---:|
+| `RabbitMQConfiguration.md` | 3 | 36 | 4 |
+| `KafkaConfiguration.md` | 3 | 58 | 5 |
+| `AWSSQSConfiguration.md` | 3 | 31 | 7 |
+| `AzureServiceBusConfiguration.md` | 3 | 26 | 4 |
+| `PostgreSQLMessageBroker.md` | 3 | 28 | 3 |
+| `InMemoryTransport.md` | 1 | 17 | 3 |
+
+**Twenty-six `manual:` declarations across 196 rows — 13%**, which reproduces phase 3's 13%
+on a corpus four times the size. Twenty-two of the twenty-six are the same three subscription
+parameters repeated once per transport: `requestType`, `getRequestType` and `messagePumpType`.
+
+**The six gates are unmoved to the digit**, which is what task 5.7 predicted for a phase that
+creates no page: link 151, pagelint 0 errors / 787 warnings / 149 pages, shape 148 / 12 /
+widest 10 of 20, redirects 77 / 7858, versioncheck 0 stale of 18 across 5. **The
+using-directive count did not move either**, and that was bought rather than given:
+`pagelint --changed` reports **0 code blocks strict across 31 hunks**, so standing obligation
+8's cheapest defence — put the table where the diff cannot reach a code block — held on all
+six pages.
+
+#### The reading that settles what a transport table contains
+
+Phase 5's preamble says it *"must not restate `Subscription`'s 17 or `Publication`'s 8 — a
+transport table lists what the transport adds or overrides"*, and design §3.2 says a transport
+page *"carries `KafkaSubscription`'s 30 and points at the base rather than restating it"*. Read
+one way that is a 13-row Kafka table with 17 `omit:` declarations; read the other it is 30 rows.
+**It is 30**, and four things in the approved documents say so rather than one:
+
+1. **The phase table's 186 is the sum of the full constructor counts** — 44 + 58 + 31 + 26 + 27.
+   A delta-only reading has no arithmetic that reaches it.
+2. **Task 5.2 puts `MakeChannels` on the Kafka table** in as many words, and `makeChannels` is
+   one of `Subscription`'s seventeen.
+3. **Task 5.6 wants 17 rows for `InMemorySubscription`**, whose seventeen parameters *are*
+   `Subscription`'s seventeen exactly. A delta-only reading makes that table empty, which is
+   `EMPTY TABLE`.
+4. **Design §4's own worked example** opens with `bufferSize`, also one of the seventeen.
+
+So the "must not" is a rule about **tables**, not about **rows**: a transport page carries no
+`Subscription` table and no `Publication` table of its own, and each transport type's table is
+that type's whole constructor. Every page says which of its rows are inherited and links up,
+which is what *points at the base* buys. **Nothing in this phase needed an `omit:`** — the
+repo-wide count is still 0.
+
+#### What the reader could not have got from the type alone
+
+**Every example in this documentation types the generic subclass, and the generic subclass has
+different defaults.** `RmqSubscription<T>`, `KafkaSubscription<T>`, `SqsSubscription<T>`,
+`AzureServiceBusSubscription<T>` and `PostgresSubscription<T>` each supply `requestType` from
+`T` and default `subscriptionName`, `channelName` and `routingKey` to `T`'s full name — and they
+disagree about the pump: **Proactor on RabbitMQ, AWS and Azure Service Bus, `Reactor` on Kafka,
+and still required on PostgreSQL and in-memory.** `SqsSubscription<T>` additionally defaults
+`channelType` to `PubSub` where the non-generic constructor requires it. The tables are of the
+non-generic types, which is the population `survey.py` and `optioncheck` both select, so each
+page states the generic form's extra defaults in a sentence beneath its table. **A reader who
+had only the table would set nothing and get a different subscription than the one it
+describes.**
+
+#### `max(props, ctor)` is a selection, and on two types the two sets are not nested
+
+Settled item 3 is that the surface is `max(props, ctor)` *"as a selection rather than a union"*,
+and `Reflect.cs` gives the reason: *"on a subscription every property has a matching parameter
+and the two differ only in case"*. **That is false on two of this phase's six types**, measured
+rather than assumed:
+
+- **`KafkaSubscription`** — 30 constructor parameters and 17 declared properties, of which
+  **four are not parameters**: `GroupProtocol`, `ReadCommittedOffsetsTimeOut`,
+  `TopicFindTimeout` and `TimeProvider`. The page's own bullets already documented the first
+  two.
+- **`InMemorySubscription`** — 17 parameters and **two properties that are not among them**,
+  `DeadLetterRoutingKey` and `InvalidMessageRoutingKey`.
+
+**And a third shape the tool cannot see at all: a public field.**
+`AzureServiceBusSubscriptionConfiguration` declares `SqlFilter` and `UseServiceBusQueue` as
+fields rather than properties, and `AzureServiceBusPublication`'s only member is the field
+`UseServiceBusQueue`. `Reflect.Describe` reads `GetProperties`, so all three are invisible.
+
+**Nothing was changed for this.** The selection is a settled decision that every count in the
+spec rests on, and widening it to a case-insensitive union plus fields would move the corpus
+figure and every per-page figure with it. What phase 5 did instead is the disciplined half:
+each affected page names the missing options and their defaults in a sentence below its table,
+so no reader is misled, and **the question goes to review** — *should the reader-facing surface
+be the union of parameters, properties and public fields, deduplicated case-insensitively?*
+It is the first thing found in this spec that argues against an approved decision rather than
+against a figure.
+
+*(This is also why the `SqlFilter` bullet on `AzureServiceBusConfiguration.md` was **not**
+corrected. It looked exactly like the Kafka `SaslKerberosName` defect below — a documented name
+absent from the type — and it is not a defect at all. Verify the defect exists before fixing
+it, on a page where two neighbouring bullets were genuinely wrong.)*
+
+### The ledger — ten entries, and `optioncheck` found none of them
+
+Standing obligation 10: record the mismatch before fixing it. **All ten were found by writing
+the correct table beside prose that was already there** — nine of the ten were in bullet lists
+and the tenth in a table with the wrong columns, and the tool reads tables. That makes it
+twelve of the spec's thirteen ledger entries so far; the exception is entry 3, which was found
+by reading the pages *as published* and proved with the compiler.
+
+| # | Page | The corpus said | The assembly says |
+|---:|---|---|---|
+| 4 | `RabbitMQConfiguration.md` | the connection property is **`AmqpUri`** | `AmpqUri` — the transposition is Brighter's, and the page's own examples had it right |
+| 5 | `KafkaConfiguration.md` | the connection type is **`KafkaMessagingGatewayConnection`** | there is no such type; it is `KafkaMessagingGatewayConfiguration`, which every example on the page already used |
+| 6 | `KafkaConfiguration.md` | **`SaslKerberosName`** | `SaslKerberosPrincipal` |
+| 7 | `KafkaConfiguration.md` | **`BootstrapServers`** | `BootStrapServers` |
+| 8 | `KafkaConfiguration.md` | `BatchNumberMessages` defaults to **10** | `10000` |
+| 9 | `KafkaConfiguration.md` | `QueueBufferingMaxMessages` defaults to **10** | `100000` |
+| 10 | `AzureServiceBusConfiguration.md` | `LockDuration` defaults to **`true`** | a `TimeSpan` of one minute |
+| 11 | `AzureServiceBusConfiguration.md` | `DefaultMessageTimeToLive` defaults to **1 minute** | three days |
+| 12 | `PostgreSQLMessageBroker.md` | `SchemaName` defaults to **`"public"`** on both publication and subscription | `null` on both; `public` is the last of three fallbacks, behind the relational configuration's own `SchemaName` |
+| 13 | `PostgreSQLMessageBroker.md` | the subscription's options are `ChannelName`, `BufferSize`, `VisibleTimeout` | the type is constructor-driven, so a reader types `channelName`, `bufferSize`, `visibleTimeout` |
+
+**Entries 8 and 9 are the spec's premise in its purest form so far**: two numbers, off by three
+and four orders of magnitude, on a page nobody had reason to doubt. **Entry 10 is the cheapest**
+— a `TimeSpan` documented as defaulting to `true` — and it survived because no tool has ever
+read that bullet. **Entry 5 is the one a reader would hit first**: the sentence introducing the
+connection names a type that has never existed, three lines above an example that spells it
+correctly.
+
+`PostgreSQLMessageBroker.md`'s three tables are replaced rather than added to, which is task
+5.5 and §2.7's first row. The third of them was `RelationalDatabaseConfiguration` with **no
+`Default` column at all**; it is now a one-row `PostgresMessagingGatewayConnection` table that
+links [phase 4's page](/contents/RelationalDatabaseConfigurationReference.md), which is D15
+paying for itself one phase after it landed.
+
+### What phase 5 changed in the instrument, and why each was forced
+
+**Both were found by pointing the checker at types phase 4 never met**, which is the same
+sentence phase 3 wrote, and the first one is the more interesting of the two.
+
+1. **A default the product takes from the environment.**
+   `RmqMessagingGatewayConnection.Name` is `= Environment.MachineName`. The checker read it,
+   rendered it as `"Mac"`, and would have accepted a table saying so — **green on the author's
+   machine and red on the CI runner, where the hostname is different.** This is the first
+   defect in this spec whose symptom is a *pass*. `Reflect.WithValue` now returns an
+   `Unreadable` reason for a string default equal to `Environment.MachineName` or
+   `Environment.UserName`, so the row is `manual:` and declares. Value comparison rather than IL
+   inspection, deliberately: §6.2's whole point is one route per column, and a second route for
+   one member is the per-parameter judgement that rule exists to avoid. A collision — a machine
+   named after a legitimate default — costs one `manual:` declaration, which counts.
+2. **`TimeSpan.MaxValue` rendered as `922337203685477 ms`.**
+   `AzureServiceBusSubscriptionConfiguration.QueueIdleBeforeDelete` is `TimeSpan.MaxValue`, and
+   the canonical rendering says nothing to a reader. `Reflect.Accepted` — the method whose
+   docstring is *"presentation is not the subject"* — now also accepts the named form. It widens
+   what a correct table may write and changes no verdict.
+
+**Red-proved before either was trusted.** The probe gained **branch 7**, on a second fixture
+(`redproof/fixture_connection.md`), because the subscription fixture has no environment-derived
+member to declare. The mutation **deletes the `manual:` line** rather than writing a value: a
+branch that wrote this machine's hostname into a committed fixture would itself be
+machine-dependent, which is the defect it exists to prove. **9/9 branches fire**, re-run after
+the second change as well as the first.
+
+### AC8, walked
+
+**All 196 descriptions are one sentence, present tense, and state what the option does.** Swept
+mechanically as well as read: no cell contains *because*, *so that*, *should*, *prefer*,
+*recommend* or *note that*, none contains two sentences, all 196 open with a capital and end in
+a full stop — **196 cells, 0 faults**. Rationale sits in prose after the table where it was
+worth having: `MaxInFlightRequestsPerConnection` being `1` so a retry cannot re-order the
+stream, `queueType` existing only on the Async client, `MaxDeliveryCount` being the transport's
+count rather than Brighter's `requeueCount`, and PostgreSQL's three-step `null` → configuration
+→ `public` fallback.
+
+**Five things the tables say that no reader could have got from the pages' prose**, all from
+standing obligation 1's *the spelling the reader types*: `AmpqUri`, `BootStrapServers`,
+`SaslKerberosPrincipal`, Kafka's `numOfPartitions` reading back as `NumPartitions`, and
+PostgreSQL's request-type parameter being called **`dataType`** — the only transport in the
+corpus that does not call it `requestType`.
 
 ---
 

--- a/tools/optioncheck/Reflect.cs
+++ b/tools/optioncheck/Reflect.cs
@@ -168,12 +168,40 @@ internal static class Reflect
         // so what came back is the checker's own sentinel. Reporting it as a
         // default would be the tool documenting itself — the failure `manual:`
         // exists to declare instead.
-        return Sentinel(rendered)
-            ? new Member(name, declared, null,
+        if (Sentinel(rendered))
+            return new Member(name, declared, null,
                 "the value on the instance is the argument the checker had to supply for a "
-                + "required constructor parameter, not a default")
-            : new Member(name, declared, rendered, null);
+                + "required constructor parameter, not a default");
+
+        if (Environmental(value) is { } source)
+            return new Member(name, declared, null,
+                $"the default is {source}, so the value read back is this machine's and every "
+                + "other machine reads a different one — there is no portable value to print");
+
+        return new Member(name, declared, rendered, null);
     }
+
+    /// <summary>
+    /// A default the product takes from the environment rather than from itself.
+    /// `RmqMessagingGatewayConnection.Name` is `Environment.MachineName`, so the
+    /// tool reads a real default and still cannot say what a table should print:
+    /// a row carrying this machine's hostname is green here and red on the CI
+    /// runner. The tool *can* read the value and *cannot* determine the default,
+    /// which is the case `manual:` exists to declare — so this returns a reason
+    /// rather than a value.
+    ///
+    /// Value comparison rather than IL inspection, deliberately: the tool's one
+    /// route to a default is an instantiated object (§6.2), and adding a second
+    /// route for one member is the judgement-per-parameter that route exists to
+    /// avoid. The cost of a collision — a machine named after a legitimate
+    /// default — is one `manual:` declaration, which declares and counts.
+    /// </summary>
+    private static string? Environmental(object? value) => value switch
+    {
+        string s when s.Length > 0 && s == Environment.MachineName => "Environment.MachineName",
+        string s when s.Length > 0 && s == Environment.UserName => "Environment.UserName",
+        _ => null,
+    };
 
     /// <summary>
     /// The synthesiser's own arguments, deliberately distinctive so that a value
@@ -198,6 +226,12 @@ internal static class Reflect
             var span = TimeSpan.FromMilliseconds(ms);
             forms.Add(span.ToString());
             forms.Add($"TimeSpan.FromMilliseconds({ms.ToString("0.###", CultureInfo.InvariantCulture)})");
+
+            // `922337203685477 ms` is the canonical rendering of `TimeSpan.MaxValue`
+            // and says nothing to a reader. The named form documents the same
+            // product, which is what this method is for.
+            if (Math.Abs(ms - TimeSpan.MaxValue.TotalMilliseconds) < 1) forms.Add("TimeSpan.MaxValue");
+
             if (ms % 1000 == 0)
             {
                 var seconds = (ms / 1000).ToString("0.###", CultureInfo.InvariantCulture);


### PR DESCRIPTION
Phase 5 of spec 012, 7/7. **Sixteen tables and 196 rows** across six pages that already existed, taking the corpus to `26 tables, 276 rows, 26 types, on 10 pages of 148 files scanned`.

## What moved, and what did not

| Gate | Before | After |
|---|---|---|
| `linkcheck.py` | 151 | **151** |
| `pagelint.py` | 0 errors, 787 warnings, 149 pages | **unchanged** |
| `--check-shape` | 148 / 12 / widest 10 of 20 | **unchanged** |
| `--check-redirects` | 77 entries, 7858 bytes | **unchanged** |
| `versioncheck.py` | 0 stale of 18 across 5 | **unchanged** |
| `optioncheck` | 10 tables, 80 rows | **26 tables, 276 rows** |

No page is created, so none of the four page-count gates could move. The using-directive count did not move either, and that was bought rather than given: `pagelint --changed` reports **0 code blocks strict across 31 hunks**, so standing obligation 8's cheapest defence — put the table where the diff cannot reach a code block — held on all six pages.

## The ledger — ten entries

All ten were found by writing the correct table beside prose that was already there; nine were in bullet lists and the tenth in a table with no `Default` column. `optioncheck` found none of them, because it reads tables.

- **Kafka `BatchNumberMessages` documented as `10`; it is `10000`.** And `QueueBufferingMaxMessages` documented as `10`; it is `100000`.
- **Azure Service Bus `LockDuration` documented as defaulting to `true`.** It is a `TimeSpan` of one minute. `DefaultMessageTimeToLive` documented as one minute; it is three days.
- **The Kafka page's prose named `KafkaMessagingGatewayConnection`**, a type that has never existed, three lines above an example spelling `KafkaMessagingGatewayConfiguration` correctly. Also `SaslKerberosName` for `SaslKerberosPrincipal`, and `BootstrapServers` for `BootStrapServers`.
- **RabbitMQ's connection prose said `AmqpUri`**; the property is `AmpqUri` — the transposition is Brighter's, and the page's own examples had it right.
- **PostgreSQL documented `SchemaName` as defaulting to `"public"`** on both publication and subscription. It is `null` on both, and `public` is the last of three fallbacks. Its subscription table also used property spellings for a constructor-driven type.

`PostgreSQLMessageBroker.md`'s three tables are replaced rather than added to — §2.7's first row — and its third is now a one-row `PostgresMessagingGatewayConnection` table linking phase 4's page, which is D15 paying for itself one phase after it landed.

## Two forced changes to the checker

Both found by pointing it at types phase 4 never met, and the first is the first defect in this spec whose symptom is a **pass**:

1. **`RmqMessagingGatewayConnection.Name` is `= Environment.MachineName`.** The checker read it, rendered it `"Mac"`, and would have accepted a table saying so — green on the author's machine and red on the CI runner. It is now an `Unreadable` reason, so the row is `manual:` and declares.
2. **`TimeSpan.MaxValue` rendered as `922337203685477 ms`.** `Reflect.Accepted` — whose docstring is *"presentation is not the subject"* — now also accepts the named form.

**Red-proved before either was trusted.** The probe gained **branch 7** on a second fixture, because the subscription fixture has no environment-derived member. The mutation *deletes the `manual:` line* rather than writing a value: a branch that wrote this machine's hostname into a committed fixture would itself be machine-dependent, which is the defect it exists to prove. **9/9 branches fire**, re-run after both changes.

## Recorded and deliberately not fixed

`max(props, ctor)` is a settled selection, and its stated reason — *"on a subscription every property has a matching parameter"* — is **false on two of this phase's six types**: `KafkaSubscription` has four properties that are not parameters, `InMemorySubscription` has two. Public **fields** are invisible to it entirely (`AzureServiceBusSubscriptionConfiguration` has two, `AzureServiceBusPublication`'s only member is one).

Nothing was changed for this: the selection is what every count in the spec rests on. Each affected page names the missing options and their defaults in a sentence below its table, so no reader is misled, and the question goes to review. It is the first thing found in this spec that argues against an approved *decision* rather than against a figure.

*(It is also why the `SqlFilter` bullet on the Azure page was **not** corrected. It looked exactly like the `SaslKerberosName` defect and is not a defect at all — it is a public field. Verify the defect exists before fixing it, on a page where two neighbouring bullets were genuinely wrong.)*

## AC8, walked

**196 descriptions, 0 faults.** One sentence, present tense, no rationale — swept mechanically for *because*, *so that*, *should*, *prefer*, *recommend*, *note that*, two-sentence cells, missing capitals and missing full stops, and read. Rationale sits in prose after the table where it was worth having.

Full record in `spec/012-configuration_reference/tasks.md` under *Phase 5 as executed*, including why a transport table is the type's whole constructor rather than a delta, and the measured differences between each transport's generic and non-generic subscription.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0146UueHL6H3zGBGTYwz7GtL