### PR TITLE
012 phase 9 — the schedulers: seven option tables across six pages

### DIFF
--- a/contents/AwsScheduler.md
+++ b/contents/AwsScheduler.md
@@ -170,6 +170,52 @@ Uses AWS SDK for .NET v3 (deprecated in AWS).
 
 ## AWS Scheduler Configuration
 
+### AWS Scheduler Factory Options
+
+`AwsSchedulerFactory` takes the AWS connection and the IAM role as constructor arguments and
+exposes the rest as properties. The surface is the same in both packages: `AWS` and `AWS.V4`
+declare the same ten options with the same defaults, and differ only in the AWS SDK they bind.
+
+<!-- optioncheck: Paramore.Brighter.MessageScheduler.AWS.AwsSchedulerFactory
+     manual: TimeProvider — initialised to TimeProvider.System, which has no printable value
+     manual: Group — initialised to a new SchedulerGroup, which has no printable value; its own defaults are the table below
+     manual: GetOrCreateMessageSchedulerId — a delegate returning a fresh identifier, which has no printable value
+     manual: GetOrCreateRequestSchedulerId — a delegate returning a fresh identifier, which has no printable value
+     manual: Role — set from a required constructor parameter, so an instance reads back that argument rather than a default
+-->
+
+| Option | Type | Default | Description |
+|---|---|---|---|
+| `TimeProvider` | `TimeProvider` | `TimeProvider.System` | The clock the scheduler measures delays against. |
+| `Group` | `SchedulerGroup` | a new `SchedulerGroup` | The EventBridge Scheduler group Brighter creates schedules in. |
+| `GetOrCreateMessageSchedulerId` | `Func<Message, string>` | a fresh identifier per message | Names the schedule Brighter creates for a message. |
+| `GetOrCreateRequestSchedulerId` | `Func<IRequest, string>` | a fresh identifier per request | Names the schedule Brighter creates for a request. |
+| `FlexibleTimeWindowMinutes` | `int?` | `null` | The window, in minutes, within which AWS may run the schedule; the schedule runs at its exact time when this is null. |
+| `SchedulerTopicOrQueue` | `RoutingKey` | `empty` | Names the topic or queue `FireAwsScheduler` messages are published to. |
+| `Role` | `string` | `none` | Names the IAM role, as a role name or an ARN, that EventBridge Scheduler assumes to deliver the message. |
+| `UseMessageTopicAsTarget` | `bool` | `true` | Targets the message's own topic or queue directly rather than routing through a `FireAwsScheduler` message. |
+| `OnConflict` | `OnSchedulerConflict` | `Throw` | What Brighter does when a schedule with the same identifier already exists. |
+| `MakeRole` | `OnMissingRole` | `Assume` | What the factory does about the IAM role before it schedules. |
+
+`Role` is a constructor argument rather than a property with a default, so every factory names
+a role. `OnSchedulerConflict` is `Throw` or `Overwrite`; `OnMissingRole` is `Assume`,
+`Validate` or `Create`, and [Automatic Role Creation](#automatic-role-creation) covers the
+last of them.
+
+### AWS Scheduler Group Options
+
+`Group` takes a `SchedulerGroup`, which carries three options of its own.
+
+<!-- optioncheck: Paramore.Brighter.MessageScheduler.AWS.SchedulerGroup
+     manual: Tags — initialised to a list holding one Tag, which has no printable value
+-->
+
+| Option | Type | Default | Description |
+|---|---|---|---|
+| `Name` | `string` | `"default"` | Names the EventBridge Scheduler group the schedules belong to. |
+| `Tags` | `List<Tag>` | one tag, `Source` = `Brighter` | The tags Brighter applies to the group when it creates it. |
+| `MakeSchedulerGroup` | `OnMissingSchedulerGroup` | `Assume` | What the factory does when the group does not exist. |
+
 ### Basic Configuration
 
 Configure AWS Scheduler with minimal settings:
@@ -451,6 +497,9 @@ public class TrialService
 | **Components** | Fewer | More (requires Dispatcher) |
 | **Flexibility** | Target must exist | More flexible |
 | **Recommended For** | Production messages | Requests and commands |
+
+`UseMessageTopicAsTarget` defaults to `true`, so a factory schedules direct to target unless
+you say otherwise — see [AWS Scheduler Factory Options](#aws-scheduler-factory-options).
 
 ## AWS Scheduler Best Practices
 

--- a/contents/AzureScheduler.md
+++ b/contents/AzureScheduler.md
@@ -136,6 +136,27 @@ dotnet add package Paramore.Brighter.MessageScheduler.Azure
 
 ## Azure Scheduler Configuration
 
+### Azure Scheduler Factory Options
+
+`AzureServiceBusSchedulerFactory` takes the client provider and the scheduler topic as
+constructor arguments, and reads both back as properties you can also set on the initialiser.
+
+<!-- optioncheck: Paramore.Brighter.MessageScheduler.Azure.AzureServiceBusSchedulerFactory
+     manual: Topic — set from a required constructor parameter, so an instance reads back that argument rather than a default
+     manual: TimeProvider — initialised to TimeProvider.System, which has no printable value
+-->
+
+| Option | Type | Default | Description |
+|---|---|---|---|
+| `ClientProvider` | `IServiceBusClientProvider` | `null` | Supplies the Service Bus client the scheduler sends through, and carries the credential. |
+| `SenderOptions` | `ServiceBusSenderOptions?` | `null` | The options the scheduler creates its Service Bus sender with. |
+| `Topic` | `RoutingKey` | `none` | Names the topic or queue scheduled messages are sent to. |
+| `TimeProvider` | `TimeProvider` | `TimeProvider.System` | The clock the scheduler measures delays against. |
+
+`ClientProvider` and `Topic` are constructor arguments rather than properties with defaults,
+so every factory supplies both. Setting them on the initialiser replaces what you passed;
+neither can be left out.
+
 ### Basic Configuration
 
 Configure Azure Service Bus Scheduler with minimal settings:

--- a/contents/HangfireScheduler.md
+++ b/contents/HangfireScheduler.md
@@ -100,6 +100,30 @@ dotnet add package Hangfire.Mongo
 
 ## Hangfire Configuration
 
+### Hangfire Scheduler Factory Options
+
+`HangfireMessageSchedulerFactory` takes no constructor arguments and exposes three properties.
+Storage, retries, the dashboard and the worker count all belong to Hangfire itself and are
+configured through `AddHangfire`, not here.
+
+<!-- optioncheck: Paramore.Brighter.MessageScheduler.Hangfire.HangfireMessageSchedulerFactory
+     manual: Queue — the factory reaches Hangfire's JobStorage static as it is constructed, so no default on this type is readable outside a configured Hangfire host
+     manual: Client — the factory reaches Hangfire's JobStorage static as it is constructed, so no default on this type is readable outside a configured Hangfire host
+     manual: TimeProvider — the factory reaches Hangfire's JobStorage static as it is constructed, so no default on this type is readable outside a configured Hangfire host
+-->
+
+| Option | Type | Default | Description |
+|---|---|---|---|
+| `Queue` | `string?` | `null` | Names the Hangfire queue scheduled jobs are enqueued on; Hangfire uses its `default` queue when this is null. |
+| `Client` | `IBackgroundJobClientV2` | a new `BackgroundJobClient` | The Hangfire client the scheduler enqueues jobs through. |
+| `TimeProvider` | `TimeProvider` | `TimeProvider.System` | The clock the scheduler measures delays against. |
+
+**`Client` is created eagerly, so configure Hangfire before you construct the factory.**
+Its initialiser calls `new BackgroundJobClient()`, which reads Hangfire's `JobStorage.Current`
+static and throws `InvalidOperationException: Current JobStorage instance has not been
+initialized yet` when no storage is registered. Register your Hangfire storage before the
+factory is constructed, as the complete examples below do.
+
 ### Basic Configuration
 
 Configure Brighter with Hangfire scheduler:

--- a/contents/InMemoryScheduler.md
+++ b/contents/InMemoryScheduler.md
@@ -123,13 +123,33 @@ public class AnalyticsService
 
 ## InMemory Scheduler Configuration
 
+### InMemory Scheduler Factory Options
+
+`InMemorySchedulerFactory` takes no constructor arguments, so `new InMemorySchedulerFactory()`
+is a complete configuration; these four properties are what you can change about it.
+
+<!-- optioncheck: Paramore.Brighter.InMemorySchedulerFactory
+     manual: TimeProvider — initialised to TimeProvider.System, which has no printable value
+     manual: GetOrCreateMessageSchedulerId — a delegate returning a fresh identifier, which has no printable value
+     manual: GetOrCreateRequestSchedulerId — a delegate returning a fresh identifier, which has no printable value
+-->
+
+| Option | Type | Default | Description |
+|---|---|---|---|
+| `TimeProvider` | `TimeProvider` | `TimeProvider.System` | The clock the scheduler measures delays against, and the seam a `FakeTimeProvider` replaces in a test. |
+| `GetOrCreateMessageSchedulerId` | `Func<Message, string>` | a fresh identifier per message | Names the timer Brighter creates for a message. |
+| `GetOrCreateRequestSchedulerId` | `Func<IRequest, string>` | a fresh identifier per request | Names the timer Brighter creates for a request. |
+| `OnConflict` | `OnSchedulerConflict` | `Throw` | What Brighter does when a timer with the same identifier already exists. |
+
+`OnSchedulerConflict` is `Throw` or `Overwrite`.
+
 ### Basic Configuration
 
 Configure the InMemory Scheduler with `InMemorySchedulerFactory`:
 
 ```csharp
 using Paramore.Brighter.Extensions.DependencyInjection;
-using Paramore.Brighter.InMemoryScheduler;
+using Paramore.Brighter;
 
 var builder = WebApplication.CreateBuilder(args);
 

--- a/contents/QuartzScheduler.md
+++ b/contents/QuartzScheduler.md
@@ -64,6 +64,28 @@ dotnet add package Quartz.Serialization.Json
 
 ## Quartz Configuration
 
+### Quartz Scheduler Factory Options
+
+`QuartzSchedulerFactory` takes the Quartz `IScheduler` as its constructor argument and exposes
+four properties. Everything else about Quartz — the job store, clustering, misfire policy — is
+configured on Quartz itself, not on Brighter's factory.
+
+<!-- optioncheck: Paramore.Brighter.MessageScheduler.Quartz.QuartzSchedulerFactory
+     manual: TimeProvider — initialised to TimeProvider.System, which has no printable value
+     manual: GetOrCreateSchedulerId — a delegate returning a fresh identifier, which has no printable value
+     manual: GetOrCreateRequestSchedulerId — a delegate returning a fresh identifier, which has no printable value
+-->
+
+| Option | Type | Default | Description |
+|---|---|---|---|
+| `TimeProvider` | `TimeProvider` | `TimeProvider.System` | The clock the scheduler measures delays against. |
+| `Group` | `string?` | `null` | Names the Quartz job group scheduled jobs are created in; Quartz uses its own default group when this is null. |
+| `GetOrCreateSchedulerId` | `Func<Message, string>` | a fresh identifier per message | Names the Quartz job Brighter creates for a message. |
+| `GetOrCreateRequestSchedulerId` | `Func<IRequest, string>` | a fresh identifier per request | Names the Quartz job Brighter creates for a request. |
+
+The message hook is `GetOrCreateSchedulerId` here and `GetOrCreateMessageSchedulerId` on the
+AWS and InMemory factories; the request hook carries the same name on all three.
+
 ### Basic Configuration
 
 Configure Brighter with Quartz scheduler:

--- a/contents/TickerQScheduler.md
+++ b/contents/TickerQScheduler.md
@@ -56,6 +56,25 @@ dotnet add package TickerQ.EntityFrameworkCore
 
 ## TickerQ Configuration
 
+### TickerQ Scheduler Factory Options
+
+`TickerQSchedulerFactory` is the one scheduler factory with **no settable properties at all**.
+Its whole surface is three required constructor arguments, and a reader cannot construct it
+without all three; the two properties it does expose, `GetOrCreateSchedulerId` and
+`ParseSchedulerId`, are get-only and cannot be replaced.
+
+<!-- optioncheck: Paramore.Brighter.MessageScheduler.TickerQ.TickerQSchedulerFactory -->
+
+| Option | Type | Default | Description |
+|---|---|---|---|
+| `timeTickerManager` | `ITimeTickerManager<TimeTickerEntity>` | `none` | Adds, updates and deletes the time tickers Brighter schedules messages with. |
+| `tickerPersistenceProvider` | `ITickerPersistenceProvider<TimeTickerEntity, CronTickerEntity>` | `none` | Reads a ticker back by its identifier when a scheduled message is rescheduled. |
+| `timeProvider` | `TimeProvider` | `none` | The clock the scheduler measures delays against. |
+
+All three come out of the container, which is why every example below builds the factory from
+a `provider` rather than with `new`. Everything else about TickerQ — persistence, the
+dashboard, the poll interval — is configured on TickerQ itself through `AddTickerQ`.
+
 ### Basic Configuration
 
 Configure Brighter with TickerQ scheduler in your `Program.cs`:

--- a/spec/012-configuration_reference/redproof/fixture_hangfire.md
+++ b/spec/012-configuration_reference/redproof/fixture_hangfire.md
@@ -1,0 +1,30 @@
+# Fixture — a type that cannot be constructed at all
+
+Not a documentation page. `redproof_optioncheck.py` mutates this file; it lives
+outside `contents/` so no gate in this repository reads it, and `optioncheck`
+sees it only because it takes path arguments.
+
+`HangfireMessageSchedulerFactory` throws `InvalidOperationException: Current
+JobStorage instance has not been initialized yet` from Hangfire's own static the
+moment anything constructs it, so **every** default on the type is unreadable —
+not one member, the whole surface, permanently. Phase 9 declared all three rows
+`manual:` and the table still exited 1 on `CANNOT CONSTRUCT`, whose predicate
+never consulted the declarations. That left no green path to a correct table:
+the only remedy was deleting the marker, which takes the `Option` and `Type`
+columns out of scope too.
+
+The predicate now fires unless every unreadable member is declared. **This
+fixture is the assertion that it still fires**: delete one `manual:` line and
+the finding must come back, naming the row that is no longer declared.
+
+<!-- optioncheck: Paramore.Brighter.MessageScheduler.Hangfire.HangfireMessageSchedulerFactory
+     manual: Queue — the type cannot be constructed, so no default on it is readable
+     manual: Client — the type cannot be constructed, so no default on it is readable
+     manual: TimeProvider — the type cannot be constructed, so no default on it is readable
+-->
+
+| Option | Type | Default | Description |
+|---|---|---|---|
+| `Queue` | `string?` | `null` | The Hangfire queue scheduled jobs are enqueued on. |
+| `Client` | `IBackgroundJobClientV2` | a `BackgroundJobClient` | The Hangfire client the scheduler enqueues through. |
+| `TimeProvider` | `TimeProvider` | `TimeProvider.System` | The clock delays are measured against. |

--- a/spec/012-configuration_reference/redproof/redproof_optioncheck.py
+++ b/spec/012-configuration_reference/redproof/redproof_optioncheck.py
@@ -8,11 +8,14 @@ caught -- NOT merely that the tool runs", AC3b for one on a body-coalesced
 default, and AC5 for exit 2 being distinguishable from exit 0. This is all
 three, in 009's `redproof_versioncheck.py` shape.
 
-Branch 7 was added at phase 5 and is the only one here about a GREEN build:
-`RmqMessagingGatewayConnection.Name` is `= Environment.MachineName`, so the
-checker read a real value and a table printing it passed on the author's machine
-and would have failed on the CI runner. It uses a second fixture, because the
-subscription one has no environment-derived member to declare.
+Branch 7 was added at phase 5 and branch 8 at phase 9; they are the two here
+about a GREEN build. `RmqMessagingGatewayConnection.Name` is
+`= Environment.MachineName`, so the checker read a real value and a table
+printing it passed on the author's machine and would have failed on the CI
+runner. `HangfireMessageSchedulerFactory` cannot be constructed at all, so a
+table declaring every row `manual:` was still red with no green path to a
+correct table. Each uses its own fixture, because the subscription one has
+neither an environment-derived member nor an unconstructable type.
 
 The discipline is 009's:
 
@@ -45,6 +48,7 @@ REPO = os.path.dirname(os.path.dirname(os.path.dirname(HERE)))
 
 FIXTURE = os.path.join(HERE, 'fixture_subscription.md')
 CONNECTION = os.path.join(HERE, 'fixture_connection.md')
+HANGFIRE = os.path.join(HERE, 'fixture_hangfire.md')
 PROJECT = os.path.join(REPO, 'tools', 'optioncheck')
 BIN = os.path.join(PROJECT, 'bin', 'Debug', 'net9.0')
 DLL = os.path.join(BIN, 'optioncheck.dll')
@@ -235,6 +239,58 @@ def main():
 
     assert digest(CONNECTION) == connection, 'the connection fixture did not survive the probe'
     print(f'connection fixture restored byte-identical: sha256 {digest(CONNECTION)}')
+
+    # -------------------------------- 8. a type that cannot be constructed
+    # Phase 9's finding, and the second branch here about a GREEN build.
+    # `HangfireMessageSchedulerFactory` throws from Hangfire's own static, so
+    # every default on the type is unreadable and CANNOT CONSTRUCT fired even
+    # when all three rows were declared `manual:` -- no green path to a correct
+    # table existed, and the only remedy was deleting the marker. The predicate
+    # now consults the declarations. THIS IS THE ASSERTION THAT IT STILL FIRES:
+    # one undeclared row must bring it back, by name.
+    #
+    # Like branch 7 the mutation DELETES a declaration rather than writing a
+    # value, and for the same reason: the fixture must not depend on a default
+    # nobody can read.
+    hangfire = digest(HANGFIRE)
+    third = os.path.join(tempfile.mkdtemp(), 'fixture_hangfire.md')
+    shutil.copy2(HANGFIRE, third)
+    assert digest(third) == hangfire, 'the copy aside is not the file'
+
+    text = read(HANGFIRE)
+    code, out = run([HANGFIRE])
+    assert 'scope: 1 table, 3 rows, 1 type' in out, (
+        'branch 8 precondition: the hangfire fixture must be IN SCOPE:\n' + out)
+    assert '3 manual: declarations' in out, (
+        'branch 8 precondition: all three rows must be DECLARED, or the '
+        f'baseline is green for a different reason than the one it tests:\n{out}')
+    assert code == 0, (
+        'branch 8 needs a green baseline: a fully-declared table on an '
+        f'unconstructable type is the case the escape exists for:\n{out}')
+    print('\nhangfire fixture baseline green: 1 table, 3 rows, 3 manual: declarations')
+
+    try:
+        mutate(text,
+               '\n     manual: Client — the type cannot be constructed, '
+               'so no default on it is readable',
+               '', HANGFIRE)
+        assert 'manual: Client' not in read(HANGFIRE), (
+            'the mutation must remove the declaration, not merely edit it')
+        assert 'manual: Queue' in read(HANGFIRE) and 'manual: TimeProvider' in read(HANGFIRE), (
+            'the mutation must leave the OTHER two declared -- the branch is '
+            'about a partly-declared table, not an undeclared one')
+        code, out = run([HANGFIRE])
+        report('8. A TYPE THAT CANNOT BE CONSTRUCTED, PARTLY DECLARED', 1, code, out,
+               'the `manual: Client` declaration is gone; the other two remain')
+        assert 'CANNOT CONSTRUCT' in out and '`Client`' in out, (
+            'exit 1 is only correct if the finding NAMES the undeclared row: a '
+            'table-level message that does not say which row is unchecked '
+            'cannot be acted on, and the escape is only safe if this fires')
+    finally:
+        write(text, HANGFIRE)
+
+    assert digest(HANGFIRE) == hangfire, 'the hangfire fixture did not survive the probe'
+    print(f'hangfire fixture restored byte-identical: sha256 {digest(HANGFIRE)}')
 
     # -------------------------------------- 6. AC5, the authority unreachable
     # Exit 2 has to be reachable as a VERDICT rather than as a restore failure:

--- a/spec/012-configuration_reference/tasks.md
+++ b/spec/012-configuration_reference/tasks.md
@@ -1987,7 +1987,7 @@ asserted by calling the extractor directly rather than inferred from a green run
 **This phase must not:** give `TickerQScheduler.md` a table. `TickerQSchedulerFactory` has
 **zero** settable properties (design §12.1). That is standing obligation 4's seventh instance.
 
-- [ ] **Task 9.1:** `AwsScheduler.md`, `QuartzScheduler.md`, `AzureScheduler.md`
+- [x] **Task 9.1:** `AwsScheduler.md`, `QuartzScheduler.md`, `AzureScheduler.md`
   - Input: `AwsSchedulerFactory` 10, `QuartzSchedulerFactory` 4,
     `AzureServiceBusSchedulerFactory` 4
   - Output: three marked tables
@@ -1996,7 +1996,7 @@ asserted by calling the extractor directly rather than inferred from a green run
     valid marker and D9 needs no new mechanism. That is the whole practical consequence of
     §12.1; the rest of it is a caution about figures.
 
-- [ ] **Task 9.2:** `InMemoryScheduler.md`, `HangfireScheduler.md`, `TickerQScheduler.md`
+- [x] **Task 9.2:** `InMemoryScheduler.md`, `HangfireScheduler.md`, `TickerQScheduler.md`
   - Input: `InMemorySchedulerFactory` 4, `HangfireMessageSchedulerFactory` 3,
     `TickerQSchedulerFactory` **0**
   - Output: two marked tables, and **one page stating that TickerQ's factory exposes no
@@ -2004,12 +2004,188 @@ asserted by calling the extractor directly rather than inferred from a green run
   - Notes: `## Hangfire Best Practices` is better than `## Hangfire Scheduler Best Practices`,
     and no rule can tell you that — heading qualification's editorial half is a judgement.
 
-- [ ] **Task 9.3:** Verify phase 9 — `optioncheck`, the six gates, and the AC8 walk
+- [x] **Task 9.3:** Verify phase 9 — `optioncheck`, the six gates, and the AC8 walk
   - Output: exit 0 with a scope naming five new tables and 25 rows; the six gates; a recorded
     AC8 verdict
   - Notes: **25 options that no figure in the requirements counts.** Nothing in the
     requirements is wrong — §2 is explicit that the survey counts *configuration types*, and a
     factory is not one. This is *ask what a figure counted.*
+
+### Phase 9 as executed — 2026-08-31, 3/3
+
+**Six pages edited, seven tables, 31 rows, and no page created** — taking the corpus to
+`58 tables, 516 rows, 58 types, on 33 pages of 157 files scanned`, exit 0.
+
+| Task | Pages | Tables | Rows | `manual:` |
+|---|---:|---:|---:|---:|
+| 9.1 AWS, Quartz, Azure | 3 | 4 | 21 | 11 |
+| 9.2 InMemory, Hangfire, TickerQ | 3 | 3 | 10 | 6 |
+| **Total** | **6** | **7** | **31** | **17** |
+
+**Every one of the three figures this phase inherited was wrong, and each was wrong in a
+different way.** The task bodies above are left as written, because what they got wrong is the
+point:
+
+| The task said | Measured with `--describe` |
+|---|---|
+| `<!-- optioncheck: Paramore.Brighter.MessageScheduler.**Aws**.AwsSchedulerFactory -->` is a valid marker (task 9.1) | **`THE TYPE IS GONE`.** The namespace is `.AWS`. The same casing produced a false finding against `../Brighter` once already |
+| *This phase must not give `TickerQScheduler.md` a table* (task 9.2) | **It gets one.** See below |
+| *five new tables and 25 rows* (task 9.3) | **seven and 31** |
+
+#### TickerQ has no settable property and three required constructor arguments
+
+Both halves of design §12.1 are true and the conclusion drawn from them is not.
+`TickerQSchedulerFactory` really does have **zero settable properties** — the two it exposes,
+`GetOrCreateSchedulerId` and `ParseSchedulerId`, are get-only expression-bodied properties a
+reader cannot replace. It also has a **primary constructor with three required parameters**,
+`timeTickerManager`, `tickerPersistenceProvider` and `timeProvider`, which `max(props, ctor)`
+selects and `--describe` prints. A reader cannot construct the factory without all three.
+
+**This is design §12.5's primary-constructor blindness one family further on**, in the one place
+§12.5 was never pointed: §12.5 lists thirteen surfaces the *old* `survey.py` could not see, and
+the scheduler family was invisible to that survey for a *different* reason — no configuration
+type — so nobody asked whether the two blind spots overlapped. They do, on exactly one type.
+
+**Standing obligation 4 keeps its rule and loses this instance.** *The absence of a
+configuration type is a fact about the product*; the absence of a settable property is not the
+same fact, and the page reports what a reader must actually supply.
+
+*(Counted while striking it, because a numeral in a noun phrase is a measurement: standing
+obligation 4 and design §10 both say **"seven instances across four families"** and both then
+name **eight** things across **five** — Spanner as a store, MSSQL and PostgreSQL as transports,
+the MSSQL and MySQL locks, TickerQ as a scheduler, Redis and MQTT as publications. Removing
+TickerQ leaves seven, which is the number both documents already claimed. Neither figure has
+ever been load-bearing and neither is edited here; the list is what a writer reads, and it is
+correct.)*
+
+#### `SchedulerGroup` binds, so it is a table rather than prose
+
+Phase 7's lesson applied before the prose was written rather than after: `--describe
+Paramore.Brighter.MessageScheduler.AWS.SchedulerGroup` prints a table, so AWS's `Group`
+sub-options — `Name`, `Tags`, `MakeSchedulerGroup`, which `AwsScheduler.md` already showed in a
+code example — became a **seventh marked table** instead of three sentences no gate would ever
+read again. That is the whole of the difference between the predicted five tables and the seven
+that shipped, plus TickerQ.
+
+#### The residue is 17 of 31 — 55%, not one row in eight
+
+Every phase before this landed between 11% and 13%. The sixteen predicted decompose as measured
+and the seventeenth is `SchedulerGroup.Tags`:
+
+- **five `TimeProvider` rows**, one on every factory but TickerQ, whose clock is a constructor
+  parameter and therefore has no default at all
+- **six `Func<Message, string>` / `Func<IRequest, string>` scheduler-id hooks** across AWS,
+  Quartz and InMemory
+- **three constructor-supplied values** — `AwsSchedulerFactory.Role`,
+  `AzureServiceBusSchedulerFactory.Topic`, and `AwsSchedulerFactory.Group`, whose
+  `SchedulerGroup` has no printable form
+- **Hangfire's three**, which are the instrument change below
+- **`SchedulerGroup.Tags`**, a `List<Tag>` with no printable form
+
+**The ratio is a property of the family being documented, not of the spec.** A *factory* carries
+clocks and delegates where a *configuration* carries strings and timespans, and one row in eight
+was never a rule about this repository — it was a rule about configuration types. Take
+`--describe`'s count before predicting one.
+
+#### What phase 9 changed in the instrument, and why it was forced
+
+**`HangfireMessageSchedulerFactory` cannot be constructed at all.** Its `Client` property is
+initialised `= new BackgroundJobClient()`, whose parameterless constructor reads Hangfire's
+`JobStorage.Current` static and throws `InvalidOperationException: Current JobStorage instance
+has not been initialized yet`. It is the only member that can throw, so the failure is located
+rather than inferred. Every default on the type is therefore unreadable — the whole surface,
+permanently, for a reason no edit in this repository can reach.
+
+**A table declaring all three rows `manual:` still exited 1**, measured with a fixture before
+anything was written. `Program.cs`'s `CANNOT CONSTRUCT` predicate fired whenever the type failed
+*and* every member was unreadable, and never consulted the declarations — so the table was red
+with **no green path to a correct table**. The only remedy was deleting the marker, which takes
+`Option`, `Type`, `UNDOCUMENTED` and `ROW NAMES NOTHING` out of scope as well. **A gate whose
+only remedy is removing the gate reports a table nobody checks as a table that passed**, which
+is what standing obligation 2 exists to prevent.
+
+So the predicate now fires unless **every** unreadable member is declared `manual:` or `omit:`,
+and it names the rows that are not. It does not soften: one undeclared row brings it back. That
+is **red-proof branch 8**, on a third fixture (`fixture_hangfire.md`), and the mutation *deletes*
+a declaration rather than writing a value for the same reason branch 7's does — the fixture must
+not depend on a default nobody can read. **10/10 branches fire**, and the corpus was unmoved at
+`0 mismatches across 51 tables and 485 rows` before the pages were touched.
+
+**What was NOT done, and it was the obvious fix:** initialising `JobStorage` in the checker's
+harness. That is the `Environment.MachineName` lesson — a checker reading its own environment and
+reporting it as the product's behaviour — and it would have made the Hangfire defaults readable
+here and unreadable on any machine without Hangfire configured.
+
+#### The instrument blind spot this phase found and did not fix
+
+`AzureServiceBusSchedulerFactory.ClientProvider` prints a default of **`null`**, and it is not a
+default: it is the argument the checker had to supply for a required constructor parameter.
+`Synthesise` records injected arguments **by parameter name** and `Reflect` matches that set
+against **property names**, so `topic` → `Topic` is caught and `client` → `ClientProvider` is
+not. The property name differs from the parameter name, and the check falls through.
+
+**It is not fixable within design §6.2's one route to a default.** The supplied value here *is*
+`null`, so reference-identity cannot tell it apart from a property that is genuinely null; only
+IL inspection could, and that is the second route §6.2 forbids. This is the
+readable-versus-determinable distinction again, arriving through a third door — the first was
+`Environment.MachineName`, the second a body-coalesced default. **Recorded, and the page says
+in its own words that `ClientProvider` and `Topic` are constructor arguments neither of which
+can be left out**, so no reader is misled by the cell.
+
+#### The ledger — one entry, and it is a code block rather than a table
+
+`optioncheck` reported **0 mismatches** on every run of this phase, before and after, exactly as
+at phase 8 — and the one defect on these six pages is in a place no marker can reach:
+
+| Page | What the corpus said | What the source says |
+|---|---|---|
+| `InMemoryScheduler.md:132` | `using Paramore.Brighter.InMemoryScheduler;` | **that namespace exists nowhere in `src/` at `10.7.0`.** `InMemorySchedulerFactory` is in `Paramore.Brighter` |
+
+**The sweep that found it carried a control**, because a zero from a grep is the answer a broken
+grep also gives: the same query was run against the other **ten** `Paramore.*` namespaces these
+six pages `using`, and every one of them returned between 2 and 86 declaring files. So the zero
+is a fact about the namespace, not about the sweep. This is *a block that passes rule 6 has
+`using` lines; it does not have the right ones*, met a second time — phase 7 met it as a
+`CS0103` under a compiler, and here there was no compiler, only the observation that a namespace
+in a `using` directive is a claim that can be checked against the source.
+
+#### AC8 walked, mechanically and by reading
+
+All 31 rows are four cells, no `Default` is blank, every description is one present-tense
+sentence ending in a full stop, and every `Type` is a code span. All 31 were then printed as a
+list and read as sentences, which is what caught two descriptions written from the type's name
+rather than its use: `tickerPersistenceProvider` is read **once**, in `ReSchedulerAsync`, to
+fetch a ticker by id, and `timeTickerManager` is `AddAsync`/`UpdateAsync`/`DeleteAsync` —
+neither is what "schedules and cancels tickers" and "reads back a ticker" said before the
+methods were read.
+
+#### The gates, and the one figure in play
+
+`optioncheck` 51 tables / 485 rows → **58 / 516**, re-derived from the run rather than from
+arithmetic — the predicted 57/513 was wrong for the reason above. Everything else is **unmoved**,
+which is what a phase creating no page predicts: link **160 files**, pagelint **158 pages,
+0 errors, 783 warnings**, shape **157 pages, widest 12 of 20**, `--check-redirects` **77 entries
+/ 7858 bytes**, `versioncheck.py` **0 stale of 18**, `--verify` **157 predicted, 157 published,
+157 agree**. `pagetypes.tsv` is unmoved at **157 data rows**, and no `SUMMARY.md` entry was owed.
+
+**`pagelint --changed origin/master` reports `10 file(s), 18 hunk(s) … 6 documentation page(s),
+1 code block(s) strict`, and the 1 is the deliverable rather than a gap.** *(It read `9 file(s),
+14 hunk(s)` an hour earlier, before this file was staged — the same figure, measured before the
+edit that moved it, which is the trap this list has recorded three times.)* These are the
+longest, most code-dense pages 012 has touched — **130 C# blocks across six pages** — and
+placement kept every one of them out of the diff except the block whose `using` directive was
+the defect above. That block already carried `using` lines, so the debt did not move.
+
+#### One thing this phase deliberately did not do
+
+**Every `##` heading on these six pages is unique and several are unqualified** —
+`## Dashboard`, `## Storage Options`, `## Persistence Options`, `## Advanced Configuration`,
+`## Important Warning`, `## Scheduling Modes Comparison`, `## Clustering and High Availability`.
+Rule 3a is green on all of them, because `pagelint.py` checks uniqueness and nothing checks
+qualification. Re-qualifying them moves seven published anchors on six pages for a reason
+unrelated to D9, so it is recorded here rather than done: **it is the editorial half of a
+rule with a tool for its mechanical half, and a green build is evidence about the mechanical
+half only.**
 
 ---
 

--- a/tools/optioncheck/Program.cs
+++ b/tools/optioncheck/Program.cs
@@ -329,9 +329,42 @@ internal static class Program
                          + $"reader-facing member of `{type.Name}` at {Authority.Pin()}");
         }
 
