### PR TITLE
spec: 013 P0-2 is corpus-wide — the documented resilience API has never existed

### DIFF
--- a/spec/013-howto_guides/requirements.md
+++ b/spec/013-howto_guides/requirements.md
@@ -170,6 +170,72 @@ grep -rl 'AddBrighterDefault' contents/ ; grep -rl 'ResiliencePipelineRegistry' 
 How-to.** A spec that only knows how to add pages would have written a twelfth resilience page
 beside eleven that already discuss `UseResiliencePipeline`.
 
+### 3.2.1 CORRECTION, 2026-09-05 — the wiring examples do not compile, and P0-2 is corpus-wide
+
+**Recorded before it is fixed**, which is 012's rule and the only evidence this drift was ever
+real. §3.2 as first written called `PolicyRetryAndCircuitBreaker.md` *"a good 445-line How-to"*
+missing two symbols. **That understated it.** The page's culminating wiring example — and four
+other pages — call **methods that do not exist in any released version of Brighter, nor on
+`origin/master`**:
+
+| Call in the corpus | Declared in Brighter `src/` at `10.7.0` | Sites |
+|---|---|---|
+| `.ResiliencePipelines(…)` | **never existed** | 2 |
+| `.ConfigureResiliencePipelines(…)` | **never existed** | 3 |
+| `.Policies(…)` | **no** — V9's `INeedPolicy` form, gone at V10 | 5 |
+| `.Resilience(…)` / `.DefaultResilience()` — **the real API** | yes | **0 sites in the corpus** |
+
+**Ten sites across five pages**, none of which any gate can see: a bare method name in a fence is
+invisible to `linkcheck.py`, `pagelint.py` and `optioncheck` alike, and `optioncheck` binds only
+what a marker names.
+
+| Page | Lines | Dead call |
+|---|---|---|
+| `PolicyRetryAndCircuitBreaker.md` | 355, 356, 372 | `.Policies(`, `.ResiliencePipelines(`, `.ConfigureResiliencePipelines(` |
+| `MigratingToPollyV8.md` | 101, 111, 112 | `.Policies(` ×2, `.ResiliencePipelines(` |
+| `CommandProcessorConfigurationReference.md` | 104 | `.ConfigureResiliencePipelines(` |
+| `CQRSWithBrighterAndDarker.md` | 378 | `.ConfigureResiliencePipelines(` |
+| `HowConfiguringTheCommandProcessorWorks.md` | 236 | `.Policies(` |
+| `HowConfiguringTheDispatcherWorks.md` | 66 | `.Policies(` |
+
+**`MigratingToPollyV8.md:112` is the sharpest**: it presents `.ResiliencePipelines(…)` as *"New:
+Polly v8 pipelines"* — the ✅ current form — and line 116 tells the reader to use both methods
+together. The real API is a **single** `Resilience(registry, policyRegistry)` with an optional
+second parameter, so the advice is wrong about the *shape*, not only the spelling. On the
+migration page, for the highest-demand topic in the corpus.
+
+**The verified remedy**, because a diagnosis without one is half a finding:
+
+- **Builder**: `.Resilience(resiliencePipelineRegistry, policyRegistry)` or `.DefaultResilience()`
+  — `CommandProcessorBuilder.cs:144`, `:171`.
+- **DI**: there is **no fluent method**. `BrighterOptions.ResiliencePipelineRegistry` is a
+  settable property (`BrighterOptions.cs:59`), so the registry is supplied inside
+  `AddBrighter(options => …)`.
+- **And it must carry `.AddBrighterDefault()`.** All three DI call sites assign with **`??=`**
+  (`ServiceCollectionExtensions.cs:339,463,705`), so Brighter supplies its defaults *only when you
+  supply no registry*. Supply your own and `CommandProcessor.OutboxProducer` is absent — at which
+  point `CommandProcessorBuilder.Resilience()` throws **unconditionally**, on its first statement
+  (`:146-148`): `ConfigurationException: The resilience pipeline registry is missing the
+  CommandProcessor.OutboxProducer resilience pipeline which is required`.
+
+**This is a likelier explanation for Brighter#3960's four hours than "the documentation was
+incomplete"** — the reader was copying methods that do not exist.
+
+**Two sites were nearly added to this list and are CORRECT.** `QueryPipelinePolicies.md:56` and
+`DarkerBasicConfiguration.md:280` call `.AddPolicies(…)`, which **is real in Darker 4.1.1**
+(`src/Paramore.Darker.Policies/QueryProcessorBuilderExtensions.cs`). Darker versions
+independently, so a Brighter-shaped sweep condemns them. **Check the right product before
+editing** — the same shape as the `SqlFilter` public field that was one edit from being deleted as
+drift.
+
+**One instance is upstream and out of scope.**
+`src/Paramore.Brighter.MessagingGateway.MsSql/README.md:95` in the Brighter repository carries
+`.Policies(policyRegistry)` too. `CLAUDE.md` makes that read-only outside `samples/`; it is worth
+an issue, not an edit.
+
+**So P0-2 is scoped corpus-wide**, and its instrument is the compiler — the only thing that has
+ever found a published example that does not compile.
+
 ### 3.3 The DLQ cluster is real, spans transports, and has no task-shaped route
 
 Four askings across 2022–2025 and two different transports. Today **21 pages mention a dead-letter
