### PR TITLE
spec: 012 phase 8 — D7 and D8, the outbox, inbox and lock pages

### DIFF
--- a/contents/AsyncAPISupport.md
+++ b/contents/AsyncAPISupport.md
@@ -164,15 +164,17 @@ When the same routing key appears in multiple sources, Brighter produces one cha
 
 Configure the generated document via the `UseAsyncApi()` delegate:
 
-| Property | Type | Default | Description |
-|----------|------|---------|-------------|
-| `Title` | `string` | `"Brighter Application"` | The `info.title` field in the generated document |
-| `Version` | `string` | `"1.0.0"` | The `info.version` field |
-| `Description` | `string?` | `null` | Optional `info.description` field |
-| `Servers` | `Dictionary<string, V3ServerDefinition>?` | `null` | Server definitions (broker endpoints) |
-| `AssembliesToScan` | `IEnumerable<Assembly>?` | Entry assembly | Assemblies to scan for `[PublicationTopic]` types |
-| `DisableAssemblyScanning` | `bool` | `false` | When `true`, skips assembly scanning entirely |
-| `SupplementalPublications` | `IEnumerable<Publication>?` | `null` | Additional publications to include beyond those in the producer registry |
+<!-- optioncheck: Paramore.Brighter.AsyncAPI.AsyncApiOptions -->
+
+| Option | Type | Default | Description |
+|---|---|---|---|
+| `Title` | `string` | `"Brighter Application"` | Sets the `info.title` field of the generated document. |
+| `Version` | `string` | `"1.0.0"` | Sets the `info.version` field of the generated document. |
+| `Description` | `string?` | `null` | Sets the `info.description` field of the generated document. |
+| `Servers` | `Dictionary<string, V3ServerDefinition>?` | `null` | Supplies the server definitions — the broker endpoints — keyed by server id. |
+| `AssembliesToScan` | `IEnumerable<Assembly>?` | `null` | Names the assemblies scanned for `[PublicationTopic]` types; the default scan set applies when it is null. |
+| `DisableAssemblyScanning` | `bool` | `false` | Turns off assembly scanning, leaving only registered producers and `SupplementalPublications`. |
+| `SupplementalPublications` | `IEnumerable<Publication>?` | `null` | Adds publications beyond those found in the producer registry and by scanning. |
 
 Full configuration example:
 