-        if (surface.Error is not null && surface.Members.All(m => m.Unreadable is not null))
+        // A type that did not construct has no readable default anywhere, so
+        // this is the table-level echo of the per-member DEFAULT NOT
+        // DETERMINABLE above — and it is an error whenever a row is left to
+        // stand on a value the checker never confirmed.
+        //
+        // PHASE 9 FORCED THE ESCAPE. `HangfireMessageSchedulerFactory` throws
+        // from Hangfire's own static (`Current JobStorage instance has not been
+        // initialized yet`) the moment anything constructs it, so EVERY route
+        // to a default is closed for the whole type, permanently and for a
+        // reason no edit here can reach. Before this clause, a table declaring
+        // all three rows `manual:` — named and reasoned in the scope block,
+        // which is the acknowledgement `manual:` exists to be — still exited 1,
+        // and there was no green path to a correct table at all. The only way
+        // to a green build was to DELETE the marker, which takes `Option`,
+        // `Type`, UNDOCUMENTED and ROW NAMES NOTHING out of scope as well. A
+        // gate whose only remedy is removing the gate reports a table nobody
+        // checks as a table that passed, which is what standing obligation 2
+        // exists to prevent.
+        //
+        // So it fires unless every unreadable member is DECLARED — `manual:`
+        // or `omit:`. It does not soften: one undeclared row and it is back,
+        // which is branch 8 of the red-proof, and the declarations are printed
+        // by name and reason in the scope block either way. Declare and count,
+        // never silence.
+        var undeclared = surface.Members
+            .Where(m => m.Unreadable is not null)
+            .Where(m => !declared.ContainsKey(m.Name) && !omit.ContainsKey(m.Name))
+            .ToList();
+
+        if (surface.Error is not null
+            && surface.Members.All(m => m.Unreadable is not null)
+            && undeclared.Count > 0)
             findings.Add($"{marker.File}:{marker.Line}: CANNOT CONSTRUCT — `{type.Name}`: {surface.Error}. "
-                         + "Every default in this table is unchecked");
+                         + $"Every default in this table is unchecked, and {undeclared.Count} of them "
+                         + $"{(undeclared.Count == 1 ? "is" : "are")} not declared: "
+                         + string.Join(", ", undeclared.Select(m => $"`{m.Name}`")));
     }
 
     /// <summary>