@@ -262,7 +328,7 @@ third** — in that order, because the README's risk section binds this spec to 
 | # | Deliverable | Why P0 | Shape |
 |---|---|---|---|
 | **P0-1** | **Use PostgreSQL for both transport and Outbox** | Publicly committed on #67 **twice** (2026-07-18 and the 2026-09-04 comment), 3 independent askings, nothing composes it | **New page** |
-| **P0-2** | **Resilience pipelines on an async handler** — `UseResiliencePipelineAsync`, the registry keys, `AddBrighterDefault`, and the non-generic `KeyNotFound` trap | 5 askings, the largest cluster; a public API on **0 of 157 pages**; the maintainer calls configuration *"one of our biggest weaknesses"* | **Edit** to `PolicyRetryAndCircuitBreaker.md` |
+| **P0-2** | **The resilience wiring, corpus-wide** — repair the **10 dead call sites across 5 pages** (§3.2.1), then add `UseResiliencePipelineAsync`, `AddBrighterDefault` and the `??=` trap | 5 askings, the largest cluster; **the documented wiring does not compile**; a required public API on **0 of 157 pages** | **Edits** to 5 pages, verified by **compiling the fences** |
 | **P0-3** | **Handle a poison message and route it to a DLQ** | 4 askings, 2 transports, 2022–2025; 21 pages carry fragments and none carries a route | **New page**, plus a decision on §3.3's known defects |
 
 ### P1 — should have
@@ -313,6 +379,11 @@ How-to), routing several types down one channel, and writing a query and its han
 |---|---|---|---|
 | `contents/PostgresForTransportAndOutbox.md` *(name to settle at design)* | create | How-to | P0-1 |
 | `contents/PolicyRetryAndCircuitBreaker.md` | edit | How-to (unchanged) | P0-2 |
+| `contents/MigratingToPollyV8.md` | edit — 3 dead sites, incl. the ✅-marked one | How-to (unchanged) | P0-2 |
+| `contents/CommandProcessorConfigurationReference.md` | edit — 1 dead site | Reference (unchanged) | P0-2 |
+| `contents/CQRSWithBrighterAndDarker.md` | edit — 1 dead site | Explanation (unchanged) | P0-2 |
+| `contents/HowConfiguringTheCommandProcessorWorks.md` | edit — 1 dead site | Explanation (unchanged) | P0-2 |
+| `contents/HowConfiguringTheDispatcherWorks.md` | edit — 1 dead site | Explanation (unchanged) | P0-2 |
 | `contents/HandlingPoisonMessages.md` *(name to settle at design)* | create | How-to | P0-3 |
 | `contents/ClaimCheckLargePayloads.md` *(name to settle at design)* | create | How-to | P1-1 |
 | `contents/MSSQLForTransportAndBoxes.md` *(name to settle at design)* | create | How-to | P1-2 |