--- a/contents/AzureBlobDistributedLock.md
+++ b/contents/AzureBlobDistributedLock.md
@@ -34,12 +34,24 @@ new AzureBlobLockingProvider(
         tokenCredential: new DefaultAzureCredential()));
 ```
 
-| Setting | Type | Default | Description |
-|---------|------|---------|-------------|
-| `BlobContainerUri` | `Uri` | *(required)* | The URI of the blob container that holds the lock blobs. |
-| `TokenCredential` | `TokenCredential` | *(required)* | The Azure credential used to authenticate, for example `DefaultAzureCredential`. |
-| `LeaseValidity` | `TimeSpan` | 1 minute | How long the blob lease is held before it expires automatically. Set it longer than a Sweeper/Archiver cycle. |
-| `StorageLocationFunc` | `Func<string, string>` | `resource => $"lock-{resource}"` | Maps a resource name to the blob name used for its lock. |
+<!-- optioncheck: Paramore.Brighter.Locking.Azure.AzureBlobLockingProviderOptions
+     manual: BlobContainerUri — set from a required constructor parameter, so an instance reads back that argument rather than a default
+     manual: TokenCredential — set from a required constructor parameter, so an instance reads back that argument rather than a default
+-->
+
+| Option | Type | Default | Description |
+|---|---|---|---|
+| `BlobContainerUri` | `Uri` | `none` | Names the blob container that holds the lock blobs. |
+| `TokenCredential` | `TokenCredential` | `none` | Authenticates to the container, for example with `DefaultAzureCredential`. |
+| `LeaseValidity` | `TimeSpan` | `60000 ms` | How long the blob lease is held before it expires automatically. |
+
+All three properties are `init`-only, so set them in the constructor call or an object
+initialiser. Set `LeaseValidity` longer than a Sweeper or Archiver cycle.
+
+**`StorageLocationFunc` is a public field rather than a property**, which is why it is not in
+the table above: it is a `Func<string, string>` mapping a resource name to the blob name that
+holds its lock, and it defaults to `resource => $"lock-{resource}"`. Assign it in an object
+initialiser like any other member.
 
 ## Azure Blob Distributed Lock Example
 

--- a/contents/BoxProvisioningConfiguration.md
+++ b/contents/BoxProvisioningConfiguration.md
@@ -124,6 +124,25 @@ services.AddBrighter()
 
 The `connectionName` overload accepts the same per-box parameters you would have set on `RelationalDatabaseConfiguration` (`outboxTableName`, `schemaName` where the backend supports it, `binaryMessagePayload`); each defaults sensibly so you can usually pass just the name.
 
+## Box Provisioning Options
+
+The delegate `UseBoxProvisioning` hands you is a `BoxProvisioningOptions`. Alongside the
+`Add{Backend}*` registrations above, it carries two settings:
+
+<!-- optioncheck: Paramore.Brighter.BoxProvisioning.BoxProvisioningOptions -->
+
+| Option | Type | Default | Description |
+|---|---|---|---|
+| `MigrationLockTimeout` | `TimeSpan` | `30000 ms` | How long a replica waits for the migration lock before giving up — see [Tuning the migration lock timeout](#tuning-the-migration-lock-timeout). |
+| `MigrationHistoryScope` | `MigrationHistoryScope` | `Global` | Where the migration-history table is placed: `Global` keeps it in the default location, `PerSchema` places it in the configured `SchemaName`. |
+
+`MigrationHistoryScope.PerSchema` places history in the `SchemaName` your
+`RelationalDatabaseConfiguration` carries, on **MSSQL and PostgreSQL only**; it is a no-op on
+MySQL, SQLite and Spanner, which have no distinct schema concept. Selecting it with a null
+`SchemaName` on MSSQL or PostgreSQL throws `ConfigurationException`. Upgrading an existing
+deployment from `Global` to `PerSchema` seeds the new history table from the old one, so the
+application still needs read access to the history table in the default schema.
+
 ## Tuning the migration lock timeout
 
 `BoxProvisioningOptions.MigrationLockTimeout` controls how long a replica is willing to wait for the per-table advisory lock during startup. The default is 30 seconds. Override it inside the same delegate, before or after the `Add{Backend}*` calls — the timeout is read late, when registrations actually run, so placement inside the delegate does not matter:

--- a/contents/BrighterOutboxSupport.md
+++ b/contents/BrighterOutboxSupport.md
@@ -173,12 +173,22 @@ The benefits of using an **Outbox Sweeper** are:
   * If there is a failure dispatch a message after it is committed to the **Outbox** it will be retried until it is dispatches
   * The ability to choose between the implicit and explicit clearing of messages
 
-The **Timed Outbox Sweeper** has the following configurables
+#### Timed Outbox Sweeper Options
 
-  * TimerInterval: The amount of seconds to wait between checks for undispatched messages (default: 5)
-  * MinimumMessageAge: The age a message (in milliseconds) that a messages should be before the **OutboxSweeper** should attempt to dispatch it. (default: 5000)
-  * BatchSize: The number of messages to attempt to dispatch in each check (default: 100)
-  * UseBulk: Use Bulk dispatching of messages on your **Messaging Gateway** (default: false), note: not all **messaging Gateway**s support Bulk dispatching.
+`UseOutboxSweeper` configures the Sweeper with a `TimedOutboxSweeperOptions`:
+
+<!-- optioncheck: Paramore.Brighter.Outbox.Hosting.TimedOutboxSweeperOptions -->
+
+| Option | Type | Default | Description |
+|---|---|---|---|
+| `TimerInterval` | `int` | `5` | How many seconds the Sweeper waits between checks for undispatched messages. |
+| `MinimumMessageAge` | `TimeSpan` | `5000 ms` | How old a message must be before the Sweeper attempts to dispatch it. |
+| `BatchSize` | `int` | `100` | How many messages the Sweeper attempts to dispatch in each check. |
+| `UseBulk` | `bool` | `false` | Whether the Sweeper dispatches in bulk; not every messaging gateway supports it. |
+
+`Args` is a public field rather than a property: a `Dictionary<string, object>` of extra
+arguments a particular flavour of Outbox needs. It is read-only, so add to the dictionary
+rather than assigning a new one.
 
 It is important to note that the lower the Minimum Message age is the more likely it is that your message will be dispatches more than once (as if you are explicitly clearing messages your application may have instructed the clearing of a message at the same time as the **Outbox Sweeper**)
 

--- a/contents/DynamoDbDistributedLock.md
+++ b/contents/DynamoDbDistributedLock.md
@@ -44,12 +44,21 @@ new DynamoDbLockingProvider(
 `DynamoDbLockingProviderOptions` takes two required values in its constructor and exposes
 two optional settings:
 
-| Setting | Type | Default | Description |
-|---------|------|---------|-------------|
-| `LockTableName` | `string` | *(required)* | The DynamoDB table that holds the locks. |
-| `LeaseholderGroupId` | `string` | *(required)* | Identifies the group of instances that share the lock. All instances that must coordinate use the same value. |
-| `LeaseValidity` | `TimeSpan` | 1 minute | How long the lease is held before it expires automatically. Set it comfortably longer than a Sweeper/Archiver cycle. |
-| `ManuallyReleaseLock` | `bool` | `false` | When `false`, the lock simply expires after `LeaseValidity`; when `true`, it is released explicitly on completion. |
+<!-- optioncheck: Paramore.Brighter.Locking.DynamoDb.DynamoDbLockingProviderOptions
+     manual: LockTableName — set from a required constructor parameter, so an instance reads back that argument rather than a default
+     manual: LeaseholderGroupId — set from a required constructor parameter, so an instance reads back that argument rather than a default
+-->
+
+| Option | Type | Default | Description |
+|---|---|---|---|
+| `LockTableName` | `string` | `none` | Names the DynamoDB table that holds the locks. |
+| `LeaseholderGroupId` | `string` | `none` | Identifies the group of instances that share the lock; every instance that must coordinate uses the same value. |
+| `LeaseValidity` | `TimeSpan` | `60000 ms` | How long the lease is held before it expires automatically. |
+| `ManuallyReleaseLock` | `bool` | `false` | Whether the provider releases the lock on completion rather than letting it expire. |
+
+Both constructor parameters are required, and both properties are `init`-only: set them in the
+constructor call or in an object initialiser, not afterwards. Set `LeaseValidity` comfortably
+longer than a Sweeper or Archiver cycle.
 
 ## DynamoDB Distributed Lock Example
 

--- a/contents/DynamoInbox.md
+++ b/contents/DynamoInbox.md
@@ -22,6 +22,25 @@ For this we will need the *Inbox* packages for the DynamoDb *Inbox*.
 
 See [AWS SQS Migration](/contents/AWSSQSMigrateToV10.md#migrating-from-aws-sdk-v3-to-v4) for migration guidance between v3 and v4.
 
+## Dynamo Inbox Options
+
+`DynamoDbInboxConfiguration` names the table and nothing else. Everything about the connection
+— credentials, region, service URL — belongs to the `AmazonDynamoDBClient` you construct and
+pass to `DynamoDbInbox`.
+
+<!-- optioncheck: Paramore.Brighter.Inbox.DynamoDB.DynamoDbInboxConfiguration -->
+
+| Option | Type | Default | Description |
+|---|---|---|---|
+| `TableName` | `string` | `"brighter_inbox"` | Names the DynamoDB table that holds the Inbox. |
+
+`tableName` is also a constructor parameter, so `new DynamoDbInboxConfiguration("my_inbox")`
+and setting the property afterwards are the same thing.
+
+The type also declares `Credentials` and `Region`. **Neither does anything**: the Inbox reads
+only `TableName`, and in the AWS SDK v3 package the two are get-only and never assigned, so
+they are always null. The v4 package declares them settable and still reads neither.
+
 ``` csharp
 using Amazon.DynamoDBv2;
 using Microsoft.Extensions.DependencyInjection;