### PR DESCRIPTION
**Phase 9 of spec 012, D9.** Six pages edited, **seven marked tables, 31 rows**, no page created. This is the family `survey.py` cannot see at all, because no scheduler ships a configuration type — the surface is factory properties.

`optioncheck` **51 tables / 485 rows → 58 / 516**, 0 mismatches. Everything else unmoved: link 160, pagelint 158 / 0 errors / 783 warnings, shape 157 widest 12 of 20, redirects 77 / 7858, versioncheck 0 of 18, `--verify` 157 / 157 / 157.

## Three things that need a reviewer's eye

**1. `TickerQScheduler.md` gets a table, and the task list says it must not.** Design §12.1 measured that `TickerQSchedulerFactory` has **zero settable properties** — true. It also has a **primary constructor with three required parameters** (`timeTickerManager`, `tickerPersistenceProvider`, `timeProvider`), which `max(props, ctor)` selects and `--describe` prints, and which a reader cannot construct the factory without. This is design §12.5's primary-constructor blindness one family further on, in the one place §12.5 was never pointed. Standing obligation 3 is *write the table from the type*, the tool agrees with the source, so the table is written and the contradiction is recorded in the phase write-up.

**2. The checker changed, and the change was forced.** `HangfireMessageSchedulerFactory` cannot be constructed at all: `Client` is initialised `= new BackgroundJobClient()`, which reads Hangfire's `JobStorage.Current` static and throws. Measured with a fixture: a table declaring **all three rows `manual:`** — named and reasoned in the scope block — still exited 1 on `CANNOT CONSTRUCT`, whose predicate never consulted the declarations. There was **no green path to a correct table**; the only remedy was deleting the marker, which takes `Option`, `Type`, `UNDOCUMENTED` and `ROW NAMES NOTHING` out of scope too.