@@ -362,10 +433,12 @@ cross-cutting guide reopens the question as a fresh decision, not an inherited o
    published example that does not: extract the page's own fences into a project and build them,
    with **`<ImplicitUsings>disable</ImplicitUsings>`**, because the question is whether the page
    *as printed* compiles. Reflection cannot answer it.
-3. **Rule 6 is held off by placement.** A guide is new, so every block in it is 100% added lines
-   and strict under `--changed`; each therefore carries its real `using` directives. Where P0-2
-   edits an existing page, **the edited block becomes strict** and earns real directives — that is
-   a budgeted cost, not a surprise.
+3. **Rule 6 is held off by placement, and P0-2 deliberately gives that up.** A guide is new, so
+   every block in it is 100% added lines and strict under `--changed`; each carries its real
+   `using` directives. **P0-2 edits ten code blocks across five existing pages, so all ten become
+   strict** and each earns real directives. That is a budgeted cost and the warning count should
+   fall — it is **779** at `af38910`, and a phase that edits ten blocks and moves it by nothing has
+   probably not edited what it thought it did.
 4. **A page must not silently document an unreleased feature.** Replay On Seen is absent from
    `10.7.0` and present on Brighter `origin/master`; five pages carry a *not yet released*
    blockquote. Any guide touching it inherits that obligation, and the trigger for removing it is
@@ -394,11 +467,12 @@ with nothing mechanical behind it.
 | **AC2** | Every new page is linked from `SUMMARY.md` and no page is orphaned | `linkcheck.py` |
 | **AC3** | Every internal link resolves, including anchors | `linkcheck.py` |
 | **AC4** | Every new page passes all seven page rules | `pagelint.py`, and `--changed origin/master` |
-| **AC5** | Every C# block on a new page compiles as printed | the harness in §11.2 — **no tool in CI** |
+| **AC5** | Every C# block on a new page **or an edited one** compiles as printed | the harness in §11.2 — **no tool in CI** |
 | **AC6** | Shape and redirects hold; nested pages move no existing URL | `urlmap.py --check-shape`, `--check-redirects`, `--verify` after publication |
 | **AC7** | Every guide ends with a verification step naming what the reader sees | walked — **no tool** |
 | **AC8** | `pagetypes.tsv` has a row per new page | walked — **no tool reads this file** |
 | **AC9** | Each guide traces to an asking, cited by number | walked — **no tool** |
+| **AC10** | **No page names a Brighter method that does not exist at the pinned ref**, checked for the resilience family and for every API this spec writes | `git grep -w <name> 10.7.0 -- src/` **with a control**, per §11.6 — **no tool** |
 
 **AC9 is walked backwards, not forwards.** Forwards — every guide has a citation — can only ever
 find guides that were written. Backwards — every cluster in §3.1 with two or more askings against

--- a/spec/014-documentation_workflow/README.md
+++ b/spec/014-documentation_workflow/README.md
@@ -69,6 +69,37 @@ the spec caused, which is the right shape. Nothing does that for the other six.
 5. **No command mentions an acceptance pass.** Both specs that ran one found a criterion unmet
    at the close — 009's AC7 and 012's AC1 — on corpora green under every gate.
 
