### PR TITLE
docs: the DynamoDB Outbox ignores outBoxTimeout too

### DIFF
--- a/contents/DynamoOutbox.md
+++ b/contents/DynamoOutbox.md
@@ -118,8 +118,10 @@ two settings that govern expiry and scan concurrency.
 surface as the get-only `Timeout` and `NumberOfShards`. `numberOfShards` defaults to 3 and
 shards the outstanding index so an active topic does not build a hot partition; the Outbox
 throws `ArgumentOutOfRangeException` above 20. `timeout` defaults to 500 and **nothing reads
-it** — the timeouts that take effect are the `outBoxTimeout` arguments on the Outbox's own
-methods. `tableName` and `scanConcurrency` are constructor parameters as well, but each has a
+it**; neither does the DynamoDB Outbox read the `outBoxTimeout` argument the `IAmAnOutbox`
+methods take, which it accepts and passes between overloads without ever acting on. Configure
+timeouts on the `AmazonDynamoDBClient` you hand to the Outbox instead. `tableName` and
+`scanConcurrency` are constructor parameters as well, but each has a
 settable property and is in the table above.
 
 ## Replay Support: The Causation Index


### PR DESCRIPTION
A correction to one sentence phase 8 shipped in #138.

The claim that `DynamoDbConfiguration.Timeout` is never read is right. The clause attached to
it — *"the timeouts that take effect are the `outBoxTimeout` arguments on the Outbox's own
methods"* — is wrong. At `10.7.0`, every occurrence of `outBoxTimeout` / `outboxTimeout` in
`DynamoDbOutbox.cs` is a doc comment, a parameter declaration, or a pass-through from a sync
overload to its async twin; the terminal `AddAsync`, `GetAsync` and `DispatchedMessagesAsync`
bodies never read it. **The DynamoDB Outbox ignores both timeouts.**

Verified with a control, because a grep that finds nothing has the same shape as a grep that is
looking in the wrong place: `_configuration.TableName` is read three times in the same file, and
`TableName` is read 41 times across `src/`.

The page now says both are ignored and points at the `AmazonDynamoDBClient`, which is where a
timeout can actually be configured.

`pagelint --changed` reports `1 file(s), 1 hunk(s) … 0 code block(s) strict`; `optioncheck` is
`0 mismatches across 1 table and 7 rows` on the page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0146UueHL6H3zGBGTYwz7GtL