### PR TITLE
spec: compiling proves types, not downcasts — the limit of 009's harness, measured

### DIFF
--- a/spec/013-howto_guides/requirements.md
+++ b/spec/013-howto_guides/requirements.md
@@ -434,10 +434,26 @@ cross-cutting guide reopens the question as a fresh decision, not an inherited o
    banner (`> **How-to** · Applies to **Brighter V10**` plus Prerequisites), `##` headings
    qualified by subject, an opening sentence ≤200 **rendered** characters that is unique across
    the corpus, and a language tag on every fence.
-2. **Code compiles as printed.** 009's method, and the only instrument that has ever found a
-   published example that does not: extract the page's own fences into a project and build them,
-   with **`<ImplicitUsings>disable</ImplicitUsings>`**, because the question is whether the page
-   *as printed* compiles. Reflection cannot answer it.
+2. **Code compiles as printed — and compiling is not enough.** 009's method, and the only
+   instrument that has ever found a published example that does not compile: extract the page's own
+   fences into a project and build them, with **`<ImplicitUsings>disable</ImplicitUsings>`**,
+   because the question is whether the page *as printed* compiles. Reflection cannot answer it.
+
+   **Its limit was measured on 2026-09-05 in Brighter#4302 and is now a standing caveat.** Two
+   examples built clean against **both** the released packages and `origin/master` — 0 errors, 0
+   warnings — and **two lines still threw at runtime**:
+   `MessagingGateway.MsSql/ChannelFactory.cs:46` **downcasts** `Subscription` to
+   `MsSqlSubscription` and throws when the cast fails, and `Subscription<T>` defaults to
+   **`Proactor`** against a mapper registry with no async half, selecting a branch that throws. **A
+   compile proves the type is satisfied and says nothing about a downcast, a null check, or a
+   default that selects a code path.**
+
+   **So, wherever an example is downstream of anything taking an interface or a base class — a
+   channel factory, a transaction provider, a scheduler — find the source repository's own test
+   for that shape and mirror it** rather than composing one.
+   `tests/Paramore.Brighter.RMQ.Sync.Tests/MessageDispatch/When_building_a_dispatcher.cs` carried
+   both answers. A runtime `ConfigurationException` from a page that looks authoritative is
+   **worse** for a reader than the compile error it replaced.
 3. **Rule 6 is held off by placement, and P0-2 deliberately gives that up.** A guide is new, so
    every block in it is 100% added lines and strict under `--changed`; each carries its real
    `using` directives. **P0-2 edits ten code blocks across five existing pages, so all ten become

--- a/spec/014-documentation_workflow/README.md
+++ b/spec/014-documentation_workflow/README.md
@@ -135,6 +135,13 @@ predicted, and items 6 to 8 are the ones no command's absence had been noticed b
   **`> **Not in a released package yet.** …`**, on five pages, with `versioncheck.py` going red at
   the pin bump as the removal trigger — so a command should cite it rather than invent one.
 
+  **Compiling is necessary and not sufficient**, measured in Brighter#4302: two examples built
+  clean against both the released packages and `origin/master` and **still threw at runtime**, one
+  on a **downcast** inside a transport's channel factory and one on a **default** that selected a
+  throwing branch. So the obligation is *compile, then mirror the source repository's own test for
+  any shape downstream of an interface or base class* — a rule a command can state and a gate
+  probably cannot check.
+
   **Whether this becomes an eighth gate is open**, and the ruling makes it harder than it first
   looked: a checker must resolve **two** refs to tell state 2 from state 3, and must know **which
   product** a page is about — `.AddPolicies(` is dead in Brighter and **alive in Darker 4.1.1**,


### PR DESCRIPTION
Records a measured limit of this programme's most-trusted instrument, and the rule that follows from it for 013's P0-2. **No page under `contents/` changes.**

## What happened

[Brighter#4302](https://github.com/BrighterCommand/Brighter/pull/4302) — our repair of the upstream half of the same defect — proposed two corrected examples, each **built twice**: against the released 10.7.0 packages *and* against `origin/master` by `ProjectReference`. **0 errors, 0 warnings each time.**

**Two lines still threw at runtime**, and a reviewer caught both:

- `MessagingGateway.MsSql/ChannelFactory.cs:46` **downcasts** `Subscription` to `MsSqlSubscription` and throws `ConfigurationException` when the cast fails (repeated at `:65`, `:88`). A `Subscription<GreetingEvent>` compiles perfectly and dies at `dispatcher.Receive()`.
- `Subscription<T>` defaults to **`Proactor`** (`Subscription.cs:291`) while `MessageMappers(registry, null, null, null)` supplies no async registry — the pump takes a branch that throws.

## Why this is a constraint and not a note

009's method is still right and is still the only instrument that has ever found a published example that does not compile. **Its limit had never been written down**: it proves the *type* is satisfied and says nothing about **a downcast, a null check, or a default that selects a code path**.

The tell is structural — **wherever a transport-specific factory accepts a base type, the base type is a lie**: the API takes `Subscription`, the implementation demands `MsSqlSubscription`.

So §11.2 now requires: **compile, then mirror the source repository's own test for any shape downstream of an interface or base class.** `tests/Paramore.Brighter.RMQ.Sync.Tests/MessageDispatch/When_building_a_dispatcher.cs` carried both answers, and one search would have found it.

**This matters for P0-2 specifically**, which edits ten blocks sitting downstream of builders and channel factories. A runtime `ConfigurationException` from a page that looks authoritative is **worse for a reader** than the compile error it replaced.

## Also recorded, in 014

The API-liveness sketch takes the same caveat: **compile-then-mirror is a rule a command can state and a gate probably cannot check** — which is more evidence for defect 8 being a workflow obligation rather than an eighth tool.

## Not hidden

The same review found **two false claims in my PR description**, both withdrawn publicly in the thread and both already-recorded lessons of this programme repeating themselves — `grep -l` counting files reported as a count of uses, and grepping the *dead V9 spelling* so that absence-of-name was read as absence-of-thing. They are in `PROMPT.md`'s lesson list, which is gitignored; they are summarised here so the record is not only in the ignored file.

## Gates

Unmoved: 160 files · 0 errors, 779 warnings, 158 pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0146UueHL6H3zGBGTYwz7GtL