### PR TITLE
spec: 012 phase 6 — D12, the five new transport pages

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -69,6 +69,11 @@
 * [Azure Service Bus Configuration](/contents/AzureServiceBusConfiguration.md)
 * [PostgreSQL Message Broker](/contents/PostgreSQLMessageBroker.md)
   * [PostgreSQL Broker Trade-Offs](/contents/PostgreSQLBrokerTradeOffs.md)
+* [MSSQL Message Broker](/contents/MSSQLMessageBroker.md)
+* [GCP Pub/Sub Configuration](/contents/GcpPubSubConfiguration.md)
+* [RocketMQ Configuration](/contents/RocketMQConfiguration.md)
+* [MQTT Configuration](/contents/MQTTConfiguration.md)
+* [Redis Configuration](/contents/RedisConfiguration.md)
 * [InMemory Transport](/contents/InMemoryTransport.md)
 * [Brighter Control API](/contents/BrighterControlAPI.md)
 

--- a/contents/GcpPubSubConfiguration.md
+++ b/contents/GcpPubSubConfiguration.md
@@ -1,0 +1,196 @@
+---
+description: "Google Cloud Pub/Sub is a managed publish-subscribe service, and Brighter configures it with a gateway connection, a publication per topic, and a subscription per consumer."
+layout:
+  description:
+    visible: false
+---
+
+# GCP Pub/Sub Configuration
+
+> **Reference** · Applies to **Brighter V10** · Prerequisites: [Basic Configuration](/contents/BrighterBasicConfiguration.md)
+
+Google Cloud Pub/Sub is a managed publish-subscribe service, and Brighter configures it with a gateway connection, a publication per topic, and a subscription per consumer.
+
+## GCP Pub/Sub General
+
+Install the transport package:
+
+```bash
+dotnet add package Paramore.Brighter.MessagingGateway.GcpPubSub
+```
+
+Pub/Sub separates the **topic** a message is published to from the **subscription** a consumer
+reads. Brighter maps its `RoutingKey` onto the topic and its `ChannelName` onto the
+subscription, so one topic can feed several independent consumers, each with its own
+acknowledgement deadline and its own backlog.
+
+Two things are worth knowing before you configure it:
+
+- **The consumer runs in one of two modes.** `SubscriptionMode.Stream`, the default, opens a
+  streaming pull with the `SubscriberClient`; `SubscriptionMode.Pull` issues unary pull
+  requests instead. The `streamingConfiguration` option reaches the streaming client's builder
+  and does nothing in pull mode.
+- **Brighter creates the topic, the subscription and their IAM bindings** when `makeChannels`
+  is `OnMissingChannel.Create`. That includes granting the project's Pub/Sub service account
+  the publisher role on a dead letter topic, so the credential you supply needs permission to
+  read and set IAM policy on the topic if you use `deadLetter`.
+
+Credentials come from the connection's `Credential` property, and Google's default credential
+resolution applies when it is left null.
+
+## GCP Pub/Sub Connection
+
+`GcpMessagingGatewayConnection` holds the project and the credential, and hands the underlying
+Google client builders to you for anything Brighter does not expose. It takes its options as
+properties.
+
+<!-- optioncheck: Paramore.Brighter.MessagingGateway.GcpPubSub.GcpMessagingGatewayConnection -->
+
+| Option | Type | Default | Description |
+|---|---|---|---|
+| `Credential` | `ICredential?` | `null` | The credential used to authenticate with Pub/Sub; null falls back to Google's default credential resolution. |
+| `ProjectId` | `string` | `""` | The Google Cloud project topics and subscriptions are created in. |
+| `TopicManagerConfiguration` | `Action<PublisherServiceApiClientBuilder>?` | `null` | Configures the client Brighter uses to create, update and delete topics. |
+| `PublisherConfiguration` | `Action<PublisherClientBuilder>?` | `null` | Configures the client Brighter uses to publish messages. |
+| `SubscriptionManagerConfiguration` | `Action<SubscriberServiceApiClientBuilder>?` | `null` | Configures the client Brighter uses to create, update and delete subscriptions. |
+| `StreamConfiguration` | `Action<SubscriberClientBuilder>?` | `null` | Configures the client Brighter uses to consume messages. |
+| `ProjectsClientConfiguration` | `Action<ProjectsClientBuilder>?` | `null` | Configures the client Brighter uses to look up the project's service account. |
+
+## GCP Pub/Sub Publication
+
+`GcpPublication` takes its options as properties and adds these three to the
+[base publication options](/contents/CommandProcessorConfigurationReference.md#publication-options),
+which it inherits.
+
+<!-- optioncheck: Paramore.Brighter.MessagingGateway.GcpPubSub.GcpPublication -->
+
+| Option | Type | Default | Description |
+|---|---|---|---|
+| `TopicAttributes` | `TopicAttributes?` | `null` | The attributes applied to the topic when Brighter creates or updates it. |
+| `EnableMessageOrdering` | `bool` | `false` | Whether the publisher sends messages with an ordering key. |
+| `PublisherClientConfiguration` | `Action<PublisherClientBuilder>?` | `null` | Configures the publishing client for this topic alone. |
+
+`TopicAttributes` is a class rather than an option, and it carries the settings Pub/Sub applies
+to a topic at creation: `Name`, `ProjectId`, `Labels`, `MessageRetentionDuration`,
+`StorePolicy`, `SchemaSettings`, `KmsKeyName` and a `TopicConfiguration` action that reaches
+the underlying `Topic` object. The topic takes its name from the publication's `Topic` when
+`Name` is left empty.
+
+## GCP Pub/Sub Subscription
+
+`GcpPubSubSubscription` takes its options as constructor arguments, so the option is the
+parameter you type. The seventeen it shares with
+[`Subscription`](/contents/DispatcherConfigurationReference.md#subscription-options) behave the
+same way here; the other sixteen are Pub/Sub's own. At thirty-three parameters it is the widest
+subscription Brighter ships.
+
+<!-- optioncheck: Paramore.Brighter.MessagingGateway.GcpPubSub.GcpPubSubSubscription
+     manual: requestType — the constructor rejects its own default, so there is no default to read
+     manual: getRequestType — assigned to MapRequestType, and the body substitutes a function returning RequestType when it is null
+     manual: messagePumpType — the constructor rejects its own default of Unknown, so there is no default to read
+     manual: timeProvider — initialised to TimeProvider.System, which has no printable value
+-->
+
+| Option | Type | Default | Description |
+|---|---|---|---|
+| `subscriptionName` | `SubscriptionName` | `none` | Names the subscription for diagnostics; read back as `Name`. |
+| `channelName` | `ChannelName` | `none` | Names the Pub/Sub subscription this consumer reads. |
+| `routingKey` | `RoutingKey` | `none` | The Pub/Sub topic the subscription is attached to. |
+| `requestType` | `Type?` | `none` | The request type messages on this subscription are translated into. |
+| `getRequestType` | `Func<Message, Type>?` | derives the type from `requestType` | Determines the request type from the message rather than from the subscription. |
+| `bufferSize` | `int` | `1` | Messages read at once and held in the channel. |
+| `noOfPerformers` | `int` | `1` | Threads reading this subscription, each with its own message pump. |
+| `timeOut` | `TimeSpan?` | `300 ms` | How long a read waits before treating the channel as empty. |
+| `requeueCount` | `int` | `-1` | Times a message is requeued before it is treated as a poison pill; -1 is unlimited. |
+| `requeueDelay` | `TimeSpan?` | `0 ms` | How long delivery of a requeued message is delayed. |
+| `unacceptableMessageLimit` | `int` | `0` | Unacceptable messages before the channel stops; 0 disables the limit. |
+| `unacceptableMessageLimitWindow` | `TimeSpan?` | `null` | The window the unacceptable-message count resets at the end of. |
+| `messagePumpType` | `MessagePumpType` | `none` | Selects the Reactor or Proactor concurrency model. |
+| `channelFactory` | `IAmAChannelFactory?` | `null` | Creates the channel; a `GcpPubSubChannelFactory` is used when null. |
+| `makeChannels` | `OnMissingChannel` | `Create` | Whether Brighter creates missing infrastructure, validates it, or assumes it. |
+| `emptyChannelDelay` | `TimeSpan?` | `500 ms` | How long the pump pauses after a read that found no message. |
+| `channelFailureDelay` | `TimeSpan?` | `1000 ms` | How long the pump pauses after a channel failure. |
+| `projectId` | `string?` | `null` | The project this subscription and its topic live in; null uses the connection's project. |
+| `topicAttributes` | `TopicAttributes?` | `null` | The attributes applied to the topic when Brighter creates it for this subscription. |
+| `ackDeadlineSeconds` | `int` | `30` | Seconds the consumer has to acknowledge a message before Pub/Sub redelivers it. |
+| `retainAckedMessages` | `bool` | `false` | Whether Pub/Sub keeps acknowledged messages for replay. |
+| `messageRetentionDuration` | `TimeSpan?` | `null` | How long Pub/Sub retains an unacknowledged message. |
+| `labels` | `MapField<string, string>?` | `empty` | Labels attached to the subscription; Brighter adds a `source` label of `brighter`. |
+| `enableMessageOrdering` | `bool` | `false` | Whether messages published with an ordering key are delivered in order. |
+| `enableExactlyOnceDelivery` | `bool` | `false` | Whether Pub/Sub applies its exactly-once delivery guarantee to this subscription. |
+| `storage` | `CloudStorageConfig?` | `null` | The Cloud Storage bucket messages are exported to. |
+| `expirationPolicy` | `ExpirationPolicy?` | `null` | How long the subscription survives inactivity before Pub/Sub deletes it. |
+| `deadLetter` | `DeadLetterPolicy?` | `null` | The dead letter topic failed messages are forwarded to, and the attempts allowed first. |
+| `maxRequeueDelay` | `TimeSpan?` | `600000 ms` | The ceiling on the exponential backoff Pub/Sub applies between redeliveries. |
+| `timeProvider` | `TimeProvider?` | `TimeProvider.System` | The time source used for time-dependent operations such as purging. |
+| `subscriptionMode` | `SubscriptionMode` | `Stream` | Selects the streaming pull consumer or the unary pull consumer. |
+| `streamingConfiguration` | `Action<SubscriberClientBuilder>?` | `null` | Configures the streaming client for this subscription alone. |
+| `subscriberMember` | `string?` | `null` | The IAM member granted the subscriber role; null derives the project's Pub/Sub service account. |
+
+`DeadLetterPolicy` is a class rather than an option. It takes the dead letter topic and its
+subscription as constructor arguments and exposes `PublisherMember`, `SubscriberMember`,
+`AckDeadlineSeconds` (60) and `MaxDeliveryAttempts` (10) as properties.
+
+The generic form `GcpPubSubSubscription<T>` supplies `requestType` from `T` and takes the same
+options otherwise, apart from `streamingConfiguration`, which it does not expose. It still
+requires a subscription name, a channel name and a routing key, and it leaves `messagePumpType`
+required, so state Reactor or Proactor on every subscription.
+
+## GCP Pub/Sub Configuration Example
+
+```csharp
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Paramore.Brighter;
+using Paramore.Brighter.Extensions.DependencyInjection;
+using Paramore.Brighter.MessagingGateway.GcpPubSub;
+using Paramore.Brighter.ServiceActivator.Extensions.DependencyInjection;
+using Paramore.Brighter.ServiceActivator.Extensions.Hosting;
+
+var builder = Host.CreateApplicationBuilder(args);
+
+var connection = new GcpMessagingGatewayConnection { ProjectId = "my-project" };
+
+builder.Services.AddBrighter()
+    .AddProducers(configure =>
+    {
+        configure.ProducerRegistry = new GcpPubSubProducerRegistryFactory(
+            connection,
+            [
+                new GcpPublication
+                {
+                    Topic = new RoutingKey("greeting.event"),
+                    RequestType = typeof(GreetingEvent)
+                }
+            ]).Create();
+    })
+    .AutoFromAssemblies();
+
+builder.Services.AddConsumers(options =>
+{
+    options.Subscriptions =
+    [
+        new GcpPubSubSubscription<GreetingEvent>(
+            new SubscriptionName("paramore.example.greeting"),
+            new ChannelName("greeting.event"),
+            new RoutingKey("greeting.event"),
+            messagePumpType: MessagePumpType.Proactor,
+            ackDeadlineSeconds: 60,
+            subscriptionMode: SubscriptionMode.Stream)
+    ];
+    options.DefaultChannelFactory = new GcpPubSubChannelFactory(connection);
+});
+
+builder.Services.AddHostedService<ServiceActivatorHostedService>();
+
+var host = builder.Build();
+await host.RunAsync();
+```
+
+## Further Reading
+
+- [Basic Configuration](/contents/BrighterBasicConfiguration.md) — registering Brighter
+- [Dispatcher Configuration Reference](/contents/DispatcherConfigurationReference.md) — the subscription options every transport shares
+- [Command Processor Configuration Reference](/contents/CommandProcessorConfigurationReference.md) — the publication options every transport shares
+- [Reactor and Proactor](/contents/ReactorAndProactor.md) — choosing a message pump
+- [Error Handling Options](/contents/ErrorHandlingOptions.md) — what Brighter does with a message it cannot process

--- a/contents/MQTTConfiguration.md
+++ b/contents/MQTTConfiguration.md
@@ -1,0 +1,173 @@
+---
+description: "MQTT is a lightweight publish-subscribe protocol for constrained networks, and Brighter configures it with a gateway configuration for each side of the wire and a subscription per consumer."
+layout:
+  description:
+    visible: false
+---
+
+# MQTT Configuration
+
+> **Reference** · Applies to **Brighter V10** · Prerequisites: [Basic Configuration](/contents/BrighterBasicConfiguration.md)
+
+MQTT is a lightweight publish-subscribe protocol for constrained networks, and Brighter configures it with a gateway configuration for each side of the wire and a subscription per consumer.
+
+## MQTT General
+
+Install the transport package:
+
+```bash
+dotnet add package Paramore.Brighter.MessagingGateway.MQTT
+```
+
+Brighter speaks MQTT v3.1.1 through MQTTnet, publishing at **at-least-once** quality of
+service. Four things shape how you configure it:
+
+- **The topic prefix is required on the consumer.** `MqttMessageConsumer` subscribes to
+  `{TopicPrefix}/#` and throws when `TopicPrefix` is null, so a consumer reads every topic
+  beneath the prefix and Brighter routes by the message header from there. The publisher
+  prefixes the topic in the same way, and leaves it alone when `TopicPrefix` is null.
+- **Producers and consumers take different configuration types.**
+  `MqttMessagingGatewayProducerConfiguration` and `MqttMessagingGatewayConsumerConfiguration`
+  both derive from `MqttMessagingGatewayConfiguration` and add nothing to it; they exist so the
+  two sides can be registered separately.
+- **The package ships no producer registry factory**, so the registry is assembled from
+  `MqttMessagePublisher` and `MqttMessageProducer` directly, as in the example below.
+- **MQTT ships no publication type.** A producer takes the base
+  [`Publication`](/contents/CommandProcessorConfigurationReference.md#publication-options),
+  which is why there is no MQTT publication table here.
+
+## MQTT Configuration Options
+
+`MqttMessagingGatewayConfiguration` takes its options as properties, and the producer and
+consumer configurations inherit all of them.
+
+<!-- optioncheck: Paramore.Brighter.MessagingGateway.MQTT.MqttMessagingGatewayConfiguration -->
+
+| Option | Type | Default | Description |
+|---|---|---|---|
+| `ClientID` | `string?` | `null` | The client identifier the connection registers with the broker. |
+| `Username` | `string?` | `null` | The username the client authenticates with. |
+| `Password` | `string?` | `null` | The password the client authenticates with. |
+| `CleanSession` | `bool` | `false` | Whether the broker discards session state when the client connects. |
+| `Hostname` | `string?` | `null` | The host name of the MQTT broker. |
+| `Port` | `int` | `1883` | The TCP port the broker listens on. |
+| `TopicPrefix` | `object?` | `null` | The prefix joined to the message topic when publishing, and the root of the `#` subscription when consuming. |
+
+One further setting is declared on this type and is **not** on the table:
+`ConnectionAttempts` has an `internal` setter, so it cannot be set from your code. It is `1`,
+and it is the number of times the publisher and the consumer try to connect before giving up.
+
+## MQTT Subscription
+
+`MqttSubscription` takes its options as constructor arguments, so the option is the parameter
+you type. The seventeen it shares with
+[`Subscription`](/contents/DispatcherConfigurationReference.md#subscription-options) behave the
+same way here; the other two are Brighter's dead letter and invalid message routing keys, which
+this transport supports itself.
+
+<!-- optioncheck: Paramore.Brighter.MessagingGateway.MQTT.MqttSubscription
+     manual: requestType — the constructor rejects its own default, so there is no default to read
+     manual: getRequestType — assigned to MapRequestType, and the body substitutes a function returning RequestType when it is null
+     manual: messagePumpType — the constructor rejects its own default of Unknown, so there is no default to read
+-->
+
+| Option | Type | Default | Description |
+|---|---|---|---|
+| `subscriptionName` | `SubscriptionName` | `none` | Names the subscription for diagnostics; read back as `Name`. |
+| `channelName` | `ChannelName` | `none` | Names the channel this subscription reads. |
+| `routingKey` | `RoutingKey` | `none` | The topic messages on this channel carry in their header. |
+| `requestType` | `Type?` | `none` | The request type messages on this channel are translated into. |
+| `getRequestType` | `Func<Message, Type>?` | derives the type from `requestType` | Determines the request type from the message rather than from the channel. |
+| `bufferSize` | `int` | `1` | Messages taken from the client at once and held in the channel. |
+| `noOfPerformers` | `int` | `1` | Threads reading this channel, each with its own message pump. |
+| `timeOut` | `TimeSpan?` | `1000 ms` | How long a read waits before treating the channel as empty. |
+| `requeueCount` | `int` | `-1` | Times a message is requeued before it is treated as a poison pill; -1 is unlimited. |
+| `requeueDelay` | `TimeSpan?` | `0 ms` | How long delivery of a requeued message is delayed. |
+| `unacceptableMessageLimit` | `int` | `0` | Unacceptable messages before the channel stops; 0 disables the limit. |
+| `unacceptableMessageLimitWindow` | `TimeSpan?` | `null` | The window the unacceptable-message count resets at the end of. |
+| `messagePumpType` | `MessagePumpType` | `none` | Selects the Reactor or Proactor concurrency model. |
+| `channelFactory` | `IAmAChannelFactory?` | `null` | Creates the channel; supply a `ChannelFactory` over a `MqttMessageConsumerFactory`. |
+| `makeChannels` | `OnMissingChannel` | `Create` | Whether Brighter creates missing infrastructure, validates it, or assumes it. |
+| `emptyChannelDelay` | `TimeSpan?` | `500 ms` | How long the pump pauses after a read that found no message. |
+| `channelFailureDelay` | `TimeSpan?` | `1000 ms` | How long the pump pauses after a channel failure. |
+| `deadLetterRoutingKey` | `RoutingKey?` | `null` | The routing key messages are dead-lettered to. |
+| `invalidMessageRoutingKey` | `RoutingKey?` | `null` | The routing key unacceptable messages are routed to. |
+
+The generic form `MqttSubscription<T>` supplies `requestType` from `T` and defaults
+`subscriptionName`, `channelName` and `routingKey` to `T`'s full name. It also defaults
+`messagePumpType` to `Proactor`, where the non-generic form requires it.
+
+## MQTT Configuration Example
+
+```csharp
+using System.Collections.Generic;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Paramore.Brighter;
+using Paramore.Brighter.Extensions.DependencyInjection;
+using Paramore.Brighter.MessagingGateway.MQTT;
+using Paramore.Brighter.ServiceActivator.Extensions.DependencyInjection;
+using Paramore.Brighter.ServiceActivator.Extensions.Hosting;
+
+var builder = Host.CreateApplicationBuilder(args);
+
+var producerConfiguration = new MqttMessagingGatewayProducerConfiguration
+{
+    Hostname = "localhost",
+    Port = 1883,
+    ClientID = "greetings-sender",
+    TopicPrefix = "brighter"
+};
+
+var consumerConfiguration = new MqttMessagingGatewayConsumerConfiguration
+{
+    Hostname = "localhost",
+    Port = 1883,
+    ClientID = "greetings-receiver",
+    TopicPrefix = "brighter"
+};
+
+var routingKey = new RoutingKey("greeting.event");
+
+builder.Services.AddBrighter()
+    .AddProducers(configure =>
+    {
+        var publisher = new MqttMessagePublisher(producerConfiguration);
+        var producer = new MqttMessageProducer(
+            publisher,
+            new Publication { Topic = routingKey, RequestType = typeof(GreetingEvent) });
+
+        configure.ProducerRegistry = new ProducerRegistry(
+            new Dictionary<ProducerKey, IAmAMessageProducer>
+            {
+                [new ProducerKey(routingKey)] = producer
+            });
+    })
+    .AutoFromAssemblies();
+
+builder.Services.AddConsumers(options =>
+{
+    options.Subscriptions =
+    [
+        new MqttSubscription<GreetingEvent>(
+            new SubscriptionName("paramore.example.greeting"),
+            new ChannelName("greeting.event"),
+            routingKey)
+    ];
+    options.DefaultChannelFactory = new ChannelFactory(
+        new MqttMessageConsumerFactory(consumerConfiguration));
+});
+
+builder.Services.AddHostedService<ServiceActivatorHostedService>();
+
+var host = builder.Build();
+await host.RunAsync();
+```
+
+## Further Reading
+
+- [Basic Configuration](/contents/BrighterBasicConfiguration.md) — registering Brighter
+- [Dispatcher Configuration Reference](/contents/DispatcherConfigurationReference.md) — the subscription options every transport shares
+- [Command Processor Configuration Reference](/contents/CommandProcessorConfigurationReference.md) — the publication options every transport shares
+- [Reactor and Proactor](/contents/ReactorAndProactor.md) — choosing a message pump
+- [Error Handling Options](/contents/ErrorHandlingOptions.md) — what Brighter does with a message it cannot process

--- a/contents/MSSQLMessageBroker.md
+++ b/contents/MSSQLMessageBroker.md
@@ -1,0 +1,166 @@
+---
+description: "The MSSQL message broker turns a SQL Server table into a queue, so an application that already has a database can send messages between processes without adding a broker to its infrastructure."
+layout:
+  description:
+    visible: false
+---
+
+# MSSQL Message Broker
+
+> **Reference** · Applies to **Brighter V10** · Prerequisites: [Basic Configuration](/contents/BrighterBasicConfiguration.md)
+
+The MSSQL message broker turns a SQL Server table into a queue, so an application that already has a database can send messages between processes without adding a broker to its infrastructure.
+
+## MSSQL Message Broker Overview
+
+Install the transport package:
+
+```bash
+dotnet add package Paramore.Brighter.MessagingGateway.MsSql
+```
+
+A producer inserts a row carrying the topic, the message type and the payload; a consumer
+reads the oldest row for its topic and deletes it. That is the whole mechanism, and it is the
+same idea as the [PostgreSQL Message Broker](/contents/PostgreSQLMessageBroker.md), with the
+same trade-offs — [PostgreSQL Broker Trade-Offs](/contents/PostgreSQLBrokerTradeOffs.md)
+applies here too.
+
+**A queue table beats a broker in one situation and loses in most others.** It wins when you
+cannot add infrastructure — a customer's estate you do not control — and the message volume is
+low: the queue is transactional with the work that produced it, it survives a reboot, and
+several producers and consumers can share a topic. It loses on throughput, on fan-out, and on
+everything a broker gives you for free, because every read is a query and every consumer polls.
+
+Brighter does not create the queue table. Create it before you start, with the columns the
+transport expects:
+
+```sql
+CREATE TABLE [dbo].[QueueData](
+    [Id] [bigint] IDENTITY(1,1) NOT NULL,
+    [Topic] [nvarchar](255) NOT NULL,
+    [MessageType] [nvarchar](1024) NOT NULL,
+    [Payload] [nvarchar](max) NOT NULL,
+    CONSTRAINT [PK_QueueData] PRIMARY KEY CLUSTERED ([Id] ASC)
+);
+
+CREATE NONCLUSTERED INDEX [IX_Topic] ON [dbo].[QueueData] ([Topic] ASC);
+```
+
+## MSSQL Message Broker Connection
+
+**This transport has no connection type and no publication type of its own.** Both the
+producer registry factory and the consumer factory take a
+`RelationalDatabaseConfiguration`, the same type the relational Outbox and Inbox take, and the
+producer registry factory takes base
+[`Publication`](/contents/CommandProcessorConfigurationReference.md#publication-options)
+objects.
+
+Its eight options are documented once, at
+[Relational Database Configuration Reference](/contents/RelationalDatabaseConfigurationReference.md),
+because seventeen Brighter components share them. Two of them matter here:
+`queueStoreTable` names the table above and **the producer registry factory throws when it is
+empty**, and `connectionString` reaches SQL Server.
+
+## MSSQL Message Broker Subscription
+
+`MsSqlSubscription` takes its options as constructor arguments, so the option is the parameter
+you type. The seventeen it shares with
+[`Subscription`](/contents/DispatcherConfigurationReference.md#subscription-options) behave the
+same way here; the other two are Brighter's dead letter and invalid message routing keys.
+
+<!-- optioncheck: Paramore.Brighter.MessagingGateway.MsSql.MsSqlSubscription
+     manual: requestType — the constructor rejects its own default, so there is no default to read
+     manual: getRequestType — assigned to MapRequestType, and the body substitutes a function returning RequestType when it is null
+-->
+
+| Option | Type | Default | Description |
+|---|---|---|---|
+| `subscriptionName` | `SubscriptionName` | `none` | Names the subscription for diagnostics; read back as `Name`. |
+| `channelName` | `ChannelName` | `none` | Names the channel this subscription reads. |
+| `routingKey` | `RoutingKey` | `none` | The topic the consumer reads rows for. |
+| `requestType` | `Type?` | `none` | The request type messages on this channel are translated into. |
+| `getRequestType` | `Func<Message, Type>?` | derives the type from `requestType` | Determines the request type from the message rather than from the channel. |
+| `bufferSize` | `int` | `1` | Rows read at once and held in the channel. |
+| `noOfPerformers` | `int` | `1` | Threads reading this topic, each with its own message pump. |
+| `timeOut` | `TimeSpan?` | `300 ms` | How long a read waits before treating the channel as empty. |
+| `requeueCount` | `int` | `-1` | Times a message is requeued before it is treated as a poison pill; -1 is unlimited. |
+| `requeueDelay` | `TimeSpan?` | `0 ms` | How long delivery of a requeued message is delayed. |
+| `unacceptableMessageLimit` | `int` | `0` | Unacceptable messages before the channel stops; 0 disables the limit. |
+| `unacceptableMessageLimitWindow` | `TimeSpan?` | `null` | The window the unacceptable-message count resets at the end of. |
+| `messagePumpType` | `MessagePumpType` | `Proactor` | Selects the Reactor or Proactor concurrency model. |
+| `channelFactory` | `IAmAChannelFactory?` | `null` | Creates the channel; supply a `ChannelFactory` over a `MsSqlMessageConsumerFactory`. |
+| `makeChannels` | `OnMissingChannel` | `Create` | Whether Brighter creates missing infrastructure, validates it, or assumes it. |
+| `emptyChannelDelay` | `TimeSpan?` | `500 ms` | How long the pump pauses after a read that found no message. |
+| `channelFailureDelay` | `TimeSpan?` | `1000 ms` | How long the pump pauses after a channel failure. |
+| `deadLetterRoutingKey` | `RoutingKey?` | `null` | The routing key messages are dead-lettered to. |
+| `invalidMessageRoutingKey` | `RoutingKey?` | `null` | The routing key unacceptable messages are routed to. |
+
+`messagePumpType` has a usable default here, which is unusual: eleven of Brighter's thirteen
+subscription types reject their declared default and make the parameter required. This package
+supports one pump, so the parameter defaults to `Proactor`.
+
+The generic form `MsSqlSubscription<T>` supplies `requestType` from `T` and defaults
+`subscriptionName`, `channelName` and `routingKey` to `T`'s full name.
+
+## MSSQL Message Broker Configuration Example
+
+```csharp
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Paramore.Brighter;
+using Paramore.Brighter.Extensions.DependencyInjection;
+using Paramore.Brighter.MessagingGateway.MsSql;
+using Paramore.Brighter.ServiceActivator.Extensions.DependencyInjection;
+using Paramore.Brighter.ServiceActivator.Extensions.Hosting;
+
+var builder = Host.CreateApplicationBuilder(args);
+
+var configuration = new RelationalDatabaseConfiguration(
+    @"Database=BrighterSqlQueue;Server=.\sqlexpress;Integrated Security=SSPI;",
+    databaseName: "BrighterSqlQueue",
+    queueStoreTable: "QueueData");
+
+builder.Services.AddBrighter()
+    .AddProducers(configure =>
+    {
+        configure.ProducerRegistry = new MsSqlProducerRegistryFactory(
+            configuration,
+            [
+                new Publication
+                {
+                    Topic = new RoutingKey("greeting.event"),
+                    RequestType = typeof(GreetingEvent)
+                }
+            ]).Create();
+    })
+    .AutoFromAssemblies();
+
+builder.Services.AddConsumers(options =>
+{
+    options.Subscriptions =
+    [
+        new MsSqlSubscription<GreetingEvent>(
+            new SubscriptionName("paramore.example.greeting"),
+            new ChannelName("greeting.event"),
+            new RoutingKey("greeting.event"))
+    ];
+    options.DefaultChannelFactory = new ChannelFactory(
+        new MsSqlMessageConsumerFactory(configuration));
+});
+
+builder.Services.AddHostedService<ServiceActivatorHostedService>();
+
+var host = builder.Build();
+await host.RunAsync();
+```
+
+A working pair of programs in this shape is in the Brighter repository at
+`samples/TaskQueue/MsSqlMessagingGateway`.
+
+## Further Reading
+
+- [PostgreSQL Message Broker](/contents/PostgreSQLMessageBroker.md) — the same idea on PostgreSQL, with visibility timeouts
+- [PostgreSQL Broker Trade-Offs](/contents/PostgreSQLBrokerTradeOffs.md) — when a queue table is the right answer, and when it is not
+- [Relational Database Configuration Reference](/contents/RelationalDatabaseConfigurationReference.md) — the eight options this transport shares with the relational stores
+- [Dispatcher Configuration Reference](/contents/DispatcherConfigurationReference.md) — the subscription options every transport shares
+- [MSSQL Outbox](/contents/MSSQLOutbox.md) — the same database as a transactional Outbox

--- a/contents/RedisConfiguration.md
+++ b/contents/RedisConfiguration.md
@@ -1,0 +1,174 @@
+---
+description: "Brighter's Redis transport turns a Redis list into a queue, and configures it with a gateway configuration shared by producers and consumers and a subscription per consumer."
+layout:
+  description:
+    visible: false
+---
+
+# Redis Configuration
+
+> **Reference** · Applies to **Brighter V10** · Prerequisites: [Basic Configuration](/contents/BrighterBasicConfiguration.md)
+
+Brighter's Redis transport turns a Redis list into a queue, and configures it with a gateway configuration shared by producers and consumers and a subscription per consumer.
+
+## Redis General
+
+Install the transport package:
+
+```bash
+dotnet add package Paramore.Brighter.MessagingGateway.Redis
+```
+
+Brighter stores each message body under a key and pushes its id onto a list per topic, so a
+consumer pops an id and reads the body back. The transport is built on **ServiceStack.Redis**,
+and three consequences follow from that:
+
+- **The connection string is ServiceStack's**, not `StackExchange.Redis`'s. It is set on
+  `RedisConnectionString`, and it accepts ServiceStack's query-string options —
+  `localhost:6379?connectTimeout=1&sendTimeout=1000&`.
+- **Most of the configuration sets ServiceStack's static `RedisConfig`**, so it is
+  process-wide rather than per-gateway. Brighter applies a value only when you supply one; a
+  null leaves ServiceStack's own default in place, which is why every default in the table
+  below is `null`.
+- **A message body is reclaimed independently of its queue entry.** `MessageTimeToLive` sets
+  how long the body survives, and an id that outlives its body is rejected when it is read.
+
+Redis ships a publication type, `RedisMessagePublication`, but it adds no option of its own —
+it exists so the producer registry factory can be typed, and everything on it is a
+[base publication option](/contents/CommandProcessorConfigurationReference.md#publication-options).
+There is no Redis publication table below for that reason.
+
+## Redis Configuration Options
+
+`RedisMessagingGatewayConfiguration` takes its options as properties, and both the producer
+registry factory and the consumer factory take one.
+
+<!-- optioncheck: Paramore.Brighter.MessagingGateway.Redis.RedisMessagingGatewayConfiguration -->
+
+| Option | Type | Default | Description |
+|---|---|---|---|
+| `DefaultConnectTimeout` | `int?` | `null` | The socket connect timeout in milliseconds. |
+| `DefaultSendTimeout` | `int?` | `null` | The socket send timeout in milliseconds. |
+| `DefaultReceiveTimeout` | `int?` | `null` | The socket receive timeout in milliseconds. |
+| `DefaultIdleTimeOutSecs` | `int?` | `null` | The seconds a pooled connection may idle before it is treated as stale. |
+| `DefaultRetryTimeout` | `int?` | `null` | The milliseconds a failed operation is retried for. |
+| `BufferPoolMaxSize` | `int?` | `null` | The size in bytes of the buffer pool operations draw from. |
+| `VerifyMasterConnections` | `bool?` | `null` | Whether connections to master hosts are re-verified as still being masters. |
+| `HostLookupTimeoutMs` | `int?` | `null` | The connect timeout in milliseconds used when finding the next available host. |
+| `DeactivatedClientsExpiry` | `TimeSpan?` | `null` | How long a deactivated client is held before its connection is disposed. |
+| `DisableVerboseLogging` | `bool?` | `null` | Whether detailed Redis operations are kept out of debug logging. |
+| `BackoffMultiplier` | `int?` | `null` | The exponential backoff interval in milliseconds between connection retries. |
+| `MaxPoolSize` | `int?` | `null` | The largest number of connections this gateway's pool holds. |
+| `MessageTimeToLive` | `TimeSpan?` | `null` | How long a message body persists in Redis before it is reclaimed. |
+| `RedisConnectionString` | `string?` | `null` | The ServiceStack connection string the gateway connects with. |
+
+One further setting is declared on this type and is **not** on the table:
+`AssumeServerVersion` is `static`, so it is set once for the process rather than per gateway,
+and it skips ServiceStack's server-version check by naming a minimum version as an integer —
+`2.8.12` is `2812`.
+
+## Redis Subscription
+
+`RedisSubscription` takes its options as constructor arguments, so the option is the parameter
+you type. The seventeen it shares with
+[`Subscription`](/contents/DispatcherConfigurationReference.md#subscription-options) behave the
+same way here; the other two are Brighter's dead letter and invalid message routing keys, which
+Redis supports rather than delegating to the broker.
+
+<!-- optioncheck: Paramore.Brighter.MessagingGateway.Redis.RedisSubscription
+     manual: requestType — the constructor rejects its own default, so there is no default to read
+     manual: getRequestType — assigned to MapRequestType, and the body substitutes a function returning RequestType when it is null
+     manual: messagePumpType — the constructor rejects its own default of Unknown, so there is no default to read
+-->
+
+| Option | Type | Default | Description |
+|---|---|---|---|
+| `subscriptionName` | `SubscriptionName` | `none` | Names the subscription for diagnostics; read back as `Name`. |
+| `channelName` | `ChannelName` | `none` | Names the Redis list this consumer pops ids from. |
+| `routingKey` | `RoutingKey` | `none` | The topic the channel subscribes to. |
+| `requestType` | `Type?` | `none` | The request type messages on this channel are translated into. |
+| `getRequestType` | `Func<Message, Type>?` | derives the type from `requestType` | Determines the request type from the message rather than from the channel. |
+| `bufferSize` | `int` | `1` | Messages read from the list at once and held in the channel. |
+| `noOfPerformers` | `int` | `1` | Threads reading this channel, each with its own message pump. |
+| `timeOut` | `TimeSpan?` | `1000 ms` | How long a read waits before treating the channel as empty. |
+| `requeueCount` | `int` | `-1` | Times a message is requeued before it is treated as a poison pill; -1 is unlimited. |
+| `requeueDelay` | `TimeSpan?` | `0 ms` | How long delivery of a requeued message is delayed. |
+| `unacceptableMessageLimit` | `int` | `0` | Unacceptable messages before the channel stops; 0 disables the limit. |
+| `unacceptableMessageLimitWindow` | `TimeSpan?` | `null` | The window the unacceptable-message count resets at the end of. |
+| `messagePumpType` | `MessagePumpType` | `none` | Selects the Reactor or Proactor concurrency model. |
+| `channelFactory` | `IAmAChannelFactory?` | `null` | Creates the channel; supply a `ChannelFactory` over a `RedisMessageConsumerFactory`. |
+| `makeChannels` | `OnMissingChannel` | `Create` | Whether Brighter creates missing infrastructure, validates it, or assumes it. |
+| `emptyChannelDelay` | `TimeSpan?` | `500 ms` | How long the pump pauses after a read that found no message. |
+| `channelFailureDelay` | `TimeSpan?` | `1000 ms` | How long the pump pauses after a channel failure. |
+| `deadLetterRoutingKey` | `RoutingKey?` | `null` | The routing key messages are dead-lettered to. |
+| `invalidMessageRoutingKey` | `RoutingKey?` | `null` | The routing key unacceptable messages are routed to. |
+
+The generic form `RedisSubscription<T>`, which the sample uses, supplies `requestType` from `T`
+and defaults `subscriptionName`, `channelName` and `routingKey` to `T`'s full name. It also
+defaults `messagePumpType` to `Proactor`, where the non-generic form requires it.
+
+## Redis Configuration Example
+
+```csharp
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Paramore.Brighter;
+using Paramore.Brighter.Extensions.DependencyInjection;
+using Paramore.Brighter.MessagingGateway.Redis;
+using Paramore.Brighter.ServiceActivator.Extensions.DependencyInjection;
+using Paramore.Brighter.ServiceActivator.Extensions.Hosting;
+
+var builder = Host.CreateApplicationBuilder(args);
+
+var redisConnection = new RedisMessagingGatewayConfiguration
+{
+    RedisConnectionString = "localhost:6379?connectTimeout=1&sendTimeout=1000&",
+    MaxPoolSize = 10,
+    MessageTimeToLive = TimeSpan.FromMinutes(10)
+};
+
+builder.Services.AddBrighter()
+    .AddProducers(configure =>
+    {
+        configure.ProducerRegistry = new RedisProducerRegistryFactory(
+            redisConnection,
+            [
+                new RedisMessagePublication
+                {
+                    Topic = new RoutingKey("greeting.event"),
+                    RequestType = typeof(GreetingEvent)
+                }
+            ]).Create();
+    })
+    .AutoFromAssemblies();
+
+builder.Services.AddConsumers(options =>
+{
+    options.Subscriptions =
+    [
+        new RedisSubscription<GreetingEvent>(
+            new SubscriptionName("paramore.example.greeting"),
+            new ChannelName("greeting.event"),
+            new RoutingKey("greeting.event"),
+            timeOut: TimeSpan.FromSeconds(1))
+    ];
+    options.DefaultChannelFactory = new ChannelFactory(
+        new RedisMessageConsumerFactory(redisConnection));
+});
+
+builder.Services.AddHostedService<ServiceActivatorHostedService>();
+
+var host = builder.Build();
+await host.RunAsync();
+```
+
+A working pair of programs in this shape is in the Brighter repository at
+`samples/TaskQueue/RedisTaskQueue`.
+
+## Further Reading
+
+- [Basic Configuration](/contents/BrighterBasicConfiguration.md) — registering Brighter
+- [Dispatcher Configuration Reference](/contents/DispatcherConfigurationReference.md) — the subscription options every transport shares
+- [Command Processor Configuration Reference](/contents/CommandProcessorConfigurationReference.md) — the publication options every transport shares
+- [Reactor and Proactor](/contents/ReactorAndProactor.md) — choosing a message pump
+- [Error Handling Options](/contents/ErrorHandlingOptions.md) — what Brighter does with a message it cannot process

--- a/contents/RelationalDatabaseConfigurationReference.md
+++ b/contents/RelationalDatabaseConfigurationReference.md
@@ -61,7 +61,7 @@ Seventeen, across four families, measured at `10.7.0` by looking for
 | Inbox | Spanner | not yet documented |
 | Box provisioning | MSSQL, MySQL, PostgreSQL, SQLite, Spanner | [Configuring Box Provisioning](/contents/BoxProvisioningConfiguration.md) |
 | Transport | PostgreSQL | [PostgreSQL Message Broker](/contents/PostgreSQLMessageBroker.md) |
-| Transport | MSSQL | not yet documented |
+| Transport | MSSQL | [MSSQL Message Broker](/contents/MSSQLMessageBroker.md) |
 
 **The two transports are the entries to know about.** A queue-table transport is not an
 Outbox, and it is easy to assume the relational configuration reaches only the box packages —

--- a/contents/RocketMQConfiguration.md
+++ b/contents/RocketMQConfiguration.md
@@ -1,0 +1,189 @@
+---
+description: "Apache RocketMQ is a distributed messaging platform, and Brighter configures it with a gateway connection wrapping the RocketMQ client, a publication per topic, and a subscription per consumer group."
+layout:
+  description:
+    visible: false
+---
+
+# RocketMQ Configuration
+
+> **Reference** · Applies to **Brighter V10** · Prerequisites: [Basic Configuration](/contents/BrighterBasicConfiguration.md)
+
+Apache RocketMQ is a distributed messaging platform, and Brighter configures it with a gateway connection wrapping the RocketMQ client, a publication per topic, and a subscription per consumer group.
+
+## RocketMQ General
+
+Install the transport package:
+
+```bash
+dotnet add package Paramore.Brighter.MessagingGateway.RocketMQ
+```
+
+Brighter publishes to a RocketMQ **topic** and consumes with a `SimpleConsumer` in a **consumer
+group**, filtering by tag. Three things shape how you configure it:
+
+- **Brighter cannot create a RocketMQ topic.** The RocketMQ C# client has no administrative
+  API, so a publication with `MakeChannels` set to `Create` logs a warning and carries on.
+  Provision topics and consumer groups with the RocketMQ tooling, and set `makeChannels` to
+  `OnMissingChannel.Assume`.
+- **The consumer group is a subscription option, and it has no usable default.** It defaults to
+  an empty string, which RocketMQ rejects, so set `consumerGroup` on every subscription.
+- **The endpoint lives on the RocketMQ client's own configuration**, not on a Brighter option.
+  `RocketMessagingGatewayConnection` takes an `Org.Apache.Rocketmq.ClientConfig` as its
+  constructor argument and exposes it as the get-only `ClientConfig` property, so the endpoint,
+  TLS and request timeout are set with `ClientConfig.Builder()` and are not in the table below.
+
+The consumer requires a `RocketSubscription`; a base `Subscription` raises a
+`ConfigurationException` when the channel is created.
+
+## RocketMQ Connection
+
+`RocketMessagingGatewayConnection` takes its options as properties, alongside the
+`ClientConfig` it is constructed with.
+
+<!-- optioncheck: Paramore.Brighter.MessagingGateway.RocketMQ.RocketMessagingGatewayConnection
+     manual: TimerProvider — initialised to TimeProvider.System, which has no printable value
+-->
+
+| Option | Type | Default | Description |
+|---|---|---|---|
+| `TimerProvider` | `TimeProvider` | `TimeProvider.System` | The time source used for delayed and time-dependent operations. |
+| `MaxAttempts` | `int` | `3` | Attempts the producer makes to deliver a message. |
+| `Checker` | `ITransactionChecker?` | `null` | The callback RocketMQ uses to resolve the state of a half-committed transactional message. |
+| `Instrumentation` | `InstrumentationOptions` | `All` | The telemetry detail producers and consumers emit. |
+
+The property is spelled `TimerProvider`, with an `r`, where the rest of Brighter spells it
+`TimeProvider`.
+
+## RocketMQ Publication
+
+`RocketMqPublication` takes its options as properties and adds these three to the
+[base publication options](/contents/CommandProcessorConfigurationReference.md#publication-options),
+which it inherits.
+
+<!-- optioncheck: Paramore.Brighter.MessagingGateway.RocketMQ.RocketMqPublication -->
+
+| Option | Type | Default | Description |
+|---|---|---|---|
+| `Tag` | `string?` | `null` | The tag messages are published with, which consumers filter on. |
+| `Instrumentation` | `InstrumentationOptions?` | `null` | The telemetry detail this publication emits; null uses the connection's setting. |
+| `TopicType` | `TopicType` | `Normal` | Selects a normal, delay or FIFO topic. |
+
+## RocketMQ Subscription
+
+The non-generic subscription type is `RocketSubscription`, and it takes its options as
+constructor arguments, so the option is the parameter you type. The seventeen it shares with
+[`Subscription`](/contents/DispatcherConfigurationReference.md#subscription-options) behave the
+same way here; the other six are RocketMQ's own, plus Brighter's dead letter and invalid
+message routing keys.
+
+<!-- optioncheck: Paramore.Brighter.MessagingGateway.RocketMQ.RocketSubscription
+     manual: requestType — the constructor rejects its own default, so there is no default to read
+     manual: getRequestType — assigned to MapRequestType, and the body substitutes a function returning RequestType when it is null
+     manual: messagePumpType — the constructor rejects its own default of Unknown, so there is no default to read
+     manual: filter — initialised to a FilterExpression of *, which has no printable value
+-->
+
+| Option | Type | Default | Description |
+|---|---|---|---|
+| `subscriptionName` | `SubscriptionName` | `none` | Names the subscription for diagnostics; read back as `Name`. |
+| `channelName` | `ChannelName` | `none` | Names the channel this subscription reads. |
+| `routingKey` | `RoutingKey` | `none` | The RocketMQ topic the consumer subscribes to. |
+| `requestType` | `Type?` | `none` | The request type messages on this topic are translated into. |
+| `getRequestType` | `Func<Message, Type>?` | derives the type from `requestType` | Determines the request type from the message rather than from the topic. |
+| `consumerGroup` | `string?` | `""` | The RocketMQ consumer group this consumer joins. |
+| `bufferSize` | `int` | `1` | Messages received at once and held in the channel. |
+| `noOfPerformers` | `int` | `1` | Threads reading this topic, each with its own message pump. |
+| `timeOut` | `TimeSpan?` | `300 ms` | How long a read waits before treating the channel as empty. |
+| `requeueCount` | `int` | `-1` | Times a message is requeued before it is treated as a poison pill; -1 is unlimited. |
+| `requeueDelay` | `TimeSpan?` | `0 ms` | How long delivery of a requeued message is delayed. |
+| `unacceptableMessageLimit` | `int` | `0` | Unacceptable messages before the channel stops; 0 disables the limit. |
+| `unacceptableMessageLimitWindow` | `TimeSpan?` | `null` | The window the unacceptable-message count resets at the end of. |
+| `messagePumpType` | `MessagePumpType` | `none` | Selects the Reactor or Proactor concurrency model. |
+| `channelFactory` | `IAmAChannelFactory?` | `null` | Creates the channel; supply a `RocketMqChannelFactory` over a `RocketMessageConsumerFactory`. |
+| `makeChannels` | `OnMissingChannel` | `Create` | Whether Brighter creates missing infrastructure, validates it, or assumes it. |
+| `filter` | `FilterExpression?` | every tag | The tag expression the consumer subscribes with. |
+| `emptyChannelDelay` | `TimeSpan?` | `500 ms` | How long the pump pauses after a read that found no message. |
+| `channelFailureDelay` | `TimeSpan?` | `1000 ms` | How long the pump pauses after a channel failure. |
+| `receiveMessageTimeout` | `TimeSpan?` | `60000 ms` | How long a receive call waits at the broker before returning empty. |
+| `invisibilityTimeout` | `TimeSpan?` | `30000 ms` | How long a received message is hidden from other consumers in the group. |
+| `deadLetterRoutingKey` | `RoutingKey?` | `null` | The routing key messages are dead-lettered to. |
+| `invalidMessageRoutingKey` | `RoutingKey?` | `null` | The routing key unacceptable messages are routed to. |
+
+The generic form is spelled differently from the non-generic one: `RocketMqSubscription<T>`
+derives from `RocketSubscription`. It supplies `requestType` from `T` and takes the same options
+otherwise. It still requires a subscription name, a channel name and a routing key, and it
+leaves `messagePumpType` required, so state Reactor or Proactor on every subscription.
+
+## RocketMQ Configuration Example
+
+RocketMQ ships a message producer factory rather than a producer registry factory, so the
+registry is built from the factory's dictionary.
+
+```csharp
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Org.Apache.Rocketmq;
+using Paramore.Brighter;
+using Paramore.Brighter.Extensions.DependencyInjection;
+using Paramore.Brighter.MessagingGateway.RocketMQ;
+using Paramore.Brighter.ServiceActivator.Extensions.DependencyInjection;
+using Paramore.Brighter.ServiceActivator.Extensions.Hosting;
+
+var builder = Host.CreateApplicationBuilder(args);
+
+var connection = new RocketMessagingGatewayConnection(
+    new ClientConfig.Builder()
+        .SetEndpoints("localhost:8081")
+        .EnableSsl(false)
+        .SetRequestTimeout(TimeSpan.FromSeconds(10))
+        .Build());
+
+var publications = new[]
+{
+    new RocketMqPublication
+    {
+        Topic = new RoutingKey("greeting.event"),
+        RequestType = typeof(GreetingEvent),
+        TopicType = TopicType.Normal,
+        MakeChannels = OnMissingChannel.Assume
+    }
+};
+
+builder.Services.AddBrighter()
+    .AddProducers(configure =>
+    {
+        configure.ProducerRegistry = new ProducerRegistry(
+            new RocketMessageProducerFactory(connection, publications).Create());
+    })
+    .AutoFromAssemblies();
+
+builder.Services.AddConsumers(options =>
+{
+    options.Subscriptions =
+    [
+        new RocketMqSubscription<GreetingEvent>(
+            new SubscriptionName("paramore.example.greeting"),
+            new ChannelName("greeting.event"),
+            new RoutingKey("greeting.event"),
+            consumerGroup: "greetings",
+            messagePumpType: MessagePumpType.Proactor,
+            makeChannels: OnMissingChannel.Assume)
+    ];
+    options.DefaultChannelFactory = new RocketMqChannelFactory(
+        new RocketMessageConsumerFactory(connection));
+});
+
+builder.Services.AddHostedService<ServiceActivatorHostedService>();
+
+var host = builder.Build();
+await host.RunAsync();
+```
+
+## Further Reading
+
+- [Basic Configuration](/contents/BrighterBasicConfiguration.md) — registering Brighter
+- [Dispatcher Configuration Reference](/contents/DispatcherConfigurationReference.md) — the subscription options every transport shares
+- [Command Processor Configuration Reference](/contents/CommandProcessorConfigurationReference.md) — the publication options every transport shares
+- [Reactor and Proactor](/contents/ReactorAndProactor.md) — choosing a message pump
+- [Error Handling Options](/contents/ErrorHandlingOptions.md) — what Brighter does with a message it cannot process

--- a/spec/011-authoring_conventions/pagetypes.tsv
+++ b/spec/011-authoring_conventions/pagetypes.tsv
@@ -147,3 +147,8 @@ contents/TutorialDurableOutbox.md	Tutorial	high	"spec 009 D3, rung 3; tutorial b
 contents/GetStarted.md	Tutorial	medium	"spec 009 D10, the ladder's landing page; not itself a build, but the entry point to the three tutorials and typed with them"	Tutorial	Brighter V10
 contents/TutorialStreamingWithKafka.md	Tutorial	high	"spec 009 D8, rung 4; tutorial by construction — one path, numbered steps, measured single-consumer and rebalanced two-consumer runs"	Tutorial	Brighter V10
 contents/RelationalDatabaseConfigurationReference.md	Reference	high	"spec 012 D15, the relational options documented once for seventeen components; consulted, not read through"	Reference	Brighter V10
+contents/MSSQLMessageBroker.md	Reference	high	"spec 012 D12, the MSSQL queue-table transport; parameter tables consulted per option"	Reference	Brighter V10
+contents/GcpPubSubConfiguration.md	Reference	high	"spec 012 D12, the GCP Pub/Sub transport; parameter tables consulted per option"	Reference	Brighter V10
+contents/RocketMQConfiguration.md	Reference	high	"spec 012 D12, the RocketMQ transport; parameter tables consulted per option"	Reference	Brighter V10
+contents/MQTTConfiguration.md	Reference	high	"spec 012 D12, the MQTT transport; parameter tables consulted per option"	Reference	Brighter V10
+contents/RedisConfiguration.md	Reference	high	"spec 012 D12, the Redis transport; parameter tables consulted per option"	Reference	Brighter V10

--- a/spec/012-configuration_reference/tasks.md
+++ b/spec/012-configuration_reference/tasks.md
@@ -1297,7 +1297,7 @@ MSSQL ships neither a publication nor a connection type** (design §8.2). A writ
 eight as though Redis added something, **and every gate in this repository would be green on
 it.**
 
-- [ ] **Task 6.1:** Write `contents/GcpPubSubConfiguration.md` — 43 options, 3 tables
+- [x] **Task 6.1:** Write `contents/GcpPubSubConfiguration.md` — 43 options, 3 tables
   - Input: `GcpPubSubSubscription` 33, `GcpMessagingGatewayConnection` 7, `GcpPublication` 3;
     design §8.1's skeleton
   - Output: the page — General, Connection, Publication, Subscription, Configuration Example,
@@ -1308,7 +1308,7 @@ it.**
     Pub/Sub sample anywhere in Brighter** and the transport has **zero mentions in the corpus
     today**: the example is written from the source types, and task 6.7 compiles it.
 
-- [ ] **Task 6.2:** Write `contents/RedisConfiguration.md` — 33 options, **2** tables
+- [x] **Task 6.2:** Write `contents/RedisConfiguration.md` — 33 options, **2** tables
   - Input: `RedisSubscription` 19, `RedisMessagingGatewayConfiguration` 14
   - Output: the page; **no `## Redis Publication` section.** Budget ~150 lines
   - Notes: Redis appears in the corpus today **only as a row in cross-cutting comparison
@@ -1316,7 +1316,7 @@ it.**
     offering nowhere to configure it. Sample material exists: `samples/TaskQueue/RedisTaskQueue`,
     three files.
 
-- [ ] **Task 6.3:** Write `contents/RocketMQConfiguration.md` — 29 options, 3 tables
+- [x] **Task 6.3:** Write `contents/RocketMQConfiguration.md` — 29 options, 3 tables
   - Input: `RocketMqSubscription` 22, `RocketMessagingGatewayConnection` **4†**,
     `RocketMqPublication` 3; task 1.5's re-run
   - Output: the page. Budget ~155 lines
@@ -1324,14 +1324,14 @@ it.**
     primary constructor. **Zero mentions in the corpus and no sample in Brighter**; written
     from the source types, compiled at task 6.7.
 
-- [ ] **Task 6.4:** Write `contents/MQTTConfiguration.md` — 27 options, **2** tables
+- [x] **Task 6.4:** Write `contents/MQTTConfiguration.md` — 27 options, **2** tables
   - Input: `MqttSubscription` 19, `MQTTMessagingGatewayConfiguration` 8
   - Output: the page; **no publication section.** Budget ~140 lines
   - Notes: no sample in Brighter. Requirements §7.2.1 already rules that these pages need no
     running broker — they are Reference pages, not tutorials — so nothing here proposes to
     build one.
 
-- [ ] **Task 6.5:** Write `contents/MSSQLMessageBroker.md` — 19 options, **1 table and a link**
+- [x] **Task 6.5:** Write `contents/MSSQLMessageBroker.md` — 19 options, **1 table and a link**
   - Input: `MsSqlSubscription` 19; design §8.3 — `MsSqlMessageProducer` takes
     `RelationalDatabaseConfiguration` (`MsSqlMessageProducer.cs:69`, `:86`), and there is no
     `MsSqlMessagingGatewayConfiguration` and no `MsSqlPublication` anywhere in the package
@@ -1342,7 +1342,7 @@ it.**
     `PostgreSQLBrokerTradeOffs.md`, which is the same trade-off. Sample material exists:
     `samples/TaskQueue/MsSqlMessagingGateway`, eight files.
 
-- [ ] **Task 6.6:** Five `SUMMARY.md` entries, five `pagetypes.tsv` rows
+- [x] **Task 6.6:** Five `SUMMARY.md` entries, five `pagetypes.tsv` rows
   - Input: design §9.1's second diff
   - Output: **MSSQL beside PostgreSQL** (they are the same idea), then GCP Pub/Sub, RocketMQ,
     MQTT, Redis in the order requirements §10 lists them, all **top-level**, all before the
@@ -1352,7 +1352,7 @@ it.**
     other nine — which is why they stay flat rather than gaining a family parent, and why S2
     moved instead. No entry moves a URL: slugs are filename-derived.
 
-- [ ] **Task 6.7:** Compile every C# block on the five new pages
+- [x] **Task 6.7:** Compile every C# block on the five new pages
   - Input: design §11; the packages `optioncheck` has already pinned and restored
   - Output: a recorded compile of every ```` ```csharp ```` block, extracted from the published
     markdown and built — not run, compiled
@@ -1363,7 +1363,7 @@ it.**
     page, not from a draft**: 009 proved that a transcription error is caught by building the
     page's own fences and is invisible to reading the two side by side.
 
-- [ ] **Task 6.8:** Verify phase 6 — `optioncheck`, the six gates, AC6 and the AC8 walk
+- [x] **Task 6.8:** Verify phase 6 — `optioncheck`, the six gates, AC6 and the AC8 walk
   - Input: the five pages
   - Output: exit 0 with a scope naming 11 new tables; the six gates; **AC6 walked** — all ten
     shipping transports now have a configuration page, no orphan, no pagelint error on any of
@@ -1371,6 +1371,184 @@ it.**
   - Notes: expect link, pagelint and shape each **+5**, and `--check-redirects` unmoved.
     `--verify` moves only after publication — predict the five paths with `urlmap.py`, never
     guess them, and check `sitemap-pages.xml` lists them before probing.
+
+### Phase 6 as executed — 2026-08-30, 8/8
+
+**Eleven tables and 151 rows on five pages that did not exist**, taking the corpus to
+`37 tables, 427 rows, 37 types, on 15 pages of 153 files scanned`, exit 0. Every figure was
+re-derived from the type with `--describe` before its table was written.
+
+| Page | Tables | Rows | `manual:` | Lines | Budget |
+|---|---:|---:|---:|---:|---:|
+| `GcpPubSubConfiguration.md` | 3 | 43 | 4 | 196 | ~190 |
+| `RedisConfiguration.md` | 2 | 33 | 3 | 174 | ~150 |
+| `RocketMQConfiguration.md` | 3 | 30 | 5 | 189 | ~155 |
+| `MQTTConfiguration.md` | 2 | 26 | 3 | 173 | ~140 |
+| `MSSQLMessageBroker.md` | 1 | 19 | 2 | 166 | ~130 |
+
+**The phase total is 151, exactly as the phase table says, and two of its five rows are
+wrong** — which is the point of standing obligation 3 rather than a coincidence worth
+celebrating. `RocketSubscription` is **23** where design §7.2 says `RocketMqSubscription` 22,
+and `MqttMessagingGatewayConfiguration` is **7** where §7.2 says
+`MQTTMessagingGatewayConfiguration` 8. The two errors are +1 and −1, so the sum reproduces and
+a writer checking only the total would have seen nothing. The MQTT figure has a cause worth
+keeping: `ConnectionAttempts` is a property with an **`internal` setter**, so it is not
+reader-settable and not on the table — named in prose instead.
+
+**Seventeen `manual:` declarations across 151 rows — 11%**, against 13% at phases 3 and 5.
+Fourteen of the seventeen are the same three subscription parameters once per transport;
+the other three are `GcpPubSubSubscription.timeProvider`,
+`RocketMessagingGatewayConnection.TimerProvider` and `RocketSubscription.filter`.
+
+**Four of the six gates moved by five, and the two that should not have did not.** Link
+151 → **156**; pagelint 149 → **154 pages, 0 errors**; shape 148 → **153 pages, widest
+10 → 12 of 20**; `--check-redirects` **unmoved at 77 entries / 7858 bytes**, which is the
+sixth-and-seventh time that assertion has held for a page added to an existing section;
+`versioncheck.py` unmoved at 0 stale of 18 across 5. `--verify` moves only after publication —
+the five predicted paths are `transports/gcppubsubconfiguration`, `transports/redisconfiguration`,
+`transports/rocketmqconfiguration`, `transports/mqttconfiguration` and
+`transports/mssqlmessagebroker`, taken from `urlmap.py` rather than guessed.
+
+**The using-directive warning count did not move — 787 — and this time it was not placement
+that bought it.** A new page is 100% added lines, so `pagelint --changed` reports
+**11 code blocks strict across 8 hunks** and every one of the five C# blocks is in scope. They
+carry real `using` directives, which task 6.7 then proved sufficient by compiling them.
+
+#### The gate caught two things, and both are the kind nothing else would have
+
+1. **Two opening sentences failed rule 7 at 203 and 213 rendered characters.** Both were
+   written to §8.1's skeleton, both read as one clause, and neither is distinguishable from a
+   passing sentence by eye.
+2. **`optioncheck` reported `BLANK DEFAULT` for `RocketSubscription.filter`, and the cell was
+   not blank.** Its default is a `FilterExpression` of `*`, so the table said `` `*` `` —
+   and `Binding.Clean` strips backticks, `**` and `*` from every cell to normalise emphasis,
+   which reduces that value to the empty string. **The tool is right to refuse it**: it cannot
+   tell a stripped value from an unfinished row, and it says so rather than passing. The cell
+   now reads `every tag` and the row declares `manual:`. Recorded because the general shape is
+   worth knowing before phase 8 meets it: **a default whose rendering is a markdown control
+   character cannot be written in a cell**, and the failure arrives as the wrong message.
+
+#### Design §8.2 is right about MQTT and half right about Redis
+
+§8.2 says *"Redis and MQTT ship no publication type"*. **MQTT ships none** — its producer takes
+the base `Publication`, measured at `MQTTMessageProducer.cs:24`. **Redis ships
+`RedisMessagePublication`**, a subclass of `Publication` whose body is the comment
+`//placeholder`, and `RedisProducerRegistryFactory` takes `IEnumerable<RedisMessagePublication>`
+— so a reader configuring Redis **types the type**, even though it adds no option.
+
+The ruling's outcome is unchanged: a table for it would be `EMPTY TABLE`, and standing
+obligation 4 says do not write a page a table it does not have. What changes is the prose. The
+Redis page names the type, says it adds nothing, and links the base publication options; a
+writer following §8.2 literally would have left a reader unable to compile the one line the
+producer registry needs. **Verify the claim, not the conclusion** — the conclusion was right.
+
+#### The strays named in prose, which is the obligation phase 5 left standing
+
+`max(props, ctor)` under-reports four surfaces in this phase, none of them a defect and none of
+them a reason to move the selection — the question was raised, measured and answered at phase 5,
+and *Phase 5 as executed* carries the measurement:
+
+| Type | Not on the table | Why the tool cannot see it |
+|---|---|---|
+| `RedisMessagingGatewayConfiguration` | `AssumeServerVersion` | declared `static`, so it is process-wide rather than per gateway |
+| `MqttMessagingGatewayConfiguration` | `ConnectionAttempts` | `internal` setter — not reader-settable at all |
+| `RocketMessagingGatewayConnection` | `ClientConfig` | a get-only primary-constructor property, and it carries the **endpoint** |
+| `GcpPubSubSubscription`, `GcpPublication` | `TopicAttributes`, `DeadLetterPolicy` | configuration-shaped classes whose names end in neither `Configuration` nor `Options`, so they are outside the selected population |
+
+**The RocketMQ row is the one that matters to a reader.** Everything Brighter exposes on that
+connection is secondary; the broker address is on the `ClientConfig` you construct it with, and
+no table in this spec can contain it. The page opens with that.
+
+**No public fields on any of the eleven types**, which reproduces the sweep recorded under
+phase 5.
+
+#### What the reader could not have got from the type alone
+
+The generic subclass is what an example types, and the five disagree with each other more than
+phase 5's did:
+
+| Transport | Generic form supplies | Pump |
+|---|---|---|
+| GCP Pub/Sub | `requestType` only — names are still required, and it **does not expose** `streamingConfiguration` | still required |
+| Redis | `requestType`, and the three names from `T` | **`Proactor`** |
+| MQTT | `requestType`, and the three names from `T` | **`Proactor`** |
+| MSSQL | `requestType`, and the three names from `T` | `Proactor` on **both** forms |
+| RocketMQ | `requestType` only — names are still required | still required |
+
+**RocketMQ spells the two types differently**: the non-generic is `RocketSubscription` and the
+generic is `RocketMqSubscription<T>`, declared in the same file. Settled item 2 records the
+first half of that (`RocketMqSubscription` "does not exist"); it exists as the **generic**, which
+is the spelling every example uses, so both names are real and neither is a typo to correct.
+
+#### Task 6.7 — the five examples compile
+
+Every ```` ```csharp ```` block was **extracted from the published markdown**, not from a
+draft, into one project per block: `net9.0`, `Nullable enable`, the page's own gateway package
+plus `Paramore.Brighter.Extensions.DependencyInjection`, `…ServiceActivator.Extensions.DependencyInjection`
+and `…ServiceActivator.Extensions.Hosting`, all at `10.7.0` — the same pins `optioncheck`
+restores. **5 of 5 build: 0 errors, 0 warnings.** The harness supplies one type the pages name
+and do not define, `GreetingEvent : Event`; the only build failure of the exercise was in that
+shim (`Id.Random` is a method, not a property), which is the harness and not a page.
+
+The eleven blocks are five `csharp`, five `bash` and one `sql`, so the six non-C# blocks are
+outside this obligation and are recorded here rather than left implicit.
+
+#### The finding the compile obligation bought, and it is on other pages
+
+**`services.AddBrighter().AddProducers(…).AddConsumers(…)` does not compile.** `AddConsumers`
+extends **`IServiceCollection`**, not `IBrighterBuilder`
+(`ServiceActivator.Extensions.DependencyInjection/ServiceCollectionExtensions.cs:29` and `:78`,
+the only two definitions in the product), so chaining it off the Brighter builder is
+**`CS1929`** — measured in the harness, with a control: deleting that one line from the same
+file builds clean.
+
+**Eleven blocks across eight pages show the chain** — `InMemoryTransport.md` (2),
+`InMemoryOptions.md` (2), `RoutingMultipleMessageTypes.md` (3), `AgreementDispatcher.md`,
+`DistributedLock.md`, `InMemoryInbox.md` and `V10MigrationGuide.md` — **and so does
+`CLAUDE.md`'s own ✅ *V10 — current* example**, which is where a writer would go to copy it.
+The tutorials are **not** affected: they write `builder.Services.AddConsumers(…)`, which is why
+009's compile-and-run pass never met this.
+
+**Nothing was fixed here.** It is not an option-table mismatch, so it is not a ledger entry; it
+is eight pages plus `CLAUDE.md`, which is its own coherent unit and its own PR. Recorded before
+fixing, per standing obligation 10's spirit if not its letter. **The general shape is the one
+009 left behind and this phase paid for again: compiling a page's own fences finds the class of
+defect that reading them cannot**, and the block that found it was on a page that does not
+carry the defect.
+
+#### The ledger — no entries, and that is what a new page means
+
+Phase 5 contributed ten entries and observed that **twelve of the spec's thirteen were found by
+writing the correct table beside prose that was already there**. Five new pages have no prose to
+disagree with, so phase 6 adds none and the spec's total stands at **thirteen**. The corollary
+for task 11.3 is that the drift ledger is a measurement of the *documented* transports, not of
+the corpus, and phase 7's four pages will say the same.
+
+*(One source-side defect, not ours and not raised: `RocketMqPublication.Instrumentation` carries
+`Tag`'s doc comment verbatim, remarks and all. It joins `Publication.Type`'s doc comment from
+phase 3 as something that lives in `src/`, which is outside this programme's exception — so it
+is an issue or it is nothing.)*
+
+#### AC6, walked
+
+**Ten transports ship at `10.7.0` and all ten now have a configuration page.** Enumerated from
+`git ls-tree --name-only 10.7.0 src/ | grep MessagingGateway`, which lists twelve directories
+for ten transports — `AWSSQS` and `AWSSQS.V4` are one, `RMQ.Async` and `RMQ.Sync` are one:
+
+RabbitMQ, Kafka, AWS SNS/SQS, Azure Service Bus, PostgreSQL, **MSSQL**, **GCP Pub/Sub**,
+**RocketMQ**, **MQTT**, **Redis** — the last five new here — plus `InMemoryTransport.md`, which
+is in the core package rather than a gateway. No orphan (`linkcheck.py` clean on a whole-repo
+run), no `pagelint` error on any of the five.
+
+#### AC8, walked
+
+**All 151 descriptions are one sentence, present tense, and state what the option does.** Swept
+mechanically as well as read: no cell contains *because*, *so that*, *should*, *prefer*,
+*recommend* or *note that*, none contains two sentences, all 151 open with a capital and end in
+a full stop — **151 cells, 0 faults**. Rationale sits in prose above each table where it was
+worth having: RocketMQ's inability to create a topic, MQTT's required `TopicPrefix` and its
+`prefix/#` subscription, Redis's static `RedisConfig` overrides, and when a queue table beats a
+broker.
 
 ---
 


### PR DESCRIPTION
Phase 6 of spec 012: the five transports Brighter ships and this documentation has never had a page for.

**Eleven tables, 151 rows, five new pages.** The corpus goes to 37 tables and 427 rows across 15 pages; `optioncheck` exits 0. Every figure was re-derived from the type with `--describe` — never from `survey.py`, never from our own prose.

| Page | Tables | Rows | `manual:` | Lines |
|---|---:|---:|---:|---:|
| `GcpPubSubConfiguration.md` | 3 | 43 | 4 | 196 |
| `RedisConfiguration.md` | 2 | 33 | 3 | 174 |
| `RocketMQConfiguration.md` | 3 | 30 | 5 | 189 |
| `MQTTConfiguration.md` | 2 | 26 | 3 | 173 |
| `MSSQLMessageBroker.md` | 1 | 19 | 2 | 166 |

`GcpPubSubSubscription`'s 33 constructor parameters make it the widest subscription Brighter ships.

## Three things worth reading the diff for

**The total is right and two of its parts are wrong.** The phase table says 151 and the measurement says 151 — but `RocketSubscription` is 23 against design §7.2's 22, and `MqttMessagingGatewayConfiguration` is 7 against its 8. The errors are +1 and −1. The MQTT one has a cause: `ConnectionAttempts` has an `internal` setter, so it is not reader-settable; it is named in prose instead.

**Design §8.2 is right about MQTT and half right about Redis.** MQTT ships no publication type. Redis ships `RedisMessagePublication` — a subclass of `Publication` whose body is `//placeholder` — and `RedisProducerRegistryFactory` takes `IEnumerable<RedisMessagePublication>`, so a reader types the type even though it adds no option. No table (that would be `EMPTY TABLE`), but the page names it.

**Task 6.7 compiled every C# block and found a defect on other pages.** The five blocks were extracted from the published markdown into one project each, against the packages `optioncheck` already pins: **5/5, 0 errors, 0 warnings**. The same harness measured that `services.AddBrighter().AddProducers(…).AddConsumers(…)` is **`CS1929`** — `AddConsumers` extends `IServiceCollection`, not `IBrighterBuilder`. Eleven blocks across eight pages show that chain, and so does `CLAUDE.md`'s own ✅ *V10 — current* example. **Not fixed here**: it is its own coherent unit and its own PR. The tutorials are unaffected — they write `builder.Services.AddConsumers(…)`.

## Gates

```text
linkcheck.py                 No broken internal links (156 files checked).      151 -> 156
pagelint.py                  0 errors, 787 warnings, 154 pages                  149 -> 154
urlmap.py --check-shape      0 — 153 pages, 12 sections, widest 12 of 20        148 -> 153
urlmap.py --check-redirects  0 — 77 entries, 7858 bytes                         unmoved
versioncheck.py              0 stale pins of 18 across 5 page(s)                unmoved
optioncheck                  0 mismatches across 37 tables and 427 rows         26/276 -> 37/427
pagelint.py --changed        11 code block(s) strict across 17 hunks, 0 errors
```

The using-directive count did not move, and on a new page that is bought rather than given: 100% added lines makes every block strict, so all five carry real `using` directives.

**AC6 walked** — ten transports ship at `10.7.0` and all ten now have a configuration page. **AC8 walked** — 151 description cells, 0 faults.

Full record in `spec/012-configuration_reference/tasks.md` under *Phase 6 as executed*, including the four surfaces `max(props, ctor)` cannot see (named in prose, not a reason to move the selection) and the ledger, which gains nothing this phase because a new page has no prose to disagree with.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0146UueHL6H3zGBGTYwz7GtL