+**Found while running 013's requirements phase, 2026-09-04/05 — these are measured, not
+predicted, and items 6 to 8 are the ones no command's absence had been noticed before:**
+
+6. **Neither `acceptance criteria` nor `open questions` appears anywhere in the nine commands.**
+   Measured across the same 451 lines: `grep -ril 'acceptance criteri'` → **0 files**;
+   `grep -ril 'open question'` → **0**. Every spec in the programme has both sections, and they
+   exist only because each spec copied the last one's document. **Both criteria found unmet at a
+   close were criteria the workflow never asked for.** This is sharper than defect 5: the
+   workflow does not ask a spec what it will be judged by, and then has no pass to judge it in.
+7. **`/spec:requirements`' Research Steps are feature-shaped.** They name ADRs, release notes,
+   source code and samples — right for a spec documenting a new feature, and wrong for 013,
+   whose demand lived in **GitHub discussions, issues and `FAQ.md`**. None of the three is
+   mentioned by any command. Run literally, the phase would have produced an intuition-ordered
+   guide list; the measured one reordered every priority and closed half the candidates.
+8. **Nothing in the workflow asks whether the API a page names still exists — and this is the
+   defect class with the highest blast radius.** 013's requirements phase found **ten call sites
+   across five pages naming Brighter builder methods that have never existed in any released
+   version** (`.ResiliencePipelines(`, `.ConfigureResiliencePipelines(`) or that died at V10
+   (`.Policies(`), while the real API — `.Resilience(…)` / `.DefaultResilience()` — appears on
+   **zero pages**. One of them is presented as the ✅ *"New: Polly v8"* form on the migration
+   page. **Every gate is green on all ten**, because a bare method name in a fence is invisible
+   to `linkcheck.py`, `pagelint.py` and `optioncheck` alike — `optioncheck` binds only what a
+   marker names, and no marker names a method. `/spec:implement`'s quality checklist says
+   *"code examples are correct"* and supplies no way to find out. **The instrument that works is
+   the compiler**, it is 009's method, and no command mentions it.
+9. **No command warns that an inherited list rots.** 013's README named six content gaps and
+   **five were already closed** by Specs 010 and 012 — three of them by page splits nobody
+   revisited. The re-derivation happened only because the README and `PROMPT.md` say so in prose
+   that no command reads. A spec that starts by executing its own README ships work that is
+   already done.
+
 ## Scope sketch — for the requirements phase to settle, not settled here
 
 - Add a **mode-mix step** to `/spec:requirements`: for each deliverable, which of the four page
@@ -81,6 +112,20 @@ the spec caused, which is the right shape. Nothing does that for the other six.
   placement defence.
 - Add an **acceptance-pass phase** — walk the criteria with evidence, and record what was found
   wrong before it was fixed.
+- Make `/spec:requirements` ask for **acceptance criteria and open questions by name**, and make
+  each criterion **name its instrument or be marked as having none** — the marked ones are where
+  every close-time failure has been (defect 6).
+- Give `/spec:requirements` a **demand step** for specs whose subject is reader problems rather
+  than a feature: discussions, issues, `FAQ.md` (defect 7). Dedupe a cross-source census **by
+  thread, not by row** — a tracker that moves an issue to a discussion leaves the same asking in
+  both enumerations — and **paginate before quoting a count**.
+- Add an **API-liveness obligation** to `/spec:implement` and `/spec:review` (defect 8): before a
+  page names a type, method or namespace, `git grep -w <name> <ref> -- src/` **with a control**,
+  and compile the page's own fences. **Consider whether it should be a gate** — the corpus has ten
+  live instances and nothing that can see them, which is exactly the argument that produced
+  `optioncheck`. Note the counter-example before designing one: `.AddPolicies(` is dead in
+  Brighter and **alive in Darker 4.1.1**, so a checker must know which product a page is about.
+- Require a phase to **re-derive its own spec's README** before executing it (defect 9).
 - Decide what belongs in `CLAUDE.md` versus in a command. `CLAUDE.md` is the authority on
   conventions and the commands should cite rather than restate it; **restating is how the two
   drifted apart in the first place**, which is 012's premise pointed at ourselves.


### PR DESCRIPTION
Amends 013's approved requirements to record a defect **before** repairing it — 012's rule, and the only evidence the drift was ever real. **No page under `contents/` changes here.** The repair itself is P0-2's work in the writing phase.