--- a/contents/DynamoOutbox.md
+++ b/contents/DynamoOutbox.md
@@ -97,6 +97,31 @@ public override async Task<AddGreeting> HandleAsync(AddGreeting addGreeting, Can
 }
 ```
 
+## DynamoDb Outbox Options
+
+`DynamoDbConfiguration` names the table and its four global secondary indexes, and carries the
+two settings that govern expiry and scan concurrency.
+
+<!-- optioncheck: Paramore.Brighter.Outbox.DynamoDB.DynamoDbConfiguration -->
+
+| Option | Type | Default | Description |
+|---|---|---|---|
+| `TableName` | `string` | `"brighter_outbox"` | Names the DynamoDB table that holds the Outbox. |
+| `DeliveredIndexName` | `string` | `"Delivered"` | Names the global secondary index of dispatched messages, indexed by topic. |
+| `DeliveredAllTopicsIndexName` | `string` | `"DeliveredAllTopics"` | Names the global secondary index of dispatched messages covering every topic. |
+| `OutstandingIndexName` | `string` | `"Outstanding"` | Names the global secondary index of undispatched messages, indexed by topic. |
+| `OutstandingAllTopicsIndexName` | `string` | `"OutstandingAllTopics"` | Names the global secondary index of undispatched messages covering every topic. |
+| `TimeToLive` | `TimeSpan?` | `null` | Sets how long a message survives in the table before DynamoDB expires it; messages do not expire when it is null. |
+| `ScanConcurrency` | `int` | `3` | Sets how many segments a parallel scan for outstanding messages uses. |
+
+**`timeout` and `numberOfShards` are constructor parameters, not properties you can set.** They
+surface as the get-only `Timeout` and `NumberOfShards`. `numberOfShards` defaults to 3 and
+shards the outstanding index so an active topic does not build a hot partition; the Outbox
+throws `ArgumentOutOfRangeException` above 20. `timeout` defaults to 500 and **nothing reads
+it** — the timeouts that take effect are the `outBoxTimeout` arguments on the Outbox's own
+methods. `tableName` and `scanConcurrency` are constructor parameters as well, but each has a
+settable property and is in the table above.
+
 ## Replay Support: The Causation Index
 
 [Replay On Seen](/contents/ReplayOnSeen.md) resends every Outbox message produced under a given Causation Id. On DynamoDB that means querying on a non-key attribute, which needs a Global Secondary Index — by default one named **Causation**, with `CausationId` as its hash key.

--- a/contents/FirestoreDistributedLock.md
+++ b/contents/FirestoreDistributedLock.md
@@ -46,10 +46,11 @@ var lockingProvider = new FirestoreDistributedLock(configuration);
 `IAmAFirestoreConnectionProvider` alongside the configuration if you want to share a
 connection provider.
 
-| Setting (on `Locking`) | Type | Description |
-|------------------------|------|-------------|
-| `Name` | `string` | The collection that holds the lock documents. |
-| `Ttl` | `TimeSpan?` | Optional expiry for lock documents. |
+The lock has no options type of its own. `FirestoreConfiguration` and the
+`FirestoreCollection` you assign to `Locking` are documented once, on the Outbox page: see
+[Firestore Outbox Options](/contents/FirestoreOutbox.md#firestore-outbox-options). The two that
+matter here are `Locking.Name`, which names the collection holding the lock documents, and
+`Locking.Ttl`, which stamps each document with an expiry timestamp.
 
 ## Firestore Distributed Lock Example
 
@@ -75,10 +76,14 @@ services
 
 The provider creates lock documents in the collection named by `Locking.Name`. It
 acquires a lock with an atomic create that succeeds only when the document does not
-already exist, so only one instance holds a given lock at a time. Setting `Ttl` lets
-stale locks expire, which protects you if an instance crashes before releasing its lock.
-Ensure the application's service account can read and write documents in the lock
-collection.
+already exist, so only one instance holds a given lock at a time. Ensure the application's
+service account can read and write documents in the lock collection.
+
+**`Ttl` writes a field; it does not delete anything on its own.** Brighter stamps a `Ttl`
+timestamp onto each lock document, and Firestore removes an expired document only once you have
+created a **TTL policy** on that field, through the Google Cloud console or the Firestore Admin
+API. Without the policy a crashed instance's lock document stays where it is, so create the
+policy if you are relying on expiry to recover the lock.
 
 ## Firestore Distributed Lock Notes
 
@@ -91,4 +96,5 @@ collection.
 ## Further Reading
 
 - [Distributed Lock](/contents/DistributedLock.md) — concepts and the full provider list
+- [Firestore Outbox](/contents/FirestoreOutbox.md) — the matching Outbox, and where `FirestoreConfiguration` is documented
 - [Outbox Support](/contents/BrighterOutboxSupport.md) — the Sweeper and Archiver

--- a/contents/InMemoryOutbox.md
+++ b/contents/InMemoryOutbox.md
@@ -14,18 +14,37 @@ The in-process Outbox: flushing, compaction, configuration and limits. It is par
 
 The InMemory Outbox provides transactional messaging support without requiring a database. Note that if you do not specify a persistent Outbox, we will use the InMemoryOutbox, by default. Any use of the `CommandProcessor`'s `Post` method uses the default `InMemoryOutbox` and not the persistent Outbox, as it does not take a transaction provider as an argument.
 
+## InMemory Outbox Options
+
+`InMemoryBoxConfiguration` carries the four settings that govern expiry and compaction. Assign
+it to `producers.DefaultBoxConfiguration` when you let Brighter create the default Outbox for
+you; when you construct an `InMemoryOutbox` yourself, set the same four as properties on the
+instance.
+
+<!-- optioncheck: Paramore.Brighter.InMemoryBoxConfiguration -->
+
+| Option | Type | Default | Description |
+|---|---|---|---|
+| `EntryLimit` | `int` | `2048` | How many messages the Outbox holds before compaction runs; `-1` disables compaction. |
+| `EntryTimeToLive` | `TimeSpan` | `300000 ms` | How long a dispatched message remains in the Outbox before expiry removes it. |
+| `ExpirationScanInterval` | `TimeSpan` | `600000 ms` | How long the Outbox waits between scans for expired messages. |
+| `CompactionPercentage` | `double` | `0.5` | What fraction of `EntryLimit` the Outbox compacts down to. |
+
+`EntryLimit` rejects `0` and any value below `-1` with `ArgumentOutOfRangeException`, so an
+invalid limit fails where you set it rather than at the first compaction.
+
 ## Flush of Expired Messages
 
 The InMemory Outbox will flush expired messages. You can configure the time limit for a message, after which it will be flushed:
 
-- **EntryTimeToLive** Defaults to 5 minutes. Governs how long a message can remain in the Outbox.
-- **ExpirationScanInterval** Defaults to 10 mins. Governs how often a scan for expired messages runs.
+- **EntryTimeToLive** Governs how long a message can remain in the Outbox.
+- **ExpirationScanInterval** Governs how often a scan for expired messages runs.
 
 ## Compaction of the InMemoryOutbox
 
 The InMemoryOutbox's capacity is constrained. You can configure the limit to the number of messages the Outbox contains. If you are using the InMemoryOutbox in production scenarios, you should pay attention to this limit. Once the limit is hit, the Outbox will compact, removing older messages first. You can set a compaction percentage, which governs how many messages will be purged from the InMemoryOutbox when we compact.
 
-- **EntryLimit** Defaults to 2048. Governs how many messages the InMemoryOutbox can hold.
+- **EntryLimit** Governs how many messages the InMemoryOutbox can hold.
 - **CompactionPercentage** When we hit a capacity limit, what percentage of messages should we purge. 
 
 ## When to Use the InMemory Outbox

--- a/contents/MongoDBOutbox.md
+++ b/contents/MongoDBOutbox.md
@@ -41,6 +41,48 @@ The MongoDB Outbox supports different strategies for collection management throu
 
 **Note:** You are responsible for creating and maintaining the collection if you choose to manage it manually. This includes tasks such as adding indexes to optimize query performance and configuring Time-To-Live (TTL) indexes for automatic message cleanup.
 
+## MongoDB Outbox Options
+
+`MongoDbConfiguration` is constructed with a client and a database name, and carries the rest
+as properties. The [MongoDB Inbox](/contents/MongoDBInbox.md) and the
+[MongoDB distributed lock](/contents/MongoDbDistributedLock.md) take the same type, so one
+instance can configure all three.
+
+<!-- optioncheck: Paramore.Brighter.MongoDb.MongoDbConfiguration
+     manual: Client — set from a constructor parameter, so an instance reads back that argument rather than a default
+     manual: TimeProvider — initialised to TimeProvider.System, which has no printable value
+-->
+
+| Option | Type | Default | Description |
+|---|---|---|---|
+| `Client` | `IMongoClient` | `none` | Supplies the MongoDB driver client used for every collection Brighter opens. |
+| `TimeProvider` | `TimeProvider` | `TimeProvider.System` | Supplies the clock used for message timestamps and time-to-live expiry. |
+| `DatabaseSettings` | `MongoDatabaseSettings?` | `null` | Sets the database-level settings, such as read preference and write concern. |
+| `InstrumentationOptions` | `InstrumentationOptions` | `All` | Sets how much telemetry detail the Outbox emits. |
+| `Outbox` | `MongoDbCollectionConfiguration?` | `null` | Configures the collection this Outbox writes messages to. |
+| `Inbox` | `MongoDbCollectionConfiguration?` | `null` | Configures the collection the [MongoDB Inbox](/contents/MongoDBInbox.md) writes to. |
+| `Locking` | `MongoDbCollectionConfiguration?` | `null` | Configures the collection the [MongoDB distributed lock](/contents/MongoDbDistributedLock.md) writes its lock documents to. |
+
+**`databaseName` is a constructor parameter, not a property you can set.** It surfaces as the
+get-only `DatabaseName`, and there is no default: a `MongoDbConfiguration` cannot be constructed
+without it. `Client` has no default either — pass an `IMongoClient`, or use the constructor that
+takes a connection string and builds one for you.
+
+**`Outbox` defaults to `null` and the Outbox will not run without it**, so read that `null` as
+*you must set this* rather than as *this is optional*.
+
+Each of `Outbox`, `Inbox` and `Locking` takes a `MongoDbCollectionConfiguration`:
+
+<!-- optioncheck: Paramore.Brighter.MongoDb.MongoDbCollectionConfiguration -->
+
+| Option | Type | Default | Description |
+|---|---|---|---|
+| `Name` | `string` | `""` | Names the MongoDB collection. |
+| `MakeCollection` | `OnResolvingACollection` | `Assume` | Sets what Brighter does when it resolves the collection — see [Collection Management](#mongodb-outbox-collection-management). |
+| `Settings` | `MongoCollectionSettings?` | `null` | Sets the collection-level settings used when the collection is opened. |
+| `CreateCollectionOptions` | `CreateCollectionOptions?` | `null` | Supplies the options used when Brighter creates the collection. |
+| `TimeToLive` | `TimeSpan?` | `null` | Sets how long a document survives before the TTL index removes it. |
+
 ## MongoDB Outbox Configuration
 
 ### Basic Configuration

--- a/contents/MongoDbDistributedLock.md
+++ b/contents/MongoDbDistributedLock.md
@@ -48,10 +48,11 @@ var lockingProvider = new MongoDbLockingProvider(configuration);
 `IAmAMongoDbConnectionProvider` alongside the configuration if you want to share a
 connection provider.
 
-| Setting (on `Locking`) | Type | Description |
-|------------------------|------|-------------|
-| `Name` | `string` | The collection that holds the lock documents. |
-| `TimeToLive` | `TimeSpan?` | Optional expiry for lock documents, applied through a MongoDB TTL index. |
+The lock has no options type of its own. `MongoDbConfiguration` and the
+`MongoDbCollectionConfiguration` you assign to `Locking` are documented once, on the Outbox
+page: see [MongoDB Outbox Options](/contents/MongoDBOutbox.md#mongodb-outbox-options). The two
+that matter here are `Locking.Name`, which names the collection holding the lock documents, and
+`Locking.TimeToLive`, which expires them through a MongoDB TTL index.
 
 ## MongoDB Distributed Lock Example
 

--- a/contents/MsSqlDistributedLock.md
+++ b/contents/MsSqlDistributedLock.md
@@ -24,11 +24,13 @@ provision** — see [Provisioning](#ms-sql-distributed-lock-provisioning).
 
 ## MS SQL Distributed Lock Configuration
 
-Unlike the lease-based providers, the MS SQL provider does not take an options class.
-You construct it with an `MsSqlConnectionProvider`, which it uses to open the session
-that holds the application lock. The connection provider is built from an
-`IAmARelationalDatabaseConfiguration` (a `RelationalDatabaseConfiguration`) carrying your
-connection string:
+**Unlike the lease-based providers, the MS SQL provider has no options type at all**, so
+there is no table of settings on this page. You construct it with an
+`MsSqlConnectionProvider`, which it uses to open the session that holds the application lock.
+The connection provider is built from an `IAmARelationalDatabaseConfiguration` (a
+`RelationalDatabaseConfiguration`) carrying your connection string, and its options are
+documented once in the [Relational Database Configuration
+Reference](/contents/RelationalDatabaseConfigurationReference.md):
 
 ```csharp
 var configuration = new RelationalDatabaseConfiguration(

--- a/contents/MySqlDistributedLock.md
+++ b/contents/MySqlDistributedLock.md
@@ -24,11 +24,12 @@ Named locks are a built-in MySQL feature, so there is **no table to provision** 
 
 ## MySQL Distributed Lock Configuration
 
-Like the MS SQL provider, the MySQL provider does not take an options class. You
-construct it with a `MySqlConnectionProvider`, which it uses to open the session that
-holds the lock. The connection provider is built from an
+**Like the MS SQL provider, the MySQL provider has no options type at all**, so there is no
+table of settings on this page. You construct it with a `MySqlConnectionProvider`, which it
+uses to open the session that holds the lock. The connection provider is built from an
 `IAmARelationalDatabaseConfiguration` (a `RelationalDatabaseConfiguration`) carrying your
-connection string:
+connection string, and its options are documented once in the [Relational Database
+Configuration Reference](/contents/RelationalDatabaseConfigurationReference.md):
 
 ```csharp
 var configuration = new RelationalDatabaseConfiguration(

--- a/contents/OutboxArchiver.md
+++ b/contents/OutboxArchiver.md
@@ -37,11 +37,19 @@ You register the Archiver with `UseOutboxArchiver<TTransaction>`, passing an arc
 
 For example, a DynamoDB Outbox uses `UseOutboxArchiver<TransactWriteItemsRequest>`. The `DynamoDbUnitOfWork` you register as the provider is *not* a transaction type, so `UseOutboxArchiver<DynamoDbUnitOfWork>` does not compile.
 
-The **Timed Outbox Archiver** has the following configurables:
+## Timed Outbox Archiver Options
 
-  * `TimerInterval`: The number of seconds to wait between checks for messages eligible for archival (default: 15)
-  * `MinimumAge`: A `TimeSpan` for how long since a message was dispatched before it is eligible for archival (default: 24 hours)
-  * `ArchiveBatchSize`: The maximum number of messages to archive in each check (default: 100)
+The second argument to `UseOutboxArchiver<TTransaction>` configures the Archiver with a
+`TimedOutboxArchiverOptions`:
+
+<!-- optioncheck: Paramore.Brighter.Outbox.Hosting.TimedOutboxArchiverOptions -->
+
+| Option | Type | Default | Description |
+|---|---|---|---|
+| `TimerInterval` | `int` | `15` | How many seconds the Archiver waits between checks for messages eligible for archival. |
+| `MinimumAge` | `TimeSpan` | `86400000 ms` | How long since a message was dispatched before it becomes eligible for archival. |
+| `ArchiveBatchSize` | `int` | `100` | How many messages the Archiver moves to the archive provider in each check. |
+| `Instrumentation` | `InstrumentationOptions` | `All` | How much telemetry detail the Archiver emits. |
 
 ## Running the Sweeper and Archiver Out of Process
 

--- a/contents/PostgresDistributedLock.md
+++ b/contents/PostgresDistributedLock.md
@@ -32,9 +32,16 @@ new PostgresLockingProvider(
         connectionString: "Host=localhost;Database=orders;Username=app;Password=secret"));
 ```
 
-| Setting | Type | Default | Description |
-|---------|------|---------|-------------|
-| `ConnectionString` | `string` | *(required)* | The connection string used to open the session that holds the advisory lock. |
+<!-- optioncheck: Paramore.Brighter.Locking.PostgresSql.PostgresLockingProviderOptions -->
+
+| Option | Type | Default | Description |
+|---|---|---|---|
+| `connectionString` | `string` | `none` | Opens the session that holds the advisory lock. |
+
+That constructor parameter is the whole of the type: it surfaces as the get-only
+`ConnectionString`, and there is nothing else to set. In particular the provider does **not**
+take a [relational database configuration](/contents/RelationalDatabaseConfigurationReference.md),
+even though the Postgres Outbox beside it does.
 
 ## Postgres Distributed Lock Example
 

--- a/spec/012-configuration_reference/tasks.md
+++ b/spec/012-configuration_reference/tasks.md
@@ -1771,7 +1771,7 @@ own store, with no type, no default and nothing for reflection to check. They ma
 option-shaped regex correctly and are **out of scope for the checker: they get no marker**
 (design §12.2).
 
-- [ ] **Task 8.1:** The outbox pages — `DynamoOutbox.md`, `MongoDBOutbox.md`,
+- [x] **Task 8.1:** The outbox pages — `DynamoOutbox.md`, `MongoDBOutbox.md`,
       `InMemoryOutbox.md`
   - Input: `DynamoDbConfiguration` 7, `MongoDbConfiguration` 7, `MongoDbCollectionConfiguration`
     5, `InMemoryBoxConfiguration` 4
@@ -1780,7 +1780,7 @@ option-shaped regex correctly and are **out of scope for the checker: they get n
     like Firestore's — write it once and point at it. `MongoDbLuggageStoreOptions` is a
     different type and is **P2**, not this task.
 
-- [ ] **Task 8.2:** The sweeper, archiver, provisioning and inbox pages —
+- [x] **Task 8.2:** The sweeper, archiver, provisioning and inbox pages —
       `BrighterOutboxSupport.md`, `OutboxArchiver.md`, `BoxProvisioningConfiguration.md`,
       `DynamoInbox.md`
   - Input: `TimedOutboxSweeperOptions` 4, `TimedOutboxArchiverOptions` 4,
@@ -1792,7 +1792,7 @@ option-shaped regex correctly and are **out of scope for the checker: they get n
     applies in miniature. Keep the table to the sweeper's own options and link the rationale.
     `DynamoDbInboxConfiguration` is a `†` row; write it from the type.
 
-- [ ] **Task 8.3:** The seven lock pages — three tables, two links, two absences
+- [x] **Task 8.3:** The seven lock pages — three tables, two links, two absences
   - Input: design §7.4, measured constructor by constructor — **and three of this task's four
     figures are floors (§2.9), which is more than any other task in the spec**.
     `DynamoDbDistributedLock.md` (`DynamoDbLockingProviderOptions` **4†**),
@@ -1812,7 +1812,7 @@ option-shaped regex correctly and are **out of scope for the checker: they get n
     the Azure Blob and DynamoDB options types are under-counted by two each and carry no mark
     at all (§2.9). All three tables are written from the type.
 
-- [ ] **Task 8.4:** Normalise `AsyncAPISupport.md`'s table — the one of the twelve no other
+- [x] **Task 8.4:** Normalise `AsyncAPISupport.md`'s table — the one of the twelve no other
       task owns
   - Input: §2.7's table; design §12.2's six header shapes; `AsyncApiOptions`, 6 options
   - Output: one table in the §7.1 shape with its marker
@@ -1826,7 +1826,7 @@ option-shaped regex correctly and are **out of scope for the checker: they get n
     unchanged, which is a coherent state; dropping any of the other four leaves a page
     half-converted.
 
-- [ ] **Task 8.5:** Verify phase 8 — `optioncheck`, the six gates, and the AC8 walk
+- [x] **Task 8.5:** Verify phase 8 — `optioncheck`, the six gates, and the AC8 walk
   - Input: everything above
   - Output: exit 0; the six gates; a recorded AC8 verdict; **the `omit:` and `manual:` counts
     read off the scope line and recorded**
@@ -1834,6 +1834,114 @@ option-shaped regex correctly and are **out of scope for the checker: they get n
     the residue is the sum of the `manual:` declarations, printed per option and by name.
     Record it here, because phase 11 will quote it and a number nobody derived is a number
     somebody guessed.
+
+### Phase 8 as executed — 2026-08-30, 5/5
+
+**Fifteen pages edited, twelve tables, 49 rows, and no page created** — taking the corpus to
+`51 tables, 485 rows, 51 types, on 27 pages of 157 files scanned`, exit 0.
+
+| Task | Pages | Tables | Rows | `manual:` |
+|---|---:|---:|---:|---:|
+| 8.1 outboxes | 3 | 4 | 23 | 2 |
+| 8.2 sweeper, archiver, provisioning, inbox | 4 | 4 | 11 | 0 |
+| 8.3 locks | 7 | 3 | 8 | 4 |
+| 8.4 `AsyncAPISupport.md` | 1 | 1 | 7 | 0 |
+| **Total** | **15** | **12** | **49** | **6** |
+
+**The residue is 6 of 49, 12%** — in line with phase 7's 1 of 9 and well below phase 3's and
+phase 5's 13%, because phase 8 writes no subscriptions and the three parameters that carry most
+of the residue elsewhere never appear. Four of the six are the same shape: a required
+constructor parameter feeding an `init`-only property, so an instantiated object reads back the
+argument the checker had to supply. The other two are `MongoDbConfiguration.Client` (the same
+shape) and `TimeProvider` (no printable value).
+
+**Every task's figures came out exactly as design §7.3 and §7.4 predicted, and §2.9's floors did
+not bite.** `DynamoDbConfiguration` 7, `MongoDbConfiguration` 7, `MongoDbCollectionConfiguration`
+5, `InMemoryBoxConfiguration` 4, `TimedOutboxSweeperOptions` 4, `TimedOutboxArchiverOptions` 4,
+`BoxProvisioningOptions` 2, `DynamoDbInboxConfiguration` 1, `DynamoDbLockingProviderOptions` 4,
+`AzureBlobLockingProviderOptions` 3, `PostgresLockingProviderOptions` 1. **§2.9 lists three of
+these as under-counted; the rebuilt `survey.py` now agrees with `optioncheck` on all eleven**
+(`survey.py --ref 10.7.0 --tsv`), so those floors were properties of the *pre-phase-1* survey
+that design §12.5 read, not of the corpus today. **The one figure that did move is design
+§7.6's**: `AsyncApiOptions` is **7**, not 6, and both instruments say so.
+
+**The only figure in play moved and the other six did not.** `optioncheck` 39 tables/436 rows →
+**51/485**; link **160 files**, pagelint **158 pages, 0 errors, 783 warnings**, shape **157
+pages, widest 12 of 20**, `--check-redirects` **77 entries / 7858 bytes**, `versioncheck.py`
+**0 stale of 18** — all five unmoved, which is what a phase that creates no page predicts, and
+`--verify` is unmoved for the same reason. **The using-directive debt did not move either.**
+
+**`pagelint --changed origin/master` reports `16 file(s), 28 hunk(s) … 15 documentation
+page(s), 0 code block(s) strict` — the sixteenth file is this one — and that vacuity is the
+deliverable rather than a gap.**
+Standing obligation 8 says the cheapest defence against rule 6 is placement; twelve tables went
+in among the **53** C# blocks those fifteen pages carry and **not one block overlaps the
+diff**, so
+the debt is unchanged and no block was dragged into strict scope. Read the scope line, not the
+verdict: this run says nothing about the strict rules, legitimately.
+
+**AC8 walked, mechanically and by reading.** All 49 rows are four cells, no `Default` is blank,
+every description is one present-tense sentence ending in a full stop, and every `Type` is a
+code span. The eleven pages carrying a table were re-read for the sentence-per-row rule as
+well, because the mechanical check cannot see a description that is a rationale.
+
+#### §2.7's twelve are now all accounted for
+
+Five lock tables normalised at task 8.3 — three became marked tables (`DynamoDbDistributedLock`,
+`AzureBlobDistributedLock`, `PostgresDistributedLock`) and two became **links** to the table
+that owns the type (`MongoDbDistributedLock` → `MongoDBOutbox.md#mongodb-outbox-options`,
+`FirestoreDistributedLock` → `FirestoreOutbox.md#firestore-outbox-options`, which is phase 7's
+handover paid). With task 5.5's three, task 2.6's one and task 8.4's one, that is ten of twelve
+normalised and `CausationTrackingStores.md`'s two deliberately left alone: they are an interface
+contract, not options, and they get no marker.
+
+**Two pages state an absence instead of carrying a table.** `MsSqlDistributedLock.md` and
+`MySqlDistributedLock.md` already said the provider takes no options class; what they gained is
+the link to D15, so a reader who needs the connection surface has somewhere to go. Those are
+two of standing obligation 4's seven instances, and the pages already reported the absence —
+what was missing was where to go next.
+
+#### The ledger — seven entries, and `optioncheck` found none of them
+
+All seven were found by writing a table from the type, which is standing obligation 3 doing the
+work the checker cannot: five are options the corpus never mentioned or described wrongly, and
+two are properties that exist and do nothing.
+
+| Page | What the corpus said | What the assembly says |
+|---|---|---|
+| `AsyncAPISupport.md:173` | `AssembliesToScan` defaults to *Entry assembly* | it is initialised to **`null`**; the default scan set is chosen downstream |
+| `BrighterOutboxSupport.md:179` | `MinimumMessageAge` is *the age of a message in milliseconds*, default 5000 | it is a **`TimeSpan`**, `TimeSpan.FromSeconds(5)` |
+| `OutboxArchiver.md:40` | three configurables | there are **four** — `Instrumentation` was undocumented |
+| `BoxProvisioningConfiguration.md` | nothing | **`MigrationHistoryScope`** appeared nowhere in the corpus, on any page |
+| `AzureBlobDistributedLock.md:42` | `StorageLocationFunc` as a table row beside three properties | it is a **public field**, invisible to reflection over properties; moved to prose |
+| `DynamoOutbox.md:187` | `DynamoDbConfiguration.CausationIndexName` defaults to `"Causation"` | **no such member exists at `10.7.0`** — see below |
+| `FirestoreDistributedLock.md:79` | setting `Ttl` *lets stale locks expire* | `Ttl` writes a field; Firestore deletes nothing without a **TTL policy** (phase 7's finding, one family over) |
+
+**Two options exist and are read by nothing**, which is a fact about the product rather than
+drift, and both are now stated on the page: `DynamoDbConfiguration.Timeout` is assigned in the
+constructor and never read — the timeouts that take effect are the `outBoxTimeout` arguments on
+the Outbox's own methods — and `DynamoDbInboxConfiguration.Credentials` and `Region` are read
+nowhere either. The Inbox pair is also the spec's first **V3/V4 divergence**: the two are
+get-only in `Paramore.Brighter.Inbox.DynamoDB` and settable in `.V4`, so the same type name has
+1 option in the pinned package and 3 in the one the page recommends. The marker binds the
+pinned one; the page says the rest in a sentence.
+
+#### `DynamoOutbox.md` documents a property that has not shipped
+
+`CausationIndexName` is absent from `git show 10.7.0:…/DynamoDbConfiguration.cs` **and** from
+the assembly `optioncheck` reflects over, and NuGet's latest for
+`paramore.brighter.outbox.dynamodb` is `10.7.0`. It exists on Brighter `master`, added between
+the tag (2026-07-29) and 2026-08-01. So the page's *The index name* section — and the wider
+replay-on-seen material it belongs to — describes the **next** release as though it were the
+current one, and a reader on 10.7.0 finds no such property to set.
+
+**Phase 8 changed nothing about it**, deliberately: the section is one page of a family
+(`ReplayOnSeen.md`, `ReplayOnSeenReference.md`, `CausationTrackingStores.md` and this one), and
+version-flagging one page of four would leave the corpus less consistent than it is now. The
+seven-row table beside it is written from the pinned type and says nothing about replay, so
+nothing on the page contradicts anything else. **It is recorded here as a question for the
+maintainer** — whether the corpus documents the latest release or the tip — and it is the
+first time this programme has met the question at all.
 
 ---
 


### PR DESCRIPTION
Phase 8 of spec 012: **fifteen pages edited, twelve marked tables, 49 rows, no page created.**
`optioncheck` goes from 39 tables / 436 rows to **51 / 485**, exit 0.

| Task | Pages | Tables | Rows | `manual:` |
|---|---:|---:|---:|---:|
| 8.1 outboxes | 3 | 4 | 23 | 2 |
| 8.2 sweeper, archiver, provisioning, Dynamo inbox | 4 | 4 | 11 | 0 |
| 8.3 locks | 7 | 3 | 8 | 4 |
| 8.4 `AsyncAPISupport.md` | 1 | 1 | 7 | 0 |
| **Total** | **15** | **12** | **49** | **6** |

Every figure came out as design §7.3 and §7.4 predicted. The one that moved is design §7.6's:
`AsyncApiOptions` is **7**, not 6 — and the rebuilt `survey.py` and `optioncheck` agree.

`§2.7`'s twelve option tables are now all accounted for: five locks normalised here (three
became marked tables, two link the table that owns the type), three at task 5.5, one at task
2.6, one here at 8.4, and `CausationTrackingStores.md`'s two deliberately left alone.

### The ledger — seven entries, none of which `optioncheck` could see

| Page | What the corpus said | What the assembly says |
|---|---|---|
| `AsyncAPISupport.md:173` | `AssembliesToScan` defaults to *Entry assembly* | initialised to `null` |
| `BrighterOutboxSupport.md:179` | `MinimumMessageAge` is *milliseconds*, default 5000 | a `TimeSpan` of 5 seconds |
| `OutboxArchiver.md:40` | three configurables | four — `Instrumentation` was undocumented |
| `BoxProvisioningConfiguration.md` | nothing | `MigrationHistoryScope` appeared nowhere in the corpus |
| `AzureBlobDistributedLock.md:42` | `StorageLocationFunc` as a table row | a public field; moved to prose |
| `DynamoOutbox.md:187` | `DynamoDbConfiguration.CausationIndexName` | **no such member at `10.7.0`** |
| `FirestoreDistributedLock.md:79` | `Ttl` *lets stale locks expire* | `Ttl` writes a field; nothing expires without a TTL policy |

Two options exist and are read by nothing — `DynamoDbConfiguration.Timeout`, and the Dynamo
inbox's `Credentials` / `Region` — and both are now stated on the page.

**`CausationIndexName` is a question rather than a fix.** It is absent from the `10.7.0` tag and
from the pinned assembly, and NuGet's latest is `10.7.0`; it exists on Brighter `master`. So
`DynamoOutbox.md`'s replay material documents the *next* release as current. Nothing was changed
— version-flagging one page of a four-page family would leave the corpus less consistent than it
is — and it is recorded in `tasks.md` for a ruling.

### Gates

```
python3 tools/linkcheck.py                 # No broken internal links (160 files checked).
python3 tools/pagelint.py                  # 0 errors, 783 warnings, 158 pages
python3 tools/urlmap.py --check-shape      # 0 — 157 pages, widest 12 of 20
python3 tools/urlmap.py --check-redirects  # 0 — 77 entries, 7858 bytes
python3 tools/versioncheck.py              # 0 stale pins of 18 across 5 page(s)
dotnet run --project tools/optioncheck     # 0 mismatches across 51 tables and 485 rows
```

All unmoved but `optioncheck`, which is what a phase creating no page predicts.
`pagelint --changed origin/master` reports `16 file(s), 28 hunk(s) … 0 code block(s) strict`:
twelve tables went in among 53 C# blocks and not one was dragged into strict scope, so the
using-directive debt stays at 783. AC8 walked over all 49 rows, mechanically and by reading.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0146UueHL6H3zGBGTYwz7GtL