The predicate now fires unless *every* unreadable member is declared, and names the ones that are not. It does not soften — one undeclared row brings it back, which is **red-proof branch 8** on a third fixture. **10/10 branches fire.** What was deliberately *not* done is initialising `JobStorage` in the harness: that is the `Environment.MachineName` lesson, a checker reading its own environment.

**3. An instrument blind spot, recorded and not fixed.** `AzureServiceBusSchedulerFactory.ClientProvider` prints a default of `null` and it is not one — it is the argument the checker had to supply. `Synthesise` records injected arguments by *parameter* name and `Reflect` matches that against *property* names, so `topic` → `Topic` is caught and `client` → `ClientProvider` is not. It is not fixable within design §6.2's one route to a default: the supplied value *is* `null`, so identity cannot tell it from a genuine null, and only IL inspection could. The page states in its own words that both are constructor arguments neither of which can be left out.

## Scope, measured

| Factory | Rows | `manual:` |
|---|---:|---:|
| `AwsSchedulerFactory` | 10 | 5 |
| `SchedulerGroup` | 3 | 1 |
| `QuartzSchedulerFactory` | 4 | 3 |
| `AzureServiceBusSchedulerFactory` | 4 | 2 |
| `InMemorySchedulerFactory` | 4 | 3 |
| `HangfireMessageSchedulerFactory` | 3 | 3 |
| `TickerQSchedulerFactory` | 3 | 0 |
| **Total** | **31** | **17** |