## The correction

§3.2 as merged called `PolicyRetryAndCircuitBreaker.md` *"a good 445-line How-to"* missing two symbols. That understated it.

| Call in the corpus | Declared in Brighter `src/` at `10.7.0`? | Sites |
|---|---|---|
| `.ResiliencePipelines(…)` | **never existed** — nor on `origin/master` | 2 |
| `.ConfigureResiliencePipelines(…)` | **never existed** | 3 |
| `.Policies(…)` | **no** — V9's `INeedPolicy` form, gone at V10 | 5 |
| `.Resilience(…)` / `.DefaultResilience()` — **the real API** | yes | **0** |

Ten sites across `PolicyRetryAndCircuitBreaker.md`, `MigratingToPollyV8.md`, `CommandProcessorConfigurationReference.md`, `CQRSWithBrighterAndDarker.md`, `HowConfiguringTheCommandProcessorWorks.md` and `HowConfiguringTheDispatcherWorks.md`. Line numbers in §3.2.1.

**`MigratingToPollyV8.md:112` is the sharpest**: it presents a method that has never existed as the ✅ *"New: Polly v8 pipelines"* form, and line 116 tells the reader to use both methods together — where the real API is a single `Resilience(registry, policyRegistry)` with an optional second parameter. Wrong about the *shape*, on the migration page, for the highest-demand topic in the corpus.

**Every gate is green on all ten.** A bare method name in a fence is invisible to `linkcheck.py` and `pagelint.py`, and `optioncheck` binds only what a *marker* names — no marker names a method.

## Why `AddBrighterDefault` matters more than "an undocumented symbol"

All three DI call sites assign with **`??=`** (`ServiceCollectionExtensions.cs:339,463,705`), so Brighter supplies its two default pipelines *only when you supply no registry*. Supply your own — which is exactly what the docs tell you to do — and `CommandProcessor.OutboxProducer` is absent, at which point `CommandProcessorBuilder.Resilience()` throws **unconditionally, on its first statement** (`:146-148`):

> `ConfigurationException: The resilience pipeline registry is missing the CommandProcessor.OutboxProducer resilience pipeline which is required`

This is a likelier explanation for Brighter#3960's four lost hours than "the documentation was incomplete" — the reader was copying methods that do not exist.

## Two near-misses, both one edit from breaking something

- **`.AddPolicies(` is REAL in Darker 4.1.1** (`Paramore.Darker.Policies/QueryProcessorBuilderExtensions.cs`), so `QueryPipelinePolicies.md` and `DarkerBasicConfiguration.md` are correct. A Brighter-shaped sweep condemns two good pages — ask which product before editing.
- **Two of my own instruments disagreed** about `.Policies(` in `src/`. The single hit is prose in `Paramore.Brighter.MessagingGateway.MsSql/README.md:95` — Brighter's own docs carrying the same dead call, not a declaration. Out of scope to edit (`CLAUDE.md`), worth an issue.

## What changes in the documents

- **§3.2.1** — the correction, the work-list with line numbers, the verified remedy, both near-misses.
- **P0-2** — rescoped from one edit to five pages, instrument named as the compiler.
- **§9** — five more edited files listed.
- **AC5** extended to edited pages; **AC10** added for API liveness, checked with a control.
- **§11.3** — ten edited blocks all become rule-6 strict, so the **779** warning count should fall. A phase that edits ten blocks and moves it by nothing has not edited what it thought it did.
- **014's defect list grows 5 → 9**, all measured while running 013's requirements phase. #8 is the one with a live ten-site instance: nothing in the workflow asks whether an API a page names exists, and `/spec:implement`'s checklist says *"code examples are correct"* while supplying no way to find out.

## Gates

Unmoved, as a spec-only change predicts: 160 files · 0 errors, 779 warnings, 158 pages · 157 pages, 12 sections, widest 12 of 20 · 77 redirects, 7858 bytes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0146UueHL6H3zGBGTYwz7GtL