### PR TITLE
012: the selection question, measured and answered, and Brighter#4285

### DIFF
--- a/spec/012-configuration_reference/tasks.md
+++ b/spec/012-configuration_reference/tasks.md
@@ -1139,10 +1139,65 @@ fields rather than properties, and `AzureServiceBusPublication`'s only member is
 spec rests on, and widening it to a case-insensitive union plus fields would move the corpus
 figure and every per-page figure with it. What phase 5 did instead is the disciplined half:
 each affected page names the missing options and their defaults in a sentence below its table,
-so no reader is misled, and **the question goes to review** — *should the reader-facing surface
-be the union of parameters, properties and public fields, deduplicated case-insensitively?*
-It is the first thing found in this spec that argues against an approved decision rather than
-against a figure.
+so no reader is misled.
+
+#### The question that raised, measured and answered — do not re-open it
+
+*Should the reader-facing surface be the union of parameters, properties and public fields,
+deduplicated case-insensitively?* Raised at phase 5 as the first thing in this spec that argues
+against an approved **decision** rather than against a figure, and **answered by measurement
+the same day: no, on both halves.** The measurement is here so nobody re-derives it.
+
+**Swept: all 26 marked types, phase 6's eleven, and — for fields — every one of the 72
+configuration types `survey.py` finds at `10.7.0`, by two independent instruments.**
+
+| | Union candidates | Of which false | Public mutable fields |
+|---|---:|---:|---:|
+| The 26 marked types | 9 across 4 types | **3** | — |
+| Phase 6's 11 types | 1 | — | **0** |
+| All 72, reflection **and** a source sweep | — | — | **6 across 4 types** |
+
+**Reject the union: a third of what it would add is a duplicate row.** The three false
+candidates are `NumPartitions`↔`numOfPartitions`, `Subscription`'s `MapRequestType`↔
+`getRequestType`, and `SqsPublication`'s `makeChannels`↔the base `Publication.MakeChannels`.
+Each names an option **the table already documents under its other spelling**, which is exactly
+the hazard requirements §7.1 exists to name — and against requirements §14's *a wrong default is
+worse than an absent one*, a second contradictory entry is worse than the gap. Doing it
+correctly needs a correspondence oracle — reading IL to learn which parameter assigns which
+property — which is the second route design §6.2 forbids. *(The false-positive rate is
+asymmetric by construction: properties are read `DeclaredOnly`, constructor parameters are not.
+Anyone writing a stray check should start there.)*
+
+**Reject including public fields, on the arithmetic.** Six exist across four types:
+
+| Type | Fields | Met by |
+|---|---|---|
+| `AzureServiceBusSubscriptionConfiguration` | `SqlFilter`, `UseServiceBusQueue` | phase 5, named in prose |
+| `AzureServiceBusPublication` | `UseServiceBusQueue` | phase 5, named in prose |
+| `AzureBlobLockingProviderOptions` | `StorageLocationFunc` | **phase 8 — owes the same sentence** |
+| `AzureBlobArchiveProviderOptions` | `TagsFunc`, `StorageLocationFunc` | P2, not scheduled |
+
+So **four rows in scope**, at the price of moving `Reflect.Describe`, `survey.py` and its
+reflection-oracle diff in lockstep, moving the corpus figure and every per-page figure, and
+forcing a mandatory one-row table onto `AzureServiceBusPublication` that design §10 says it
+should not have. **There is a cheaper path to the same end state**, and it is upstream: all six
+sit among properties in their own class and read as oversights, so
+**[Brighter#4285](https://github.com/BrighterCommand/Brighter/issues/4285)** asks for them to
+become properties. If it lands, the blind spot's exposure is zero and this tool needs no change
+at all.
+
+**Re-measure at phase 11, not before** — one sweep over the then-complete set of markers. The
+trigger to revisit is a type with *many* strays, or one stray a reader would never find in
+prose. Neither exists today.
+
+*(Three parse defects were made and caught inside this one measurement, all by controls rather
+than by review: `git grep -n` puts the line number in the third colon-field, so the first source
+sweep reported **0** for a field already read; a type token without spaces cannot match
+`Func<Message, string>`, **which is the identical defect `survey.py` shipped** and is recorded
+in this programme's lessons; and splitting on `=` before testing for `=>` let 90 expression-bodied
+properties in. Each was caught by asserting the sweep could still see something already known to
+be there. **Two instruments disagreeing about the same file is what made all three visible** —
+reflection said four fields, the source said three, and neither was right.)*
 
 *(This is also why the `SqlFilter` bullet on `AzureServiceBusConfiguration.md` was **not**
 corrected. It looked exactly like the Kafka `SaslKerberosName` defect below — a documented name


### PR DESCRIPTION
Phase 5 raised the first thing in spec 012 that argues against an approved **decision** rather than against a figure. This records the measurement that answers it. **No page changes — `spec/` only, so nothing published moves.**

## The question

`max(props, ctor)` selects a type's reader-facing surface, and `Reflect.cs` states why the union would be wrong: *"on a subscription every property has a matching parameter and the two differ only in case."* Phase 5 measured that as false on `KafkaSubscription` (four property-only options) and `InMemorySubscription` (two), with public **fields** invisible to it entirely.

## The measurement

Swept all 26 marked types, phase 6's eleven, and — for fields — all 72 configuration types, by **two independent instruments** (reflection over the pinned packages, and a source sweep of every `public` declaration in `src/`).

| | Union candidates | Of which false | Public mutable fields |
|---|---:|---:|---:|
| The 26 marked types | 9 across 4 types | **3** | — |
| Phase 6's 11 types | 1 | — | **0** |
| All 72, both instruments | — | — | **6 across 4 types** |

## The answer: no, on both halves

**The union is rejected because a third of what it adds is a duplicate.** The three false candidates are `NumPartitions`↔`numOfPartitions`, `Subscription`'s `MapRequestType`↔`getRequestType`, and `SqsPublication`'s `makeChannels`↔the base `Publication.MakeChannels`. Each names an option **the table already documents under its other spelling** — requirements §7.1's hazard exactly — and under §14's *a wrong default is worse than an absent one*, a second contradictory entry is worse than the gap. Getting it right needs a correspondence oracle (reading IL to learn which parameter assigns which property), the second route design §6.2 forbids.

**Fields are rejected on arithmetic.** Six exist, four are in scope: `AzureServiceBusSubscriptionConfiguration` (2) and `AzureServiceBusPublication` (1) were met in phase 5 and are named in prose; **`AzureBlobLockingProviderOptions.StorageLocationFunc` is phase 8's, and phase 8 now owes the same sentence**; `AzureBlobArchiveProviderOptions` (2) is P2. Four rows is not worth moving `Reflect.Describe`, `survey.py` and its oracle diff in lockstep, moving every count in the spec, and forcing a mandatory one-row table onto `AzureServiceBusPublication` that design §10 says it should not have.

**The cheaper path is upstream.** All six sit among properties in their own class and read as oversights, so [Brighter#4285](https://github.com/BrighterCommand/Brighter/issues/4285) asks for them to become properties — verified at `10.7.0` and on master, with no `ref`/`out` or reflect-by-name usage anywhere, so the change is source-compatible across that repository. If it lands, the exposure is zero and no tool here changes.

**Re-measure at phase 11, not before.** The trigger to revisit is a type with *many* strays, or one a reader would never find in prose. Neither exists today.

## Three parse defects, caught by controls rather than by review

Inside this one measurement: `git grep -n` puts the line number in the *third* colon-field, so the first source sweep reported **0** for a field already read on screen; a type token without spaces cannot match `Func<Message, string>` — **a verbatim repeat of a defect this programme already has recorded against `survey.py`** — so the second reported 3 where reflection said 4; and splitting on `=` before testing for `=>` admitted **90 expression-bodied properties** as fields.

None was found by reading the code. All three were found by asserting the sweep could still see a case already read with my own eyes, and by the two instruments disagreeing about the same files. Both are written up, because the rule to carry is narrower than *diff two instruments*: **make a sweep assert it can still find something you have already seen, before you read its total.**

Gates unmoved: `linkcheck` 151, `pagelint` 0 errors / 787 warnings / 149 pages, `optioncheck` 0 mismatches across 26 tables and 276 rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0146UueHL6H3zGBGTYwz7GtL