### PR TITLE
docs: mark Replay On Seen as not yet released

### DIFF
--- a/contents/CausationTrackingStores.md
+++ b/contents/CausationTrackingStores.md
@@ -9,6 +9,11 @@ layout:
 
 > **How-to** · Applies to **Brighter V10**
 
+> **Not in a released package yet.** Replay On Seen ships **after Brighter 10.7.0**, which is
+> the current release. `OnceOnlyAction.Replay`, `SupportsCausationTracking` and the Causation Id
+> plumbing this page describes are on Brighter's development branch and are in no version you
+> can install today, so treat what follows as the feature as it will ship.
+
 [Replay On Seen](/contents/ReplayOnSeen.md) needs two things from your storage. It needs
 an Inbox that can hand back the [Causation Id](/contents/ReplayOnSeen.md#causation-id) it
 recorded when a request was first handled, and an Outbox that can find every message stored

--- a/contents/DynamoOutbox.md
+++ b/contents/DynamoOutbox.md
@@ -124,6 +124,12 @@ settable property and is in the table above.
 
 ## Replay Support: The Causation Index
 
+> **Not in a released package yet.** This section describes
+> [Replay On Seen](/contents/ReplayOnSeen.md), which ships **after Brighter 10.7.0** — the
+> current release. `DynamoDbConfiguration.CausationIndexName` and the `CausationId` attribute
+> below are on Brighter's development branch and are in no version you can install today, which
+> is why `CausationIndexName` is absent from the options table above.
+
 [Replay On Seen](/contents/ReplayOnSeen.md) resends every Outbox message produced under a given Causation Id. On DynamoDB that means querying on a non-key attribute, which needs a Global Secondary Index — by default one named **Causation**, with `CausationId` as its hash key.
 
 This applies to both `Paramore.Brighter.Outbox.DynamoDB` and `.V4`. The DynamoDB **Inbox** needs nothing: it looks a Causation Id up by the table's own primary key.

--- a/contents/ReplayOnSeen.md
+++ b/contents/ReplayOnSeen.md
@@ -9,6 +9,11 @@ layout:
 
 > **Explanation** · Applies to **Brighter V10**
 
+> **Not in a released package yet.** Replay On Seen ships **after Brighter 10.7.0**, which is
+> the current release. `OnceOnlyAction.Replay`, `SupportsCausationTracking` and the Causation Id
+> plumbing this page describes are on Brighter's development branch and are in no version you
+> can install today, so treat what follows as the feature as it will ship.
+
 When your [Inbox](/contents/BrighterInboxSupport.md) recognises a message it has already
 handled, it normally throws or logs a warning and stops — the work is done, so there is
 nothing to do. `OnceOnlyAction.Replay` changes what a duplicate means: instead of stopping,

--- a/contents/ReplayOnSeenReference.md
+++ b/contents/ReplayOnSeenReference.md
@@ -9,6 +9,11 @@ layout:
 
 > **Reference** · Applies to **Brighter V10** · Prerequisites: [Replay On Seen](/contents/ReplayOnSeen.md)
 
+> **Not in a released package yet.** Replay On Seen ships **after Brighter 10.7.0**, which is
+> the current release. `OnceOnlyAction.Replay`, `SupportsCausationTracking` and the Causation Id
+> plumbing this page describes are on Brighter's development branch and are in no version you
+> can install today, so treat what follows as the feature as it will ship.
+
 Which stores support Replay On Seen, the cases where it does not fire, the events it emits, and its limitations. For the concept see [Replay On Seen](/contents/ReplayOnSeen.md); for the procedure see [Turning On Replay On Seen](/contents/TurningOnReplayOnSeen.md).
 
 ## Store Support

--- a/contents/TurningOnReplayOnSeen.md
+++ b/contents/TurningOnReplayOnSeen.md
@@ -9,6 +9,11 @@ layout:
 
 > **How-to** · Applies to **Brighter V10** · Prerequisites: [Replay On Seen](/contents/ReplayOnSeen.md)
 
+> **Not in a released package yet.** Replay On Seen ships **after Brighter 10.7.0**, which is
+> the current release. `OnceOnlyAction.Replay`, `SupportsCausationTracking` and the Causation Id
+> plumbing this page describes are on Brighter's development branch and are in no version you
+> can install today, so treat what follows as the feature as it will ship.
+
 This page is the procedure: what to switch on, what you must thread through your code, what to check before you enable it, and a worked example. For what Replay On Seen is and why it behaves as it does, see [Replay On Seen](/contents/ReplayOnSeen.md).
 
 ## Turning It On

--- a/spec/012-configuration_reference/tasks.md
+++ b/spec/012-configuration_reference/tasks.md
@@ -1935,13 +1935,25 @@ the tag (2026-07-29) and 2026-08-01. So the page's *The index name* section — 
 replay-on-seen material it belongs to — describes the **next** release as though it were the
 current one, and a reader on 10.7.0 finds no such property to set.
 
-**Phase 8 changed nothing about it**, deliberately: the section is one page of a family
-(`ReplayOnSeen.md`, `ReplayOnSeenReference.md`, `CausationTrackingStores.md` and this one), and
-version-flagging one page of four would leave the corpus less consistent than it is now. The
-seven-row table beside it is written from the pinned type and says nothing about replay, so
-nothing on the page contradicts anything else. **It is recorded here as a question for the
-maintainer** — whether the corpus documents the latest release or the tip — and it is the
-first time this programme has met the question at all.
+**Phase 8's own PR changed nothing about it**, deliberately: the section is one page of a
+family, and version-flagging one page of several would leave the corpus less consistent than it
+is. The seven-row table beside it is written from the pinned type and says nothing about
+replay, so nothing on the page contradicts anything else.
+
+**Ruled the same day: the four pages carry a marker, and the count was five, not four.**
+Measured rather than assumed — `OnceOnlyAction.Replay`, `SupportsCausationTracking`,
+`ReplayCausation` and `CausationId` are **all absent from `10.7.0` and all present on
+`origin/master`**, so the whole feature is unreleased, and **fifteen** pages mention it.
+Weighting by how much replay material each carries put the flag where a reader could actually
+be misled: the four dedicated pages — `ReplayOnSeen.md` (28 hits), `ReplayOnSeenReference.md`
+(60), `TurningOnReplayOnSeen.md` (55), `CausationTrackingStores.md` (32) — take a blockquote
+below the banner, and `DynamoOutbox.md`'s *Replay Support* section (14) takes one of its own
+naming `CausationIndexName`. The remaining ten mention it in passing and take nothing.
+
+**The blockquote goes immediately below the banner and rule 7 does not notice**, which is worth
+knowing before the next such marker: `opening_sentence()` passes over blockquotes by design, so
+all five pages keep the opening sentence their `description:` front matter was derived from —
+asserted by calling the extractor directly rather than inferred from a green run.
 
 ---
 


### PR DESCRIPTION
Phase 8 found that `DynamoOutbox.md` documents `DynamoDbConfiguration.CausationIndexName`, which
**does not exist in any released version**: absent from the `10.7.0` tag and from the assembly
`optioncheck` reflects over, present on Brighter's development branch, and NuGet's latest for
every Brighter package is `10.7.0`.

Measured across the whole feature rather than the one property — `OnceOnlyAction.Replay`,
`SupportsCausationTracking`, `ReplayCausation` and `CausationId` are **all** absent at `10.7.0`
and **all** present on `origin/master`. `OnceOnlyAction` at the tag is `Throw, Warn`; on the
branch it is `Throw, Warn, Replay`. So Replay On Seen is unreleased in its entirety, and
**fifteen** pages mention it.

**Five pages carry the marker**, chosen by how much replay material each holds so the flag lands
where a reader could be misled:

| Page | Replay hits | Marker |
|---|---:|---|
| `ReplayOnSeenReference.md` | 60 | blockquote below the banner |
| `TurningOnReplayOnSeen.md` | 55 | blockquote below the banner |
| `CausationTrackingStores.md` | 32 | blockquote below the banner |
| `ReplayOnSeen.md` | 28 | blockquote below the banner |
| `DynamoOutbox.md` | 14 | one on the *Replay Support* section, naming `CausationIndexName` |

The other ten pages mention it in passing and take nothing.

**Rule 7 is not disturbed.** `opening_sentence()` passes over blockquotes by design, so all five
pages keep the sentence their `description:` front matter was derived from — asserted by calling
the extractor directly rather than inferred from the green run.

Gates: link `160 files`, pagelint `0 errors, 783 warnings, 158 pages`, shape `157 pages, widest
12 of 20`, redirects `77 / 7858`, versioncheck `0 stale of 18`, optioncheck `0 mismatches across
51 tables and 485 rows`. `pagelint --changed` reaches `0 code block(s) strict` — the diff is five
blockquotes and a paragraph in `tasks.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0146UueHL6H3zGBGTYwz7GtL