### PR TITLE
spec: API liveness has three states, not two — and AC10 had the rule backwards

### DIFF
--- a/spec/013-howto_guides/requirements.md
+++ b/spec/013-howto_guides/requirements.md
@@ -228,10 +228,15 @@ independently, so a Brighter-shaped sweep condemns them. **Check the right produ
 editing** — the same shape as the `SqlFilter` public field that was one edit from being deleted as
 drift.
 
-**One instance is upstream and out of scope.**
-`src/Paramore.Brighter.MessagingGateway.MsSql/README.md:95` in the Brighter repository carries
-`.Policies(policyRegistry)` too. `CLAUDE.md` makes that read-only outside `samples/`; it is worth
-an issue, not an edit.
+**Two instances are upstream and out of scope, and are RAISED.**
+`src/Paramore.Brighter.MessagingGateway.MsSql/README.md:95` and
+`docs/guides/paramore_brighter_core_guide.md:909` in the Brighter repository carry the same dead
+chain, both still on `origin/master`. `CLAUDE.md` makes those read-only outside `samples/`, so
+they went up as **[Brighter#4301](https://github.com/BrighterCommand/Brighter/issues/4301)** on
+2026-09-05 — which also carries two defects the Docs-side sweep did not have: **`.NoTaskQueues()`**,
+whose only occurrence in that entire repository is the README naming it, and a **dangling `cref`**
+in `CommandProcessorBuilder.cs`'s own XML comment pointing at `CommandProcessorBuilder.Policies`,
+a member that no longer exists.
 
 **So P0-2 is scoped corpus-wide**, and its instrument is the compiler — the only thing that has
 ever found a published example that does not compile.
@@ -439,14 +444,49 @@ cross-cutting guide reopens the question as a fresh decision, not an inherited o
    strict** and each earns real directives. That is a budgeted cost and the warning count should
    fall — it is **779** at `af38910`, and a phase that edits ten blocks and moves it by nothing has
    probably not edited what it thought it did.
-4. **A page must not silently document an unreleased feature.** Replay On Seen is absent from
-   `10.7.0` and present on Brighter `origin/master`; five pages carry a *not yet released*
-   blockquote. Any guide touching it inherits that obligation, and the trigger for removing it is
-   `versioncheck.py` going red.
+4. **An API is in one of THREE states, and only the third is a defect.** Ruled by the maintainer
+   2026-09-05, after the §3.2.1 findings raised the question of what "does not exist" means.
+
+   | State | Test | What a page may do |
+   |---|---|---|
+   | **Live** | present at the pinned release (`10.7.0`) | document freely |
+   | **Forthcoming** | absent at the release, **present on `origin/master`** | **document it — but say so explicitly** |
+   | **Dead or invented** | present at **neither** | **always a defect**, repair it |
+
+   **Documenting ahead of a release is legitimate and expected — the documentation is part of the
+   work, not a follow-up to it.** What is not acceptable is doing it *silently*, so a forthcoming
+   API is documented only as a deliberate, stated choice: the writer confirms they intend to
+   document an unreleased feature and knows it is not installable today.
+
+   **The form already exists in the corpus and is not to be reinvented** — five pages carry it,
+   four immediately below the banner and one scoped to a section
+   (`DynamoOutbox.md:129`). Verbatim from `ReplayOnSeen.md:12`:
+
+   ```markdown
+   > **Not in a released package yet.** Replay On Seen ships **after Brighter 10.7.0**, which is
+   > the current release. `OnceOnlyAction.Replay`, `SupportsCausationTracking` and the Causation Id
+   > plumbing this page describes are on Brighter's development branch and are in no version you
+   > can install today, so treat what follows as the feature as it will ship.
+   ```
+
+   It names the feature, names the release it ships after, names the symbols, and tells the reader
+   what to do with the page. The trigger for removing it is **`versioncheck.py` going red** at the
+   pin bump.
+
+   **013's default posture is live-only, and that is a property of this spec rather than of the
+   rule.** This programme is restructuring what is already published, not documenting work to come,
+   so a forthcoming API appearing in a 013 guide should be rare and deliberate. **The ten sites in
+   §3.2.1 are none of these things** — `.ResiliencePipelines(` and `.ConfigureResiliencePipelines(`
+   are absent from **both** refs, which is the third state, and `.Policies(` is a V9 survival.
 5. **Link, do not copy** — configuration values come from Spec 012's tables by link.
-6. **Verify a claim at the ref.** `git show 10.7.0:<path>`. A type name assembled from surrounding
-   vocabulary is this programme's most-repeated defect: `RequeueAction`, `AwsMessagingGatewayConnection`
-   and `#transport-support-matrix` were all plausible, all invented, and all invisible to every gate.
+6. **Verify a claim at BOTH refs, and with a control.** `git show 10.7.0:<path>` for live,
+   `origin/master` for forthcoming — a check against one ref cannot tell state 2 from state 3. A
+   type name assembled from surrounding vocabulary is this programme's most-repeated defect:
+   `RequeueAction`, `AwsMessagingGatewayConnection` and `#transport-support-matrix` were all
+   plausible, all invented, and all invisible to every gate. **Use `git grep -w`, not a
+   hand-rolled regex**: three regexes were wrong inside §3.2.1's own sweep, two of them returning
+   a plausible zero, and each was caught only by a control asserting the search could still find
+   something already read by eye.
 7. **A namespace claim is checked by nothing here.** Every `using Paramore.*` line a guide prints
    gets `git grep "namespace X" 10.7.0 -- src/` **with a control**, because a zero is also what a
    broken grep returns.
@@ -472,7 +512,7 @@ with nothing mechanical behind it.
 | **AC7** | Every guide ends with a verification step naming what the reader sees | walked — **no tool** |
 | **AC8** | `pagetypes.tsv` has a row per new page | walked — **no tool reads this file** |
 | **AC9** | Each guide traces to an asking, cited by number | walked — **no tool** |
-| **AC10** | **No page names a Brighter method that does not exist at the pinned ref**, checked for the resilience family and for every API this spec writes | `git grep -w <name> 10.7.0 -- src/` **with a control**, per §11.6 — **no tool** |
+| **AC10** | **No page names an API that exists in neither the pinned release nor `origin/master`**, and any API present only on `origin/master` carries the *Not in a released package yet* blockquote — see §11.4 | `git grep -w <name>` at **both refs**, **with a control**, per §11.6 — **no tool** |
 
 **AC9 is walked backwards, not forwards.** Forwards — every guide has a citation — can only ever
 find guides that were written. Backwards — every cluster in §3.1 with two or more askings against

--- a/spec/014-documentation_workflow/README.md
+++ b/spec/014-documentation_workflow/README.md
@@ -83,8 +83,8 @@ predicted, and items 6 to 8 are the ones no command's absence had been noticed b
    whose demand lived in **GitHub discussions, issues and `FAQ.md`**. None of the three is
    mentioned by any command. Run literally, the phase would have produced an intuition-ordered
    guide list; the measured one reordered every priority and closed half the candidates.
-8. **Nothing in the workflow asks whether the API a page names still exists — and this is the
-   defect class with the highest blast radius.** 013's requirements phase found **ten call sites
+8. **Nothing in the workflow asks whether the API a page names exists — and this is the defect
+   class with the highest blast radius.** 013's requirements phase found **ten call sites
    across five pages naming Brighter builder methods that have never existed in any released
    version** (`.ResiliencePipelines(`, `.ConfigureResiliencePipelines(`) or that died at V10
    (`.Policies(`), while the real API — `.Resilience(…)` / `.DefaultResilience()` — appears on
@@ -119,12 +119,28 @@ predicted, and items 6 to 8 are the ones no command's absence had been noticed b
   than a feature: discussions, issues, `FAQ.md` (defect 7). Dedupe a cross-source census **by
   thread, not by row** — a tracker that moves an issue to a discussion leaves the same asking in
   both enumerations — and **paginate before quoting a count**.
-- Add an **API-liveness obligation** to `/spec:implement` and `/spec:review` (defect 8): before a
-  page names a type, method or namespace, `git grep -w <name> <ref> -- src/` **with a control**,
-  and compile the page's own fences. **Consider whether it should be a gate** — the corpus has ten
-  live instances and nothing that can see them, which is exactly the argument that produced
-  `optioncheck`. Note the counter-example before designing one: `.AddPolicies(` is dead in
-  Brighter and **alive in Darker 4.1.1**, so a checker must know which product a page is about.
+- Add an **API-liveness obligation** to `/spec:implement` and `/spec:review` (defect 8), built on
+  the maintainer's 2026-09-05 ruling that an API is in one of **three** states, not two:
+
+  | State | Test | What a page may do |
+  |---|---|---|
+  | **Live** | present at the pinned release | document freely |
+  | **Forthcoming** | absent there, **present on `origin/master`** | document it, **but say so explicitly** |
+  | **Dead or invented** | present at **neither** | always a defect |
+
+  **Documenting ahead of a release is legitimate and expected** — the docs are part of the work,
+  so the rule must not be *"the API must exist in the released package"*. The obligation is that
+  the unreleased case is **stated, never silent**: the writer confirms they are documenting a
+  forthcoming feature and knows it is not installable. The corpus already has the form —
+  **`> **Not in a released package yet.** …`**, on five pages, with `versioncheck.py` going red at
+  the pin bump as the removal trigger — so a command should cite it rather than invent one.
+
+  **Whether this becomes an eighth gate is open**, and the ruling makes it harder than it first
+  looked: a checker must resolve **two** refs to tell state 2 from state 3, and must know **which
+  product** a page is about — `.AddPolicies(` is dead in Brighter and **alive in Darker 4.1.1**,
+  which versions independently. Note also that the manual sweep that found the ten sites made
+  **three wrong regexes**, two returning a plausible zero, all three caught only by a control; a
+  gate would have to be red-proved against exactly that failure.
 - Require a phase to **re-derive its own spec's README** before executing it (defect 9).
 - Decide what belongs in `CLAUDE.md` versus in a command. `CLAUDE.md` is the authority on
   conventions and the commands should cite rather than restate it; **restating is how the two


### PR DESCRIPTION
Records the maintainer's 2026-09-05 ruling on what *"the API does not exist"* should mean, and corrects an acceptance criterion that had it backwards. **No page under `contents/` changes.**

## The ruling

Having found [ten sites naming methods the product has never had](https://github.com/BrighterCommand/Docs/pull/147), the obvious rule to write is *the API must exist at the pinned release*. That is wrong, because **documentation is part of shipping a feature rather than a follow-up to it** — a page written against `origin/master` before the release is correct work, not drift.

| State | Test | What a page may do |
|---|---|---|
| **Live** | present at the pinned release (`10.7.0`) | document freely |
| **Forthcoming** | absent there, **present on `origin/master`** | **document it — but say so explicitly** |
| **Dead or invented** | present at **neither** | **always a defect** |

Only the third is a defect. The obligation on the second is that it is **stated, never silent**.

## What was wrong on our side

**AC10 as merged in #147** read *"No page names a Brighter method that does not exist at the pinned ref"* — which forbids exactly what the ruling permits, and would have been satisfied by a writer quietly declining to document a feature until after release. **That failure produces no red build and leaves no record.** It was written within an hour of the defect it was reacting to, which is what over-fitting a rule to the last failure looks like.

Corrected: AC10 now tests **both refs**, and §11.6 says why — a one-ref check cannot distinguish state 2 from state 3.

## The explicit form is not reinvented

The corpus already carries it **five times**, four immediately below the banner and one section-scoped at `DynamoOutbox.md:129`. Verbatim from `ReplayOnSeen.md:12`:

> **Not in a released package yet.** Replay On Seen ships **after Brighter 10.7.0**, which is the current release. `OnceOnlyAction.Replay`, `SupportsCausationTracking` and the Causation Id plumbing this page describes are on Brighter's development branch and are in no version you can install today, so treat what follows as the feature as it will ship.

It names the feature, the release it ships after, the symbols, and what the reader should do with the page — and retires when `versioncheck.py` goes red at the pin bump. *(`PROMPT.md` had been calling this a "not yet released" blockquote; that string appears nowhere in the corpus. Right in substance, wrong as a quotation — and a paraphrase is what you grep for when you finally need it.)*

**013's default posture stays live-only**, but that is a property of this spec — restructuring what is already published — not of the rule.

## Upstream

The two instances in the Brighter repository are raised as **[Brighter#4301](https://github.com/BrighterCommand/Brighter/issues/4301)**: `MessagingGateway.MsSql/README.md:95` and `docs/guides/paramore_brighter_core_guide.md:909`, both still on `origin/master`. It carries two defects the Docs-side sweep did not have — **`.NoTaskQueues()`**, whose only occurrence in that entire repository is the README naming it, and a **dangling `cref`** in `CommandProcessorBuilder.cs`'s own XML comment pointing at `CommandProcessorBuilder.Policies`, a member that no longer exists.

## For 014

The scope sketch takes the three-state model and records why a gate here is harder than it looks: it must resolve **two refs**, must know **which product** a page is about (`.AddPolicies(` is dead in Brighter and **alive in Darker 4.1.1**), and would need red-proving against the failure mode this sweep actually hit — **three wrong regexes, two returning a plausible zero**, every one caught by a control rather than by reading the code.

## Gates

Unmoved: 160 files · 0 errors, 779 warnings, 158 pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0146UueHL6H3zGBGTYwz7GtL