**The residue is 17 of 31 — 55%**, against the 11–13% every previous phase landed at. A *factory* carries clocks and `Func<>` hooks where a *configuration* carries strings and timespans; the ratio is a property of the family being documented, not of the spec.

`SchedulerGroup` is the seventh table because `--describe` answers for it — phase 7's lesson (*before working around an instrument's limit, ask the instrument*) applied before the prose was written rather than after.

## The ledger — one entry

`optioncheck` reported 0 mismatches on every run, and the one defect on these six pages is somewhere no marker reaches:

| Page | What the corpus said | What the source says |
|---|---|---|
| `InMemoryScheduler.md:132` | `using Paramore.Brighter.InMemoryScheduler;` | that namespace exists **nowhere** in `src/` at `10.7.0`; `InMemorySchedulerFactory` is in `Paramore.Brighter` |

The sweep carried a control: the same query against the other **ten** `Paramore.*` namespaces these pages `using` returned between 2 and 86 declaring files each, so the zero is a fact about the namespace and not about the sweep.

## Rule 6

`pagelint --changed origin/master`: **`10 file(s), 18 hunk(s) … 6 documentation page(s), 1 code block(s) strict`**. These are the most code-dense pages 012 has touched — **130 C# blocks across six pages** — and placement kept every one out of the diff except the block whose `using` directive was the defect. The debt is unchanged at 783.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0146UueHL6H3zGBGTYwz7GtL